### PR TITLE
SDD-775: Convert escg refset query (^) from concept to member search...

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/escg/IndexQueryQueryEvaluator.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/escg/IndexQueryQueryEvaluator.java
@@ -17,13 +17,9 @@ package com.b2international.snowowl.snomed.datastore.escg;
 
 import java.io.Serializable;
 
-import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermQuery;
 
-import com.b2international.snowowl.datastore.index.IndexUtils;
 import com.b2international.snowowl.snomed.datastore.index.mapping.SnomedMappings;
 import com.b2international.snowowl.snomed.dsl.query.ast.AndClause;
 import com.b2international.snowowl.snomed.dsl.query.ast.ConceptRef;
@@ -86,10 +82,7 @@ public class IndexQueryQueryEvaluator implements Serializable, IQueryEvaluator<B
 			
 			final RefSet refSet = (RefSet) expression;
 			final String refSetId = refSet.getId();
-			
-			mainQuery.add(createRefSetQuery(refSetId), Occur.MUST);
-			
-			return mainQuery;
+			throw new EscgParseFailedException("Refset search not handled: " +  refSetId);
 			
 		} else if (expression instanceof SubExpression) {
 			
@@ -161,22 +154,4 @@ public class IndexQueryQueryEvaluator implements Serializable, IQueryEvaluator<B
 		return mainQuery;
 	}
 	
-	private Term createRefSetTerm(String refSetId) {
-		return new Term(SnomedMappings.conceptReferringRefSetId().fieldName(), IndexUtils.longToPrefixCoded(refSetId));
-	}
-	
-	private Term createMappingRefSetTerm(String refSetId) {
-		return new Term(SnomedMappings.conceptReferringMappingRefSetId().fieldName(), IndexUtils.longToPrefixCoded(refSetId));
-	}
-	
-	private Query createRefSetQuery(String refSetId) {
-		final BooleanQuery refSetQuery = new BooleanQuery(true);
-		refSetQuery.add(new TermQuery(createRefSetTerm(refSetId)), Occur.SHOULD);
-		refSetQuery.add(new TermQuery(createMappingRefSetTerm(refSetId)), Occur.SHOULD);
-		final BooleanQuery query = new BooleanQuery(true);
-		query.add(refSetQuery, Occur.MUST);
-		query.add(SnomedMappings.newQuery().active().matchAll(), Occur.MUST);
-		return query;
-	}
-
 }

--- a/snomed/com.b2international.snowowl.snomed.importer.rf2/src/com/b2international/snowowl/snomed/importer/rf2/SnomedRf2IndexInitializer.java
+++ b/snomed/com.b2international.snowowl.snomed.importer.rf2/src/com/b2international/snowowl/snomed/importer/rf2/SnomedRf2IndexInitializer.java
@@ -119,6 +119,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Maps;
@@ -1059,7 +1060,7 @@ public class SnomedRf2IndexInitializer extends Job {
 	}
 	
 	private Collection<String> getCurrentRefSetMemberships(final Collection<String> refSetIds, final Collection<RefSetMemberChange> changes) {
-		final Collection<String> refSetMemberships = Sets.newHashSet(refSetIds);
+		final Collection<String> refSetMemberships = HashMultiset.create(refSetIds);
 		
 		for (RefSetMemberChange change : changes) {
 			if (change.getChangeKind().equals(MemberChangeKind.REMOVED)) {


### PR DESCRIPTION
...and ensure multiple memberships in the same refset can be handled by
the SnomedRf2IndexInitializer
Note: Active members with inactive referenced components will now show
up among the search results