### PR TITLE
SDD-770: Fix NPE thrown while saving classification results

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedEditingContext.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedEditingContext.java
@@ -1202,7 +1202,7 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 			if (IS_A.equals(relationship.getType().getId())) {
 				if (relationship != null) {
 					deletionPlan = canDelete(relationship, deletionPlan);
-					if(deletionPlan.isRejected()) {
+					if (deletionPlan.getRejectionReasons().size() > 0) {
 						deletionPlan.addRejectionReason(String.format(UNABLE_TO_DELETE_CONCEPT_MESSAGE, toString(concept)));
 						return deletionPlan;
 					}
@@ -1330,8 +1330,10 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 		// a released refset member cannot be deleted. however, since a released refset member can
 		// only contain released relationships, we would not have made it this far if anyway
 		deletionPlan.markForDeletion(refSetEditingContext.getReferringMembers(relationship));		
-		
-		deletionPlan.markForDeletion(relationship);
+
+		if (relationship.getSource() != null) {
+			deletionPlan.markForDeletion(relationship);
+		}
 		
 		return deletionPlan;
 	}

--- a/snomed/com.b2international.snowowl.snomed.reasoner.server/src/com/b2international/snowowl/snomed/reasoner/server/classification/EquivalentConceptMerger.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner.server/src/com/b2international/snowowl/snomed/reasoner/server/classification/EquivalentConceptMerger.java
@@ -56,6 +56,7 @@ import com.b2international.snowowl.snomed.snomedrefset.SnomedSimpleMapRefSetMemb
 import com.b2international.snowowl.snomed.snomedrefset.SnomedStructuralRefSet;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Iterables;
@@ -99,6 +100,14 @@ public class EquivalentConceptMerger {
 					@Override
 					public Relationship apply(SnomedRelationshipIndexEntry input) {
 						return (Relationship) editingContext.lookup(input.getStorageKey());
+					}
+				})
+				.filter(new Predicate<Relationship>() {
+
+					@Override
+					public boolean apply(Relationship input) {
+						//Exclude relationships that were already marked redundant
+						return input.getDestination() != null && input.getSource() != null;
 					}
 				})
 				.index(new Function<Relationship, String>() {


### PR DESCRIPTION
Fix NPE thrown while saving classification results of equivalent singapore medicinal product descendants:
 1. Include stated relationships in checking for equivalent concepts
that need to be fixed
 2. Filter out inboun redundant relationships while fixing equivalent
concepts
 3. Avoid attempt to delete already deleted relationships in the
deletion plan
 4. Allow for deletion plan completion even if delete items are empty