### PR TITLE
SO-2662: single refset export fix

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/SnomedExportRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/SnomedExportRestService.java
@@ -21,6 +21,7 @@ import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.security.Principal;
 import java.text.ParseException;
 import java.util.Date;
 import java.util.UUID;
@@ -227,11 +228,14 @@ public class SnomedExportRestService extends AbstractSnomedRestService {
 			final UUID exportId,
 			
 			@RequestHeader
-			final HttpHeaders headers) throws IOException {
+			final HttpHeaders headers,
+			
+			final Principal principal) throws IOException {
 
 		final SnomedExportRestRun export = getExport(exportId);
 		
 		final UUID exportedFile = SnomedRequests.rf2().prepareExport()
+			.setUserId(principal.getName())
 			.setReleaseType(export.getType())
 			.setCodeSystem(export.getCodeSystemShortName())
 			.setExtensionOnly(export.isExtensionOnly())

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/internal/rf2/SnomedExportResult.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/internal/rf2/SnomedExportResult.java
@@ -29,13 +29,11 @@ public class SnomedExportResult implements Serializable {
 	private static final String DEFAULT_SUCCESSFUL_MESSAGE = "SNOMED CT export successfully finished.";
 	private static final String DEFAULT_EXCEPTION_MESSAGE = "An error occurred while exporting SNOMED CT components: exception during export.";
 	private static final String DEFAULT_CANCELED_MESSAGE = "SNOMED CT export was canceled.";
-	private static final String DEFAULT_IN_PROGRESS_MESSAGE = "SNOMED CT publication is already in progress.";
 	
 	public enum Result {
 		SUCCESSFUL,
 		EXCEPTION,
-		CANCELED,
-		IN_PROGRESS
+		CANCELED
 	}
 	
 	private Result result;
@@ -84,9 +82,6 @@ public class SnomedExportResult implements Serializable {
 			break;
 		case CANCELED:
 			this.message = DEFAULT_CANCELED_MESSAGE;
-			break;
-		case IN_PROGRESS:
-			this.message = DEFAULT_IN_PROGRESS_MESSAGE;
 			break;
 		}
 	}

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/SnomedRf2ExportRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/SnomedRf2ExportRequestBuilder.java
@@ -31,6 +31,7 @@ import com.b2international.snowowl.snomed.core.domain.Rf2ReleaseType;
  */
 public final class SnomedRf2ExportRequestBuilder extends BaseRequestBuilder<SnomedRf2ExportRequestBuilder, BranchContext, UUID> implements RevisionIndexRequestBuilder<UUID> {
 
+	private String userId;
 	private String codeSystem = SnomedTerminologyComponentConstants.SNOMED_SHORT_NAME;
 	private boolean includeUnpublished;
 	private String startEffectiveTime;
@@ -41,8 +42,14 @@ public final class SnomedRf2ExportRequestBuilder extends BaseRequestBuilder<Snom
 	private boolean extensionOnly;
 	private String namespace;
 	private Collection<String> refSets = Collections.emptySet();
+	private Collection<String> componentTypes = Collections.emptySet();
 	
 	SnomedRf2ExportRequestBuilder() {}
+	
+	public SnomedRf2ExportRequestBuilder setUserId(String userId) {
+		this.userId = userId;
+		return getSelf();
+	}
 	
 	public SnomedRf2ExportRequestBuilder setCodeSystem(String codeSystem) {
 		this.codeSystem = codeSystem;
@@ -93,11 +100,17 @@ public final class SnomedRf2ExportRequestBuilder extends BaseRequestBuilder<Snom
 		this.refSets = refSets;
 		return getSelf();
 	}
+	
+	public SnomedRf2ExportRequestBuilder setComponentTypes(Collection<String> componentTypes) {
+		this.componentTypes = componentTypes;
+		return getSelf();
+	}
 
 	@Override
 	protected Request<BranchContext, UUID> doBuild() {
 		SnomedRf2ExportRequest req = new SnomedRf2ExportRequest();
 		req.setReleaseType(releaseType);
+		req.setUserId(userId);
 		req.setCodeSystem(codeSystem);
 		req.setIncludeUnpublished(includeUnpublished);
 		req.setExtensionOnly(extensionOnly);
@@ -107,6 +120,7 @@ public final class SnomedRf2ExportRequestBuilder extends BaseRequestBuilder<Snom
 		req.setTransientEffectiveTime(transientEffectiveTime);
 		req.setNamespace(namespace);
 		req.setRefSets(refSets);
+		req.setComponentTypes(componentTypes);
 		return req;
 	}
 


### PR DESCRIPTION
Allow exported content filtering by component type.
Single reference set only export will happen when you select a single
refset + refset member type.
Also remove the restriction to allow a single export at any given point
in time.