### PR TITLE
Use property accessors for values that stay the same in branch copying methods

### DIFF
--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/internal/branch/BranchImpl.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/internal/branch/BranchImpl.java
@@ -79,24 +79,24 @@ public class BranchImpl extends MetadataHolderImpl implements Branch, InternalBr
 	
     @Override
     public InternalBranch withDeleted() {
-		return createBranch(name, parentPath, baseTimestamp, headTimestamp, true, metadata());
+		return createBranch(name(), parentPath(), baseTimestamp(), headTimestamp(), true, metadata());
 	}
 
     @Override
     public InternalBranch withBaseTimestamp(long newBaseTimestamp) {
-        checkArgument(newBaseTimestamp > baseTimestamp, "New base timestamp may not be smaller or equal than old base timestamp.");
-		return createBranch(name, parentPath, newBaseTimestamp, newBaseTimestamp, deleted, metadata());
+        checkArgument(newBaseTimestamp > baseTimestamp(), "New base timestamp may not be smaller or equal than old base timestamp.");
+		return createBranch(name(), parentPath(), newBaseTimestamp, newBaseTimestamp, isDeleted(), metadata());
 	}
 	
     @Override
     public InternalBranch withHeadTimestamp(long newHeadTimestamp) {
-		checkArgument(newHeadTimestamp > headTimestamp, "New head timestamp may not be smaller or equal than old head timestamp.");
-		return createBranch(name, parentPath, baseTimestamp, newHeadTimestamp, deleted, metadata());
+		checkArgument(newHeadTimestamp > headTimestamp(), "New head timestamp may not be smaller or equal than old head timestamp.");
+		return createBranch(name(), parentPath(), baseTimestamp(), newHeadTimestamp, isDeleted(), metadata());
 	}
     
     @Override
-    public InternalBranch withMetadata(Metadata metadata) {
-    	return createBranch(name, parentPath, baseTimestamp, headTimestamp, deleted, metadata);
+    public InternalBranch withMetadata(Metadata newMetadata) {
+    	return createBranch(name(), parentPath(), baseTimestamp(), headTimestamp(), isDeleted(), newMetadata);
     }
     
 	private BranchImpl createBranch(String name, String parentPath, long baseTimestamp, long headTimestamp, boolean deleted, Metadata metadata) {

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/internal/branch/CDOBranchImpl.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/internal/branch/CDOBranchImpl.java
@@ -71,12 +71,15 @@ public class CDOBranchImpl extends BranchImpl implements InternalCDOBasedBranch 
 	}
 	
 	@Override
-	public InternalCDOBasedBranch withSegmentId(int segmentId) {
+	public InternalCDOBasedBranch withSegmentId(int newSegmentId) {
 		final Builder<Integer> builder = ImmutableSet.builder();
-		builder.add(segmentId);
+		builder.add(newSegmentId);
 		// use previous segments here, the branch got a new segment because a new child branch got opened
 		builder.addAll(segments());
-		return new CDOBranchImpl(name(), parentPath(), baseTimestamp(), headTimestamp(), isDeleted(), metadata(), cdoBranchId(), segmentId, builder.build(), parentSegments);
+		
+		CDOBranchImpl branch = new CDOBranchImpl(name(), parentPath(), baseTimestamp(), headTimestamp(), isDeleted(), metadata(), cdoBranchId(), newSegmentId, builder.build(), parentSegments());
+		branch.setBranchManager(getBranchManager());
+		return branch;
 	}
 	
 	@Override

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/internal/branch/CDOMainBranchImpl.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/internal/branch/CDOMainBranchImpl.java
@@ -61,19 +61,19 @@ public class CDOMainBranchImpl extends MainBranchImpl implements InternalCDOBase
 	}
 	
 	@Override
-	public InternalBranch withHeadTimestamp(long newHeadTimestamp) {
-		final MainBranchImpl main = new CDOMainBranchImpl(baseTimestamp(), newHeadTimestamp, metadata(), segmentId, segments);
-		main.setBranchManager(branchManager);
-		return main;
+	protected BranchImpl doCreateBranch(String name, String parentPath, long baseTimestamp, long headTimestamp, boolean deleted, Metadata metadata) {
+		return new CDOMainBranchImpl(baseTimestamp, headTimestamp, metadata, segmentId, segments);
 	}
 	
 	@Override
-	public InternalCDOBasedBranch withSegmentId(int segmentId) {
+	public InternalCDOBasedBranch withSegmentId(int newSegmentId) {
 		final Builder<Integer> builder = ImmutableSet.builder();
-		builder.add(segmentId);
+		builder.add(newSegmentId);
 		// MAIN branch uses all his previous segments because he never gets reopened
 		builder.addAll(segments());
-		return new CDOMainBranchImpl(baseTimestamp(), headTimestamp(), metadata(), segmentId, builder.build());
+		
+		final CDOMainBranchImpl main = new CDOMainBranchImpl(baseTimestamp(), headTimestamp(), metadata(), newSegmentId, builder.build());
+		main.setBranchManager(getBranchManager());
+		return main;
 	}
-
 }


### PR DESCRIPTION
This is done to prevent accidentally using a field carrying the previous value instead of the method parameter in `withT(T newValue)` methods of Branch subclasses.
