### PR TITLE
Index Lucene fragment groovy memory leak fix

### DIFF
--- a/commons/com.b2international.index.api.tests/.launch/com.b2international.index.api.tests-lucene (groovy).launch
+++ b/commons/com.b2international.index.api.tests/.launch/com.b2international.index.api.tests-lucene (groovy).launch
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.JunitLaunchConfig">
+<booleanAttribute key="append.args" value="true"/>
+<stringAttribute key="application" value="org.eclipse.pde.junit.runtime.coretestapplication"/>
+<booleanAttribute key="askclear" value="false"/>
+<booleanAttribute key="automaticAdd" value="false"/>
+<booleanAttribute key="automaticValidate" value="true"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="true"/>
+<booleanAttribute key="clearws" value="true"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+<booleanAttribute key="default" value="false"/>
+<booleanAttribute key="includeOptional" value="false"/>
+<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/com.b2international.index.api.tests/src/com/b2international/index/GroovyMemoryLeakTest.java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.b2international.index.GroovyMemoryLeakTest"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="com.b2international.index.api.tests"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms128m -Xmx128m -XX:MaxMetaspaceSize=60m -XX:+PrintGCDetails -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=d:/groovy-dump.hprof"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="com.b2international.snowowl.product.product"/>
+<booleanAttribute key="run_in_ui_thread" value="false"/>
+<stringAttribute key="selected_target_plugins" value="ch.qos.logback.classic@default:default,ch.qos.logback.core@default:default,ch.qos.logback.slf4j@default:false,com.fasterxml.jackson.core.jackson-annotations@default:default,com.fasterxml.jackson.core.jackson-core@default:default,com.fasterxml.jackson.core.jackson-databind@default:default,com.fasterxml.jackson.dataformat.jackson-dataformat-smile@default:default,com.fasterxml.jackson.dataformat.jackson-dataformat-yaml@default:default,com.fasterxml.jackson.module.jackson-module-afterburner@default:default,com.google.guava*18.0.0@default:default,com.google.inject@default:default,com.ibm.icu@default:default,com.ning.compress-lzf@default:default,javax.el@default:default,javax.inject@default:default,javax.servlet*3.0.0.v201112011016@default:default,javax.servlet*3.1.0.v201410161800@default:default,javax.transaction@default:false,javax.xml@default:default,org.apache.ant@default:default,org.apache.commons.lang@default:default,org.assertj.core@default:default,org.codehaus.groovy*2.0.7.xx-201411061342-e43j8-RELEASE@default:default,org.codehaus.groovy*2.3.7.xx-201411061342-e43j8-RELEASE@default:default,org.eclipse.core.contenttype@default:default,org.eclipse.core.databinding.observable@default:default,org.eclipse.core.databinding.property@default:default,org.eclipse.core.databinding@default:default,org.eclipse.core.jobs@default:default,org.eclipse.core.net.win32.x86_64@default:false,org.eclipse.core.net@default:default,org.eclipse.core.runtime@default:true,org.eclipse.emf.common@default:default,org.eclipse.emf.ecore@default:default,org.eclipse.equinox.app@default:default,org.eclipse.equinox.common@2:true,org.eclipse.equinox.preferences@default:default,org.eclipse.equinox.registry@default:default,org.eclipse.equinox.security.win32.x86_64@default:false,org.eclipse.equinox.security@default:default,org.eclipse.equinox.transforms.hook@default:false,org.eclipse.equinox.weaving.hook@default:false,org.eclipse.osgi@-1:true,org.emfjson.core@default:default,org.emfjson.jackson@default:default,org.hamcrest.core@default:default,org.jboss.netty@default:default,org.junit*4.11.0.v201303080030@default:default,org.junit*4.12.0.v201504281640@default:default,org.mockito.mockito-all@default:default,org.slf4j.api@default:default,system.bundle.package.exporter@default:false"/>
+<stringAttribute key="selected_workspace_plugins" value="com.b2international.collections.api@default:default,com.b2international.collections.fastutil@default:false,com.b2international.commons.base@default:default,com.b2international.commons.test@default:false,com.b2international.commons@default:default,com.b2international.index.api.tests.tools@default:default,com.b2international.index.api.tests@default:false,com.b2international.index.api@default:default,com.b2international.index.lucene@default:false,com.b2international.org.apache.lucene@default:default,com.b2international.snowowl.hibernate.validator@default:default,com.b2international.snowowl.logging.logbackconfiguration@default:false"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="false"/>
+<booleanAttribute key="useProduct" value="false"/>
+</launchConfiguration>

--- a/commons/com.b2international.index.api.tests/src/com/b2international/index/GroovyMemoryLeakTest.java
+++ b/commons/com.b2international.index.api.tests/src/com/b2international/index/GroovyMemoryLeakTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.b2international.index.Fixtures.Data;
@@ -36,12 +37,27 @@ import com.b2international.index.query.SortBy;
 import com.google.common.collect.ImmutableList;
 
 /**
+ * Test to verify that Groovy script execution in the Lucene implementation of the Index API does not produce huge amount of compiled script classes and constant GC allocation failures (even Metaspace) and eventually unresponsiveness of the entire server.
+ * 
+ * To detect the memory leak:
+ * 1. Use 5.10.10 version of Snow Owl
+ * 2. Run this test via the provided launch configuration
+ * 3. Use the GC log output to detect the mem leak (or use an external JVM monitoring app, like jvisualvm)
+ * 4. After the first/second GC in the Metaspace area the JVM will enter into a state, where it constantly tries to GC the Metaspace area, but it can't free up space at all.  
+ * 
+ * To verify the memory leak:
+ * 1. Use 5.10.11 version of Snow Owl (or apply the fix from the corresponding commit)
+ * 2. Run this test via the provided launch configuration
+ * 3. Use the GC log output to detect that there is no Metaspace GC at all (or use an external JVM monitoring app, like jvisualvm)
+ * 4. The fix reduces the amount of runtime generated Script classes, so Metaspace won't fill up and the JVM won't enter into the above observed state
+ * 
  * @since 5.10.11
  */
 public class GroovyMemoryLeakTest extends BaseIndexTest {
 
 	private static final int NUM_DOCS = 10_000;
 	
+	@Ignore
 	@Test
 	public void tryToGenerateMemoryLeak() throws Exception {
 		final List<String> orderedItems = newArrayList(); 
@@ -75,12 +91,15 @@ public class GroovyMemoryLeakTest extends BaseIndexTest {
 			}
 		};
 
+		// run 4 threads to simulate a bit higher load on the index
 		executor.submit(theQuery, null);
 		executor.submit(theQuery, null);
 		executor.submit(theQuery, null);
 		executor.submit(theQuery, null);
-		
+
 		executor.shutdown();
+		// this won't pass at all, even if the fix is applied
+		// the purpose of this test to detect and verify the GC via external monitoring thus it cannot be automated properly
 		assertTrue(executor.awaitTermination(5, TimeUnit.MINUTES));
 	}
 

--- a/commons/com.b2international.index.api.tests/src/com/b2international/index/GroovyMemoryLeakTest.java
+++ b/commons/com.b2international.index.api.tests/src/com/b2international/index/GroovyMemoryLeakTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.index;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Maps.newHashMap;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Test;
+
+import com.b2international.index.Fixtures.Data;
+import com.b2international.index.query.Expressions;
+import com.b2international.index.query.Query;
+import com.b2international.index.query.SortBy;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * @since 5.10.11
+ */
+public class GroovyMemoryLeakTest extends BaseIndexTest {
+
+	private static final int NUM_DOCS = 10_000;
+	
+	@Test
+	public void tryToGenerateMemoryLeak() throws Exception {
+		final List<String> orderedItems = newArrayList(); 
+		final Map<String, Data> documents = newHashMap();
+		
+		for (int i = 0; i < NUM_DOCS; i++) {
+			String item = null;
+			while (item == null || orderedItems.contains(item)) {
+				item = RandomStringUtils.randomAlphabetic(10);
+			}
+			orderedItems.add(item);
+			
+			final Data data = new Data();
+			data.setField1(item); 
+			data.setFloatField(100.0f - i);
+			documents.put(Integer.toString(i), data);
+		}
+		
+		indexDocuments(documents);
+
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		
+		final Runnable theQuery = () -> {
+			for (int i = 0; i < 10_000; i++) {
+				final Query<Data> query = Query.select(Data.class)
+						.where(Expressions.scriptScore(Expressions.matchAll(), "floatField"))
+						.limit(NUM_DOCS)
+						.sortBy(SortBy.SCORE)
+						.build();
+				search(query);
+			}
+		};
+
+		executor.submit(theQuery, null);
+		executor.submit(theQuery, null);
+		executor.submit(theQuery, null);
+		executor.submit(theQuery, null);
+		
+		executor.shutdown();
+		assertTrue(executor.awaitTermination(5, TimeUnit.MINUTES));
+	}
+
+	@Override
+	protected Collection<Class<?>> getTypes() {
+		return ImmutableList.<Class<?>>of(Data.class);
+	}
+	
+}

--- a/commons/com.b2international.index.lucene/src/com/b2international/index/LuceneIndexAdmin.java
+++ b/commons/com.b2international.index.lucene/src/com/b2international/index/LuceneIndexAdmin.java
@@ -28,7 +28,7 @@ import com.b2international.index.translog.TransactionLog;
 /**
  * @since 4.7
  */
-public interface LuceneIndexAdmin extends IndexAdmin {
+public interface LuceneIndexAdmin extends IndexAdmin, ScriptEngine {
 	
 	void close();
 	

--- a/commons/com.b2international.index.lucene/src/com/b2international/index/ScriptEngine.java
+++ b/commons/com.b2international.index.lucene/src/com/b2international/index/ScriptEngine.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.index;
+
+/**
+ * @since 5.10.11
+ */
+public interface ScriptEngine {
+
+	groovy.lang.Script compile(String script);
+	
+}

--- a/commons/com.b2international.index.lucene/src/com/b2international/index/admin/BaseLuceneIndexAdmin.java
+++ b/commons/com.b2international.index.lucene/src/com/b2international/index/admin/BaseLuceneIndexAdmin.java
@@ -57,8 +57,12 @@ import com.b2international.index.mapping.DocumentMapping;
 import com.b2international.index.mapping.Mappings;
 import com.b2international.index.query.slowlog.SlowLogConfig;
 import com.b2international.index.translog.TransactionLog;
+import com.google.common.collect.MapMaker;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
+
+import groovy.lang.GroovyShell;
+import groovy.lang.Script;
 
 /**
  * @since 4.7
@@ -86,6 +90,8 @@ public abstract class BaseLuceneIndexAdmin implements LuceneIndexAdmin {
 	private TransactionLog tlog;
 	private ReentrantLock lock = new ReentrantLock();
 	private QueryBuilder queryBuilder;
+	private GroovyShell shell;
+	private Map<String, Class<?>> scriptCache = new MapMaker().makeMap();
 	
 	protected BaseLuceneIndexAdmin(String name, Mappings mappings) {
 		this(name, mappings, Maps.<String, Object>newHashMap());
@@ -175,6 +181,8 @@ public abstract class BaseLuceneIndexAdmin implements LuceneIndexAdmin {
 			directory = openDirectory();
 			closer.register(directory);
 			
+			shell = new GroovyShell();
+			
 			writer = new IndexWriter(directory, createConfig(false));
 			queryBuilder = new QueryBuilder(getSearchAnalyzer());
 			closer.register(writer);
@@ -210,6 +218,23 @@ public abstract class BaseLuceneIndexAdmin implements LuceneIndexAdmin {
 	protected abstract TransactionLog createTransactionlog(Map<String, String> commitData) throws IOException;
 
 	protected abstract Directory openDirectory() throws IOException;
+	
+	@Override
+	public Script compile(String script) {
+		final Class<? extends Script> scriptClass = getScriptClass(script);
+		try {
+			return scriptClass.newInstance();
+		} catch (InstantiationException | IllegalAccessException e) {
+			throw new IndexException("Couldn't instantiate groovy script", e);
+		}
+	}
+	
+	private Class<? extends Script> getScriptClass(String script) {
+		if (!scriptCache.containsKey(script)) {
+			scriptCache.put(script, (Class<?>) shell.getClassLoader().parseClass(script));
+		}
+		return (Class<? extends Script>) scriptCache.get(script);
+	}
 
 	private void initPeriodicCommit(IndexWriter writer, TransactionLog tlog) {
 		final long periodicCommitInterval = (long) settings().get(IndexClientFactory.COMMIT_INTERVAL_KEY);
@@ -290,6 +315,7 @@ public abstract class BaseLuceneIndexAdmin implements LuceneIndexAdmin {
 			writer = null;
 			manager = null;
 			tlog = null;
+			shell = null;
 			closer.close();
 			closer = null;
 			open.set(false);

--- a/commons/com.b2international.index.lucene/src/com/b2international/index/json/JsonDocumentSearcher.java
+++ b/commons/com.b2international.index.lucene/src/com/b2international/index/json/JsonDocumentSearcher.java
@@ -50,6 +50,7 @@ import com.b2international.index.Hits;
 import com.b2international.index.IndexClientFactory;
 import com.b2international.index.IndexException;
 import com.b2international.index.LuceneIndexAdmin;
+import com.b2international.index.ScriptEngine;
 import com.b2international.index.Searcher;
 import com.b2international.index.WithHash;
 import com.b2international.index.WithId;
@@ -93,8 +94,10 @@ public class JsonDocumentSearcher implements Searcher {
 	private final int resultWindow;
 	private final Logger log;
 	private final QueryBuilder luceneQueryBuilder;
+	private final ScriptEngine scriptEngine;
 
 	public JsonDocumentSearcher(LuceneIndexAdmin admin, ObjectMapper mapper) {
+		this.scriptEngine = admin;
 		this.log = admin.log();
 		this.mapper = mapper;
 		this.mappings = admin.mappings();
@@ -387,7 +390,7 @@ public class JsonDocumentSearcher implements Searcher {
 	}
 
 	private org.apache.lucene.search.Query toLuceneQuery(DocumentMapping mapping, Expression where) {
-		return new LuceneQueryBuilder(mapping, luceneQueryBuilder).build(where);
+		return new LuceneQueryBuilder(mapping, luceneQueryBuilder, scriptEngine).build(where);
 	}
 
 	private org.apache.lucene.search.Sort toLuceneSort(DocumentMapping mapping, Query<?> query) {

--- a/commons/com.b2international.index.lucene/src/com/b2international/index/json/JsonDocumentWriter.java
+++ b/commons/com.b2international.index.lucene/src/com/b2international/index/json/JsonDocumentWriter.java
@@ -144,7 +144,7 @@ public class JsonDocumentWriter implements Writer {
 	@Override
 	public <T> void bulkUpdate(BulkUpdate<T> update) throws IOException {
 		this.withUpdate = true;
-		this.operations.add(new BulkUpdateOperation<T>(update, mapper, mappings));
+		this.operations.add(new BulkUpdateOperation<T>(update, mapper, mappings, admin));
 	}
 
 }

--- a/commons/com.b2international.index.lucene/src/com/b2international/index/translog/EsTransactionLogTest.java
+++ b/commons/com.b2international.index.lucene/src/com/b2international/index/translog/EsTransactionLogTest.java
@@ -59,6 +59,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 
+import groovy.lang.Script;
+
 /**
  * @since 5.0
  */
@@ -114,6 +116,11 @@ final class EsTransactionLogTest {
 		@Override
 		public Logger log() {
 			return logger;
+		}
+		
+		@Override
+		public Script compile(String script) {
+			throw new UnsupportedOperationException();
 		}
 
 		@Override


### PR DESCRIPTION
This PR fixes a possible memory leak found in the Groovy script evaluation inside the Lucene based index implementation. 
The implementation now caches the compiled script class for later use and instantiates a new instance every time the code would like to execute the script.