### PR TITLE
Enable gzip compression by default

### DIFF
--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/config/SnowOwlConfiguration.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/config/SnowOwlConfiguration.java
@@ -47,6 +47,8 @@ public class SnowOwlConfiguration extends Configuration {
 	
 	private String description = "You Know, for Terminologies";
 
+	private boolean gzip = true;
+
 	@JsonProperty
 	public String getDescription() {
 		return description;
@@ -95,6 +97,16 @@ public class SnowOwlConfiguration extends Configuration {
 	@JsonProperty("systemUser")
 	public void setSystemUserNeeded(boolean systemUserNeeded) {
 		this.systemUserNeeded = systemUserNeeded;
+	}
+	
+	@JsonProperty
+	public boolean isGzip() {
+		return gzip;
+	}
+	
+	@JsonProperty
+	public void setGzip(boolean gzip) {
+		this.gzip = gzip;
 	}
 	
 	/**

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/CDORepositoryManager.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/CDORepositoryManager.java
@@ -215,8 +215,7 @@ import com.google.common.net.HostAndPort;
 		//read extension points first, then create managed items 
 		super.doBeforeActivate();
 		
-		final RepositoryConfiguration configuration = getRepositoryConfiguration();
-		if (configuration.isCompressed()) {
+		if (getSnowOwlConfiguration().isGzip()) {
 			IPluginContainer.INSTANCE.addPostProcessor(new GZIPStreamWrapperInjector(CDOProtocolConstants.PROTOCOL_NAME));
 		}
 		
@@ -230,7 +229,7 @@ import com.google.common.net.HostAndPort;
 		
 		LifecycleUtil.activate(IPluginContainer.INSTANCE);
 		
-		final HostAndPort hostAndPort = configuration.getHostAndPort();
+		final HostAndPort hostAndPort = getRepositoryConfiguration().getHostAndPort();
 		// open port in server environments
 		if (SnowOwlApplication.INSTANCE.getEnviroment().isServer()) {
 			TCPUtil.getAcceptor(IPluginContainer.INSTANCE, hostAndPort.toString()); // Start the TCP transport
@@ -241,7 +240,11 @@ import com.google.common.net.HostAndPort;
 	}
 	
 	private RepositoryConfiguration getRepositoryConfiguration() {
-		return ApplicationContext.getInstance().getServiceChecked(SnowOwlConfiguration.class).getModuleConfig(RepositoryConfiguration.class);
+		return getSnowOwlConfiguration().getModuleConfig(RepositoryConfiguration.class);
+	}
+
+	private SnowOwlConfiguration getSnowOwlConfiguration() {
+		return ApplicationContext.getInstance().getServiceChecked(SnowOwlConfiguration.class);
 	}
 	
 	@Override

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/DatastoreServerBootstrap.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/DatastoreServerBootstrap.java
@@ -85,9 +85,9 @@ public class DatastoreServerBootstrap implements PreRunCapableBootstrapFragment 
 		final IManagedContainer container = env.container();
 		final RpcConfiguration rpcConfig = configuration.getModuleConfig(RpcConfiguration.class);
 		LOG.debug("Preparing RPC communication with config {}", rpcConfig);
-		RpcUtil.prepareContainer(container, rpcConfig);
+		RpcUtil.prepareContainer(container, rpcConfig, configuration.isGzip());
 		LOG.debug("Preparing EventBus communication");
-		EventBusNet4jUtil.prepareContainer(container);
+		EventBusNet4jUtil.prepareContainer(container, configuration.isGzip());
 		env.services().registerService(IEventBus.class, EventBusNet4jUtil.getBus(container));
 		LOG.debug("Preparing JSON support");
 		final ObjectMapper mapper = JsonSupport.getDefaultObjectMapper();

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/DatastoreServerBootstrap.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/DatastoreServerBootstrap.java
@@ -83,11 +83,12 @@ public class DatastoreServerBootstrap implements PreRunCapableBootstrapFragment 
 	@Override
 	public void init(SnowOwlConfiguration configuration, Environment env) throws Exception {
 		final IManagedContainer container = env.container();
+		final boolean gzip = configuration.isGzip();
 		final RpcConfiguration rpcConfig = configuration.getModuleConfig(RpcConfiguration.class);
-		LOG.debug("Preparing RPC communication with config {}", rpcConfig);
-		RpcUtil.prepareContainer(container, rpcConfig, configuration.isGzip());
-		LOG.debug("Preparing EventBus communication");
-		EventBusNet4jUtil.prepareContainer(container, configuration.isGzip());
+		LOG.debug("Preparing RPC communication (config={},gzip={})", rpcConfig, gzip);
+		RpcUtil.prepareContainer(container, rpcConfig, gzip);
+		LOG.debug("Preparing EventBus communication (gzip={})", gzip);
+		EventBusNet4jUtil.prepareContainer(container, gzip);
 		env.services().registerService(IEventBus.class, EventBusNet4jUtil.getBus(container));
 		LOG.debug("Preparing JSON support");
 		final ObjectMapper mapper = JsonSupport.getDefaultObjectMapper();

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/cdo/CDOConnectionManager.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/cdo/CDOConnectionManager.java
@@ -347,7 +347,7 @@ import com.google.common.collect.Maps;
 				sessionConfiguration.setRepositoryName(repositoryUuid);
 				sessionConfiguration.setConnector(connector);
 
-				if (repositoryConfiguration.isCompressed()) {
+				if (getSnowOwlConfiguration().isGzip()) {
 					sessionConfiguration.setStreamWrapper(new GZIPStreamWrapper());
 				}
 

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/config/RepositoryConfiguration.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/config/RepositoryConfiguration.java
@@ -36,8 +36,6 @@ import com.google.common.net.HostAndPort;
  */
 public class RepositoryConfiguration extends ConnectionPoolConfiguration {
 	
-	private boolean compressed = false;
-
 	@NotEmpty
 	private String host = "0.0.0.0";
 
@@ -61,27 +59,6 @@ public class RepositoryConfiguration extends ConnectionPoolConfiguration {
 
 	private boolean revisionCacheEnabled = true;
 	
-	/**
-	 * Returns whether the communication used by the persistance layer is done
-	 * in a compressed way or not.
-	 * 
-	 * @return
-	 */
-	@JsonProperty
-	public boolean isCompressed() {
-		return compressed;
-	}
-
-	/**
-	 * Set to enable compressed data transfer in the persistance layer.
-	 * 
-	 * @param compressed
-	 */
-	@JsonProperty
-	public void setCompressed(boolean compressed) {
-		this.compressed = compressed;
-	}
-
 	/**
 	 * @return the host
 	 */

--- a/documentation/src/main/asciidoc/configuration_reference.adoc
+++ b/documentation/src/main/asciidoc/configuration_reference.adoc
@@ -200,16 +200,11 @@ NOTE: Changing these settings is not recommended and currently unsupported in pr
 |logging
 |`false`
 |`true`, `false`, `ON`, `OFF` - enable or disable verbose logging during RPC communication
-
-|compressed
-|`false`
-|`true`, `false`, `ON`, `OFF` - enable or disable GZIP compression of the communication.
 |===
 
 --------------------------
 rpc:
   logging: true
-  compressed: false
 --------------------------
 
 == Metrics

--- a/net4j/com.b2international.snowowl.eventbus/src/com/b2international/snowowl/eventbus/net4j/EventBusNet4jUtil.java
+++ b/net4j/com.b2international.snowowl.eventbus/src/com/b2international/snowowl/eventbus/net4j/EventBusNet4jUtil.java
@@ -15,6 +15,7 @@
  */
 package com.b2international.snowowl.eventbus.net4j;
 
+import org.eclipse.net4j.signal.wrapping.GZIPStreamWrapperInjector;
 import org.eclipse.net4j.util.container.IManagedContainer;
 import org.eclipse.spi.net4j.ClientProtocolFactory;
 
@@ -33,12 +34,16 @@ public class EventBusNet4jUtil {
 	 * network.
 	 * 
 	 * @param container
+	 * @param b 
 	 */
-	public static final void prepareContainer(IManagedContainer container) {
+	public static final void prepareContainer(IManagedContainer container, boolean gzipEnabled) {
 		container.registerFactory(new EventBusProtocol.ClientFactory());
 		container.registerFactory(new EventBusProtocol.ServerFactory());
 		container.registerFactory(new EventBus.Factory());
 		container.addPostProcessor(new EventBusProtocolInjector());
+		if (gzipEnabled) {
+			container.addPostProcessor(new GZIPStreamWrapperInjector(EventBusConstants.PROTOCOL_NAME));
+		}
 	}
 
 	/**

--- a/net4j/com.b2international.snowowl.eventbus/src/com/b2international/snowowl/eventbus/net4j/EventBusNet4jUtil.java
+++ b/net4j/com.b2international.snowowl.eventbus/src/com/b2international/snowowl/eventbus/net4j/EventBusNet4jUtil.java
@@ -34,14 +34,14 @@ public class EventBusNet4jUtil {
 	 * network.
 	 * 
 	 * @param container
-	 * @param b 
+	 * @param gzip - to enable gzip compression on the protocol or not
 	 */
-	public static final void prepareContainer(IManagedContainer container, boolean gzipEnabled) {
+	public static final void prepareContainer(IManagedContainer container, boolean gzip) {
 		container.registerFactory(new EventBusProtocol.ClientFactory());
 		container.registerFactory(new EventBusProtocol.ServerFactory());
 		container.registerFactory(new EventBus.Factory());
 		container.addPostProcessor(new EventBusProtocolInjector());
-		if (gzipEnabled) {
+		if (gzip) {
 			container.addPostProcessor(new GZIPStreamWrapperInjector(EventBusConstants.PROTOCOL_NAME));
 		}
 	}

--- a/net4j/com.b2international.snowowl.rpc.test/src/com/b2international/snowowl/rpc/test/testcases/AbstractRpcTest.java
+++ b/net4j/com.b2international.snowowl.rpc.test/src/com/b2international/snowowl/rpc/test/testcases/AbstractRpcTest.java
@@ -59,7 +59,7 @@ public abstract class AbstractRpcTest<T, U extends T> {
 		
 		Net4jUtil.prepareContainer(container);
 		JVMUtil.prepareContainer(container);
-		RpcUtil.prepareContainer(container, new RpcConfiguration());
+		RpcUtil.prepareContainer(container, new RpcConfiguration(), false);
 		
 		JVMUtil.getAcceptor(container, JVM_DESCRIPTION);
 	}

--- a/net4j/com.b2international.snowowl.rpc/src/com/b2international/snowowl/rpc/RpcConfiguration.java
+++ b/net4j/com.b2international.snowowl.rpc/src/com/b2international/snowowl/rpc/RpcConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2017 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,12 @@
 package com.b2international.snowowl.rpc;
 
 
-
 /**
  * Represents the configuration settings of the RPC protocol.
  * 
  */
 public class RpcConfiguration {
 
-	private boolean compressed = false;
 	private boolean logging = false;
 	
 	/**
@@ -40,20 +38,6 @@ public class RpcConfiguration {
 		this.logging = logging;
 	}
 	
-	/**
-	 * @return <code>true</code> if compression is enabled, <code>false</code> otherwise
-	 */
-	public boolean isCompressed() {
-		return compressed;
-	}
-	
-	/**
-	 * @param compressed
-	 */
-	public void setCompressed(boolean compressed) {
-		this.compressed = compressed;
-	}
-	
 	@Override
 	public String toString() {
 		final StringBuilder builder = new StringBuilder();
@@ -61,10 +45,6 @@ public class RpcConfiguration {
 		builder.append("logging");
 		builder.append("=");
 		builder.append(isLogging());
-		builder.append(",");
-		builder.append("compressed");
-		builder.append("=");
-		builder.append(isCompressed());
 		builder.append("}");
 		return builder.toString();
 	}

--- a/net4j/com.b2international.snowowl.rpc/src/com/b2international/snowowl/rpc/RpcProtocol.java
+++ b/net4j/com.b2international.snowowl.rpc/src/com/b2international/snowowl/rpc/RpcProtocol.java
@@ -32,7 +32,6 @@ import org.eclipse.net4j.util.container.IManagedContainer;
 import org.eclipse.net4j.util.event.IEvent;
 import org.eclipse.net4j.util.event.IListener;
 import org.eclipse.net4j.util.factory.ProductCreationException;
-import org.eclipse.net4j.util.io.GZIPStreamWrapper;
 import org.eclipse.spi.net4j.ClientProtocolFactory;
 import org.eclipse.spi.net4j.ServerProtocolFactory;
 
@@ -79,9 +78,6 @@ public class RpcProtocol extends SignalProtocol<RpcSession> {
 		
 		if (!skipInitialization) { 
 			initializeRegistry(); 
-		}
-		if (configuration.isCompressed()) {
-			addStreamWrapper(new GZIPStreamWrapper());
 		}
 
 		addListener(signalListener);

--- a/net4j/com.b2international.snowowl.rpc/src/com/b2international/snowowl/rpc/RpcUtil.java
+++ b/net4j/com.b2international.snowowl.rpc/src/com/b2international/snowowl/rpc/RpcUtil.java
@@ -15,6 +15,7 @@
  */
 package com.b2international.snowowl.rpc;
 
+import org.eclipse.net4j.signal.wrapping.GZIPStreamWrapperInjector;
 import org.eclipse.net4j.util.container.IManagedContainer;
 import org.eclipse.net4j.util.container.IPluginContainer;
 import org.eclipse.spi.net4j.ClientProtocolFactory;
@@ -65,10 +66,13 @@ public class RpcUtil {
 	 * 
 	 * @param container
 	 */
-	public static void prepareContainer(final IManagedContainer container, RpcConfiguration configuration) {
+	public static void prepareContainer(final IManagedContainer container, RpcConfiguration configuration, boolean gzip) {
 		container.registerFactory(new RpcProtocol.ClientFactory(configuration));
 		container.registerFactory(new RpcProtocol.ServerFactory(configuration));
 		container.registerFactory(new RpcSessionImpl.Factory());
 		container.addPostProcessor(new RpcServerProtocolInjector());
+		if (gzip) {
+			container.addPostProcessor(new GZIPStreamWrapperInjector(RpcProtocolConstants.TYPE));
+		}
 	}
 }


### PR DESCRIPTION
This PR contains the following changes:
* Moved `compressed` configuration value to root of the config object, and changed its name to `gzip`. Changed default value to `true`. 
* Add gzip compression support to `EventBusProtocol`s