### PR TITLE
Minor API improvements

### DIFF
--- a/core/com.b2international.snowowl.core/META-INF/MANIFEST.MF
+++ b/core/com.b2international.snowowl.core/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.9.0",
  xstream;bundle-version="1.4.7",
  org.eclipse.xtext.util;bundle-version="[2.11.0,2.13.0)",
  io.reactivex.rxjava2.rxjava;bundle-version="2.0.7";visibility:=reexport,
- org.reactivestreams.reactive-streams;bundle-version="1.0.0";visibility:=reexport
+ org.reactivestreams.reactive-streams;bundle-version="1.0.0";visibility:=reexport,
+ org.eclipse.emf.cdo;bundle-version="4.1.10"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: com.b2international.snowowl.core,

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/api/Net4jProtocolConstants.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/api/Net4jProtocolConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,11 +66,6 @@ public abstract class Net4jProtocolConstants {
 	public static final short LOINC_IMPORT_SIGNAL = 701;
 	public static final short LOINC_EXPORT_SIGNAL = 702;
 	public static final short LOINC_INDEX_SEARCHER_SIGNAL = 703;
-	
-	// Local terminology protocol
-	public static final short LOCAL_TERMINOLOGY_IMPORT_SIGNAL = 751;
-	public static final short LOCAL_TERMINOLOGY_EXPORT_SIGNAL = 752;
-	public static final short LOCAL_TERMINOLOGY_SEARCHER_SIGNAL = 753;
 	
 	// Value set protocol
 	public static final short VALUE_SET_EXCEL_IMPORT_SIGNAL = 801;

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/BaseComponent.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/BaseComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,6 @@
  */
 package com.b2international.snowowl.core.domain;
 
-import com.b2international.snowowl.core.ComponentIdentifier;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 /**
  * @since 4.0
  */
@@ -28,47 +25,32 @@ public abstract class BaseComponent implements IComponent {
 	private Boolean released;
 	
 	@Override
-	public String getId() {
+	public final String getId() {
 		return id;
 	}
 
 	@Override
-	public Boolean isReleased() {
+	public final Boolean isReleased() {
 		return released;
 	}
 	
 	@Override
-	public long getStorageKey() {
+	public final long getStorageKey() {
 		return storageKey;
 	}
 
-	public void setId(final String id) {
+	public final void setId(final String id) {
 		this.id = id;
 	}
 
-	public void setReleased(final boolean released) {
+	public final void setReleased(final boolean released) {
 		this.released = released;
 	}
 	
 	/**
-	 * Returns a {@link ComponentIdentifier} instance to identify this component using its {@link #getTerminologyComponentId() type} and {@link #getId() id}.
-	 * @return
-	 */
-	@JsonIgnore
-	public final ComponentIdentifier getComponentIdentifier() {
-		return ComponentIdentifier.of(getTerminologyComponentId(), getId());
-	}
-	
-	/**
-	 * @return the associated terminology component type identifier of this component.
-	 */
-	@JsonIgnore
-	public abstract short getTerminologyComponentId();
-	
-	/**
 	 * @deprecated - see {@link IComponent#getStorageKey()}
 	 */
-	public void setStorageKey(long storageKey) {
+	public final void setStorageKey(long storageKey) {
 		this.storageKey = storageKey;
 	}
 	

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/IComponent.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/IComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.b2international.snowowl.core.domain;
 
 import java.io.Serializable;
 
+import com.b2international.snowowl.core.ComponentIdentifier;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Function;
 
@@ -62,4 +63,19 @@ public interface IComponent extends Serializable {
 	 */
 	@JsonIgnore
 	long getStorageKey();
+	
+	/**
+	 * Returns a {@link ComponentIdentifier} instance to identify this component using its {@link #getTerminologyComponentId() type} and {@link #getId() id}.
+	 * @return
+	 */
+	@JsonIgnore
+	default ComponentIdentifier getComponentIdentifier() {
+		return ComponentIdentifier.of(getTerminologyComponentId(), getId());
+	}
+	
+	/**
+	 * @return the associated terminology component type identifier of this component.
+	 */
+	@JsonIgnore
+	short getTerminologyComponentId();
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/TransactionContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/TransactionContext.java
@@ -18,6 +18,7 @@ package com.b2international.snowowl.core.domain;
 import java.util.Collection;
 import java.util.Map;
 
+import org.eclipse.emf.cdo.CDOObject;
 import org.eclipse.emf.ecore.EObject;
 
 import com.b2international.snowowl.core.exceptions.ComponentNotFoundException;
@@ -122,7 +123,7 @@ public interface TransactionContext extends BranchContext, AutoCloseable {
 	 * @param type
 	 * @return
 	 */
-	<T extends EObject> Map<String, T> lookup(Collection<String> componentIds, Class<T> type);
+	<T extends CDOObject> Map<String, T> lookup(Collection<String> componentIds, Class<T> type);
 
 	/**
 	 * Clears the entire content of the repository this context belongs to.

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/TransactionContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/TransactionContext.java
@@ -65,6 +65,13 @@ public interface TransactionContext extends BranchContext, AutoCloseable {
 	/**
 	 * Commits any changes made to {@link EObject}s into the store.
 	 * 
+	 * @return
+	 */
+	long commit();
+	
+	/**
+	 * Commits any changes made to {@link EObject}s into the store.
+	 * 
 	 * @param userId
 	 *            - the owner of the commit
 	 * @param commitComment

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/TransactionContextProvider.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/TransactionContextProvider.java
@@ -20,6 +20,6 @@ package com.b2international.snowowl.core.domain;
  */
 public interface TransactionContextProvider {
 
-	TransactionContext get(BranchContext context, String userId);
+	TransactionContext get(BranchContext context, String userId, String commitComment, String parentContextDescription);
 	
 }

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/CDOServerChangeManager.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/CDOServerChangeManager.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/IEClassProvider.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/IEClassProvider.java
@@ -15,9 +15,11 @@
  */
 package com.b2international.snowowl.datastore.server;
 
+import java.io.IOException;
+
 import org.eclipse.emf.ecore.EClass;
 
-import com.b2international.snowowl.core.api.IBranchPath;
+import com.b2international.index.revision.RevisionSearcher;
 
 /**
  * Interface for providing {@link EClass}.
@@ -26,17 +28,12 @@ public interface IEClassProvider {
 
 	/**
 	 * Returns with the {@link EClass} of an object identified by a unique storage key.
-	 * @param branchPath the branch path.
+	 * @param searcher - a searcher to use to get the EClass for the storageKey
 	 * @param storageKey the unique storage key.
 	 * @return the {@link EClass}.
+	 * @throws IOException 
 	 */
-	EClass getEClass(IBranchPath branchPath, final long storageKey);
-	
-	/**
-	 * Returns with the priority of the implementation. The less the more important. 
-	 * @return the priority.
-	 */
-	int getPriority();
+	EClass getEClass(RevisionSearcher searcher, final long storageKey) throws IOException;
 	
 	/**
 	 * Returns with the UUID of the repository where the current provider works on.  

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/importer/AbstractTerminologyExcelExporter.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/importer/AbstractTerminologyExcelExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFHyperlink;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
-import org.eclipse.emf.cdo.CDOObject;
 import org.eclipse.net4j.util.om.monitor.OMMonitor;
 
 import com.b2international.commons.AlphaNumericComparator;
@@ -55,7 +54,7 @@ import com.google.common.collect.Ordering;
  * @param <M>
  *            the terminology component member/mapping/concept.
  */
-public abstract class AbstractTerminologyExcelExporter<T, M extends CDOObject> extends AbstractFilteredComponentsTerminologyExporter {
+public abstract class AbstractTerminologyExcelExporter<T, M> extends AbstractFilteredComponentsTerminologyExporter {
 
 	// necessary for auto sizing column in the excel
 	// basic java supports Sarif, Sans-serif, Monospaced, Dialog, DialogInput font styles,
@@ -66,19 +65,8 @@ public abstract class AbstractTerminologyExcelExporter<T, M extends CDOObject> e
 	private static final AlphaNumericComparator COMPARATOR = new AlphaNumericComparator();
 	
 	// The two fields below are non-static because the type parameter needs to be known
-	private final Function<M, String> getLowerCaseMemberCodeFunction = new Function<M, String>() {
-		@Override
-		public String apply(M input) {
-			return getMemberCode(input).toLowerCase(Locale.ENGLISH);
-		}
-	};
-
-	private final Function<T, String> getLowerCaseComponentNameFunction = new Function<T, String>() {
-		@Override
-		public String apply(T input) {
-			return getComponentName(input).toLowerCase(Locale.ENGLISH);
-		}
-	};
+	private final Function<M, String> getLowerCaseMemberCodeFunction = input -> getMemberCode(input).toLowerCase(Locale.ENGLISH);
+	private final Function<T, String> getLowerCaseComponentNameFunction = input -> getComponentName(input).toLowerCase(Locale.ENGLISH);
 
 	private final Workbook workbook = new XSSFWorkbook();
 

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/importer/AbstractTerminologyExcelExporter.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/importer/AbstractTerminologyExcelExporter.java
@@ -122,8 +122,6 @@ public abstract class AbstractTerminologyExcelExporter<T, M> extends AbstractFil
 
 		exportTerminologyComponents(monitor);
 
-		getEditingContext().close();
-
 		workbook.write(outputStream);
 		outputStream.close();
 

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/importer/AbstractTerminologyExcelImportJob.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/importer/AbstractTerminologyExcelImportJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,7 @@ import com.google.common.collect.Sets;
  */
 public abstract class AbstractTerminologyExcelImportJob<T extends CDOObject> extends AbstractTerminologyImportJob {
 
+	public static final String INDEX_SHEET = "index";
 	protected static final boolean DEFAULT_ACTIVE_STATUS = true;
 
 	private long latestSuccessfulCommitTime;
@@ -285,14 +286,14 @@ public abstract class AbstractTerminologyExcelImportJob<T extends CDOObject> ext
 		return CDOServerUtils.getLastCommitTime(getEditingContext().getTransaction().getBranch());
 	}
 
-	private Set<Sheet> collectSheets(final Workbook workbook) {
+	public static Set<Sheet> collectSheets(final Workbook workbook) {
 		final Set<Sheet> sheets = Sets.newHashSet();
 		final int numberOfSheets = workbook.getNumberOfSheets();
 
 		for (int i = 0; i < numberOfSheets; i++) {
 			final Sheet sheet = workbook.getSheetAt(i);
 
-			if (!"index".equalsIgnoreCase(sheet.getSheetName())) {
+			if (!INDEX_SHEET.equalsIgnoreCase(sheet.getSheetName())) {
 				sheets.add(sheet);
 			}
 

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/importer/AbstractTerminologyExporter.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/importer/AbstractTerminologyExporter.java
@@ -30,7 +30,6 @@ import com.b2international.snowowl.core.api.IBranchPath;
 import com.b2international.snowowl.core.api.SnowowlServiceException;
 import com.b2international.snowowl.core.date.Dates;
 import com.b2international.snowowl.core.date.EffectiveTimes;
-import com.b2international.snowowl.datastore.CDOEditingContext;
 
 /**
  * Abstract exporter to export terminology.
@@ -56,13 +55,6 @@ public abstract class AbstractTerminologyExporter implements ITerminologyExporte
 	 * @return
 	 */
 	protected abstract String getTerminologyName();
-	
-	/**
-	 * Gets the terminology specific editing context.
-	 * 
-	 * @return
-	 */
-	protected abstract CDOEditingContext getEditingContext();
 	
 	/**
 	 * Initializes resources for the export.

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/importer/AbstractTerminologyImportValidator.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/importer/AbstractTerminologyImportValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.poi.ss.usermodel.Row;
-import org.eclipse.emf.cdo.CDOObject;
 
 import com.b2international.commons.StringUtils;
 import com.b2international.snowowl.datastore.importer.TerminologyImportType;
@@ -43,7 +42,7 @@ import com.google.common.collect.Sets;
  * @param <T>
  *            the terminology for the validation process.
  */
-public abstract class AbstractTerminologyImportValidator<T extends CDOObject> {
+public abstract class AbstractTerminologyImportValidator<T> {
 
 	private final TerminologyImportType importType;
 	private final TerminologyImportExcelParser excelParser;

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/importer/TerminologyImportResult.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/importer/TerminologyImportResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,8 @@
  */
 package com.b2international.snowowl.datastore.server.importer;
 
+import java.io.Serializable;
 import java.util.Set;
-
-import org.eclipse.emf.cdo.CDOObject;
 
 import com.b2international.snowowl.datastore.importer.TerminologyImportValidationDefect;
 import com.google.common.collect.Sets;
@@ -28,18 +27,22 @@ import com.google.common.collect.Sets;
  * 
  * @since Snow&nbsp;Owl 3.0.1
  */
-public class TerminologyImportResult {
+public final class TerminologyImportResult implements Serializable {
 	
-	private Set<CDOObject> visitedComponents;
-	private Set<TerminologyImportValidationDefect> validationDefects;
+	private final Set<String> visitedComponentIds;
+	private final Set<TerminologyImportValidationDefect> validationDefects;
 	
 	public TerminologyImportResult() {
-		visitedComponents = Sets.newHashSet();
+		visitedComponentIds = Sets.newHashSet();
 		validationDefects = Sets.newHashSet();
 	}
 	
-	public Set<CDOObject> getVisitedComponents() {
-		return visitedComponents;
+	public void visit(String componentId) {
+		visitedComponentIds.add(componentId);
+	}
+
+	public Set<String> getVisitedComponents() {
+		return visitedComponentIds;
 	}
 	
 	public boolean hasValidationDefects() {

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/internal/CDOBranchContext.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/internal/CDOBranchContext.java
@@ -42,9 +42,9 @@ public class CDOBranchContext extends DefaultBranchContext implements Transactio
 	}
 	
 	@Override
-	public TransactionContext get(BranchContext context, String userId) {
+	public TransactionContext get(BranchContext context, String userId, String commitComment, String parentContextDescription) {
 		final CDOEditingContext ec = service(EditingContextFactory.class).createEditingContext(branch().branchPath());
-		return new CDOTransactionContext(context, ec, userId);
+		return new CDOTransactionContext(context, ec, userId, commitComment, parentContextDescription);
 	}
 	
 }

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/internal/CDOTransactionContext.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/internal/CDOTransactionContext.java
@@ -42,13 +42,23 @@ import com.b2international.snowowl.datastore.exception.RepositoryLockException;
 public final class CDOTransactionContext extends DelegatingBranchContext implements TransactionContext {
 
 	private final String userId;
+	private final String commitComment;
+	private final String parentContextDescription;
 	private final CDOEditingContext editingContext;
+	
 	private boolean isNotificationEnabled = true;
 
-	CDOTransactionContext(BranchContext context, CDOEditingContext editingContext, String userId) {
+	CDOTransactionContext(BranchContext context, CDOEditingContext editingContext, String userId, String commitComment, String parentContextDescription) {
 		super(context);
 		this.editingContext = editingContext;
 		this.userId = userId;
+		this.commitComment = commitComment;
+		this.parentContextDescription = parentContextDescription;
+	}
+	
+	@Override
+	public long commit() {
+		return commit(userId(), commitComment, parentContextDescription);
 	}
 	
 	@Override

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/internal/CDOTransactionContext.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/internal/CDOTransactionContext.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.ConcurrentModificationException;
 import java.util.Map;
 
+import org.eclipse.emf.cdo.CDOObject;
 import org.eclipse.emf.cdo.common.commit.CDOCommitInfo;
 import org.eclipse.emf.cdo.util.CommitException;
 import org.eclipse.emf.ecore.EObject;
@@ -74,7 +75,7 @@ public final class CDOTransactionContext extends DelegatingBranchContext impleme
 	}
 	
 	@Override
-	public <T extends EObject> Map<String, T> lookup(Collection<String> componentIds, Class<T> type) {
+	public <T extends CDOObject> Map<String, T> lookup(Collection<String> componentIds, Class<T> type) {
 		return editingContext.lookup(componentIds, type);
 	}
 	

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/net4j/AbstractImportIndication.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/net4j/AbstractImportIndication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import java.util.Set;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.emf.cdo.CDOObject;
 import org.eclipse.net4j.signal.IndicationWithMonitoring;
 import org.eclipse.net4j.signal.SignalProtocol;
 import org.eclipse.net4j.util.io.ExtendedDataInputStream;
@@ -35,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.b2international.snowowl.core.api.Net4jProtocolConstants;
-import com.b2international.snowowl.datastore.cdo.CDOUtils;
 import com.b2international.snowowl.datastore.importer.TerminologyImportType;
 import com.b2international.snowowl.datastore.importer.TerminologyImportValidationDefect;
 import com.b2international.snowowl.datastore.importer.TerminologyImportValidationDefect.Defect;
@@ -142,12 +140,12 @@ public abstract class AbstractImportIndication extends IndicationWithMonitoring 
 			if (result.isOK()) {
 				out.writeBoolean(true);
 				
-				final Set<CDOObject> visitedComponents = importer.getTerminologyImportResult().getVisitedComponents();
+				final Set<String> visitedComponents = importer.getTerminologyImportResult().getVisitedComponents();
 				
 				out.writeInt(visitedComponents.size());
 				
-				for (final CDOObject cdoObject : visitedComponents) {
-					out.writeLong(CDOUtils.getStorageKey(cdoObject));
+				for (final String componentId : visitedComponents) {
+					out.writeUTF(componentId);
 				}
 			} else if (result.equals(Status.CANCEL_STATUS)) {
 				out.writeBoolean(false);

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/version/PublishManager.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/version/PublishManager.java
@@ -21,7 +21,6 @@ import static com.b2international.snowowl.datastore.cdo.CDOIDUtils.STORAGE_KEY_T
 import static com.b2international.snowowl.datastore.cdo.CDOUtils.getObjectIfExists;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.Boolean.TRUE;
-import static java.text.MessageFormat.format;
 import static org.eclipse.emf.cdo.common.revision.CDORevisionUtil.createDelta;
 import static org.eclipse.emf.ecore.InternalEObject.EStore.NO_INDEX;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -45,7 +44,6 @@ import org.slf4j.Logger;
 
 import com.b2international.collections.longs.LongSet;
 import com.b2international.snowowl.core.ApplicationContext;
-import com.b2international.snowowl.core.CoreTerminologyBroker;
 import com.b2international.snowowl.core.api.IBranchPath;
 import com.b2international.snowowl.core.api.SnowowlServiceException;
 import com.b2international.snowowl.core.branch.Branch;
@@ -77,8 +75,6 @@ public abstract class PublishManager implements IPublishManager {
 	/** Shared logger instance. */
 	protected static final Logger LOGGER = getLogger(PublishManager.class);
 
-	private static final String NEW_VERSION_CREATED_TEMPLATE = "New version ''{0}'' has been successfully created for {1}.";
-
 	private Supplier<CDOEditingContext> editingContextSupplier;
 
 	@Override
@@ -93,7 +89,6 @@ public abstract class PublishManager implements IPublishManager {
 				}
 			});
 			
-			ToolingIdThreadLocal.setToolingId(toolingId);
 			aggregator.add(getTransaction());
 			publishTerminologyChanges(configuration);
 			logWork(monitor);
@@ -102,12 +97,7 @@ public abstract class PublishManager implements IPublishManager {
 
 		} catch (final SnowowlServiceException e) {
 			handleError(e);
-		} finally {
-			ToolingIdThreadLocal.reset();
 		}
-
-		format(NEW_VERSION_CREATED_TEMPLATE, configuration.getVersionId(), getToolingName());
-
 	}
 	
 	@Override
@@ -204,11 +194,6 @@ public abstract class PublishManager implements IPublishManager {
 		LOGGER.info("Effective time adjustment successfully finished.");
 	}
 
-	/** Returns with the primary component ID for the underlying tooling feature. */
-	protected String getPrimaryComponentId() {
-		return CoreTerminologyBroker.getInstance().getPrimaryComponentIdByTerminologyId(getToolingId());
-	}
-
 	/** Loads and returns with the CDO object given by the unique CDO ID argument. */
 	protected CDOObject loadObject(final long storageKey) {
 		return checkNotNull(getObjectIfExists(getTransaction(), storageKey), "Component cannot be found in " + getTransaction() + " with CDOID: "
@@ -293,15 +278,6 @@ public abstract class PublishManager implements IPublishManager {
 		postProcess(config);
 	}
 
-	/** Returns with the current tooling feature ID. */
-	private String getToolingId() {
-		return ToolingIdThreadLocal.getToolingId();
-	}
-
-	private String getToolingName() {
-		return CoreTerminologyBroker.getInstance().getTerminologyName(getToolingId());
-	}
-
 	/** Published a component given by its unique storage key. */
 	private void publishComponent(final CDORevision revision, final Object effectiveTime) {
 		if (!isIgnoredType(revision.getEClass())) {
@@ -354,23 +330,6 @@ public abstract class PublishManager implements IPublishManager {
 	private void handleError(final SnowowlServiceException e) throws SnowowlServiceException {
 		LOGGER.error("Error while performing the publication.", e);
 		throw e;
-	}
-
-	/** Class for storing the configuration in the thread local. */
-	static final class ToolingIdThreadLocal {
-		private static final ThreadLocal<String> TOOLING_ID_THREAD_LOCAL = new ThreadLocal<String>();
-
-		static void setToolingId(final String toolingId) {
-			TOOLING_ID_THREAD_LOCAL.set(toolingId);
-		}
-
-		static String getToolingId() {
-			return TOOLING_ID_THREAD_LOCAL.get();
-		}
-
-		static void reset() {
-			TOOLING_ID_THREAD_LOCAL.set(null);
-		}
 	}
 
 }

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/CDOEditingContext.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/CDOEditingContext.java
@@ -433,19 +433,11 @@ public abstract class CDOEditingContext implements AutoCloseable {
 	 * @return an immutable list of the available code systems.
 	 */
 	public List<CodeSystem> getCodeSystems() {
-		if (!getBranch().equals(IBranchPath.MAIN_BRANCH)) {
-			throw new IllegalStateException(String.format("Snomed Code Systems are maintained on MAIN branch, this editing context uses %s", getBranch()));
-		}
-		
 		final CDOResource cdoResource = transaction.getOrCreateResource(getMetaRootResourceName());
 		return FluentIterable.from(cdoResource.getContents()).filter(CodeSystem.class).toList();
 	}
 	
 	public CodeSystem getCodeSystem(final String uniqueId) {
-		if (!getBranch().equals(IBranchPath.MAIN_BRANCH)) {
-			throw new IllegalStateException(String.format("Snomed Code Systems are maintained on MAIN branch, this editing context uses %s", getBranch()));
-		}
-		
 		final Optional<CodeSystem> optional = FluentIterable.from(getCodeSystems()).firstMatch(new Predicate<CodeSystem>() {
 			@Override
 			public boolean apply(final CodeSystem input) {

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/importer/TerminologyImportType.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/importer/TerminologyImportType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,18 @@ public enum TerminologyImportType {
 	@Override
 	public String toString() {
 		return label;
+	}
+
+	public boolean isClear() {
+		return CLEAR == this;
+	}
+	
+	public boolean isMerge() {
+		return MERGE == this;
+	}
+	
+	public boolean isReplace() {
+		return REPLACE == this;
 	}
 	
 }

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/importer/TerminologyImportValidationDefect.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/importer/TerminologyImportValidationDefect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.b2international.snowowl.datastore.importer;
 
+import java.io.Serializable;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
@@ -24,7 +25,7 @@ import com.google.common.collect.Sets;
  * 
  * @since SNow&nbsp;Owl 3.0.1
  */
-public class TerminologyImportValidationDefect {
+public class TerminologyImportValidationDefect implements Serializable {
 	
 	private final String sheetName;
 	private final Set<Defect> defects;
@@ -59,7 +60,7 @@ public class TerminologyImportValidationDefect {
 	/**
 	 * Represents a terminology import defect with a defect type and an error message. 
 	 */
-	public class Defect {
+	public class Defect implements Serializable {
 		
 		private final DefectType defectType;
 		private final String errorMessage;

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/internal/branch/BranchManagerImpl.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/internal/branch/BranchManagerImpl.java
@@ -89,7 +89,7 @@ public abstract class BranchManagerImpl implements BranchManager {
 		}
 		final String path = toAbsolutePath(parent.path(), name);
 		Branch existingBranch = getBranchFromStore(path);
-		if (existingBranch != null) {
+		if (existingBranch != null && !existingBranch.isDeleted()) {
 			// throw AlreadyExistsException if exists before trying to enter the sync block
 			throw new AlreadyExistsException(Branch.class.getSimpleName(), path);
 		} else {
@@ -106,7 +106,7 @@ public abstract class BranchManagerImpl implements BranchManager {
 			public InternalBranch call() throws Exception {
 				// check again and return if exists, otherwise open the child branch
 				final Branch existingBranch = getBranchFromStore(toAbsolutePath(parentPath, name));
-				if (existingBranch != null) {
+				if (existingBranch != null && !existingBranch.isDeleted()) {
 					return (InternalBranch) existingBranch;
 				} else {
 					final InternalBranch createdBranch = doReopen(parent, name, metadata);

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/net4j/ImportRequest.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/net4j/ImportRequest.java
@@ -42,7 +42,7 @@ public class ImportRequest extends RequestWithMonitoring<Boolean> {
 
 	private final File sourceDir;
 	private final TerminologyImportType importType;
-	private Set<Long> visitedComponentStorageKeys;
+	private Set<String> visitedComponentIds;
 	private Set<TerminologyImportValidationDefect> defects;
 	
 	/**
@@ -126,11 +126,11 @@ public class ImportRequest extends RequestWithMonitoring<Boolean> {
 		boolean importOk = in.readBoolean();
 		
 		if (importOk) {
-			visitedComponentStorageKeys = Sets.newHashSet();
+			visitedComponentIds = Sets.newHashSet();
 			int size = in.readInt();
 			
 			for (int i = 0; i < size; i++) {
-				visitedComponentStorageKeys.add(in.readLong());
+				visitedComponentIds.add(in.readUTF());
 			}
 		} else {
 			int size = in.readInt();
@@ -183,8 +183,8 @@ public class ImportRequest extends RequestWithMonitoring<Boolean> {
 		return 85;
 	}
 
-	public Set<Long> getVisitedComponentStorageKeys() {
-		return visitedComponentStorageKeys;
+	public final Set<String> getVisitedComponentIds() {
+		return visitedComponentIds;
 	}
 	
 	public Set<TerminologyImportValidationDefect> getDefects() {

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/request/TransactionalRequest.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/request/TransactionalRequest.java
@@ -60,7 +60,7 @@ public final class TransactionalRequest implements Request<BranchContext, Commit
 	public CommitResult execute(BranchContext context) {
 		final Metrics metrics = context.service(Metrics.class);
 		metrics.setExternalValue("preRequest", preRequestPreparationTime);
-		try (final TransactionContext transaction = context.service(TransactionContextProvider.class).get(context, userId)) {
+		try (final TransactionContext transaction = context.service(TransactionContextProvider.class).get(context, userId, commitComment, parentContextDescription)) {
 			final Object body = executeNext(transaction);
 			return commit(transaction, body);
 		} catch (ApiException e) {

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/terminologyregistry/core/request/CodeSystemCreateRequest.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/terminologyregistry/core/request/CodeSystemCreateRequest.java
@@ -15,6 +15,7 @@
  */
 package com.b2international.snowowl.terminologyregistry.core.request;
 
+import com.b2international.snowowl.core.branch.Branch;
 import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.exceptions.AlreadyExistsException;
@@ -108,6 +109,14 @@ final class CodeSystemCreateRequest implements Request<TransactionContext, Strin
 		
 		if (getCodeSystem(shortName, context) != null) {
 			throw new AlreadyExistsException("Code system", shortName);
+		}
+		
+		if (!Strings.isNullOrEmpty(shortName) ) {
+			try {
+				Branch.BranchNameValidator.DEFAULT.checkName(shortName);
+			} catch(BadRequestException e) {
+				throw new BadRequestException(e.getMessage(), shortName);
+			}
 		}
 		
 		if (!Strings.isNullOrEmpty(extensionOf) && getCodeSystem(extensionOf, context) == null) {

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/terminologyregistry/core/request/CodeSystemCreateRequest.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/terminologyregistry/core/request/CodeSystemCreateRequest.java
@@ -15,14 +15,12 @@
  */
 package com.b2international.snowowl.terminologyregistry.core.request;
 
-import com.b2international.snowowl.core.branch.Branch;
 import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.exceptions.AlreadyExistsException;
 import com.b2international.snowowl.core.exceptions.BadRequestException;
 import com.b2international.snowowl.core.exceptions.NotFoundException;
 import com.b2international.snowowl.datastore.CodeSystemEntry;
-import com.b2international.snowowl.datastore.request.RepositoryRequests;
 import com.b2international.snowowl.terminologymetadata.CodeSystem;
 import com.b2international.snowowl.terminologyregistry.core.builder.CodeSystemBuilder;
 import com.google.common.base.Strings;
@@ -114,16 +112,6 @@ final class CodeSystemCreateRequest implements Request<TransactionContext, Strin
 		
 		if (!Strings.isNullOrEmpty(extensionOf) && getCodeSystem(extensionOf, context) == null) {
 			throw new BadRequestException("Couldn't find base Code System with unique ID %s.", extensionOf);
-		}
-		
-		final Branch branch = RepositoryRequests
-				.branching()
-				.prepareGet(branchPath)
-				.build()
-				.execute(context);
-		
-		if (branch.isDeleted()) {
-			throw new BadRequestException("Branch with identifier %s is deleted.", branchPath);
 		}
 	}
 	

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/terminologyregistry/core/request/CodeSystemCreateRequest.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/terminologyregistry/core/request/CodeSystemCreateRequest.java
@@ -111,14 +111,6 @@ final class CodeSystemCreateRequest implements Request<TransactionContext, Strin
 			throw new AlreadyExistsException("Code system", shortName);
 		}
 		
-		if (!Strings.isNullOrEmpty(shortName) ) {
-			try {
-				Branch.BranchNameValidator.DEFAULT.checkName(shortName);
-			} catch(BadRequestException e) {
-				throw new BadRequestException(e.getMessage(), shortName);
-			}
-		}
-		
 		if (!Strings.isNullOrEmpty(extensionOf) && getCodeSystem(extensionOf, context) == null) {
 			throw new BadRequestException("Couldn't find base Code System with unique ID %s.", extensionOf);
 		}

--- a/snomed/com.b2international.snowowl.snomed.datastore.server/src/com/b2international/snowowl/datastore/server/snomed/ImportOnlySnomedTransactionContext.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.server/src/com/b2international/snowowl/datastore/server/snomed/ImportOnlySnomedTransactionContext.java
@@ -129,6 +129,11 @@ public class ImportOnlySnomedTransactionContext implements TransactionContext {
 	}
 
 	@Override
+	public long commit() {
+		throw new UnsupportedOperationException("TODO implement me");
+	}
+	
+	@Override
 	public long commit(final String userId, final String commitComment, final String parentContextDescription) {
 		try {
 			final CDOCommitInfo info = new CDOServerCommitBuilder(userId, commitComment, editingContext.getTransaction())

--- a/snomed/com.b2international.snowowl.snomed.datastore.server/src/com/b2international/snowowl/datastore/server/snomed/ImportOnlySnomedTransactionContext.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.server/src/com/b2international/snowowl/datastore/server/snomed/ImportOnlySnomedTransactionContext.java
@@ -18,6 +18,7 @@ package com.b2international.snowowl.datastore.server.snomed;
 import java.util.Collection;
 import java.util.Map;
 
+import org.eclipse.emf.cdo.CDOObject;
 import org.eclipse.emf.cdo.common.commit.CDOCommitInfo;
 import org.eclipse.emf.cdo.util.CommitException;
 import org.eclipse.emf.ecore.EObject;
@@ -155,7 +156,7 @@ public class ImportOnlySnomedTransactionContext implements TransactionContext {
 	}
 	
 	@Override
-	public <T extends EObject> Map<String, T> lookup(Collection<String> componentIds, Class<T> type) {
+	public <T extends CDOObject> Map<String, T> lookup(Collection<String> componentIds, Class<T> type) {
 		return editingContext.lookup(componentIds, type);
 	}
 	

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/MrcmEditingContext.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/MrcmEditingContext.java
@@ -18,11 +18,11 @@ package com.b2international.snowowl.snomed.datastore;
 import java.util.Collection;
 import java.util.UUID;
 
+import org.eclipse.emf.cdo.CDOObject;
 import org.eclipse.emf.cdo.CDOState;
-import org.eclipse.emf.ecore.EObject;
 
-import com.b2international.collections.longs.LongValueMap;
 import com.b2international.snowowl.core.api.IBranchPath;
+import com.b2international.snowowl.core.domain.IComponent;
 import com.b2international.snowowl.datastore.CDOEditingContext;
 import com.b2international.snowowl.snomed.mrcm.AttributeConstraint;
 import com.b2international.snowowl.snomed.mrcm.ConceptModel;
@@ -87,8 +87,13 @@ public class MrcmEditingContext extends BaseSnomedEditingContext {
 	}
 
 	@Override
-	protected <T extends EObject> LongValueMap<String> getStorageKeys(Collection<String> componentIds, Class<T> type) {
+	protected <T extends CDOObject> Collection<? extends IComponent> fetchComponents(Collection<String> componentIds, Class<T> type) {
 		throw new UnsupportedOperationException("Cannot fetch storage keys for " + type);
+	}
+	
+	@Override
+	protected String getId(CDOObject component) {
+		throw new UnsupportedOperationException("Cannot get ID for " + component);
 	}
 	
 	/*creates and returns with a new concept model instance.*/

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedRefSetEditingContext.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedRefSetEditingContext.java
@@ -26,13 +26,13 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
+import org.eclipse.emf.cdo.CDOObject;
 import org.eclipse.emf.cdo.CDOState;
 import org.eclipse.emf.cdo.util.CommitException;
 import org.eclipse.emf.cdo.view.CDOView;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.spi.cdo.FSMUtil;
 
-import com.b2international.collections.longs.LongValueMap;
 import com.b2international.commons.StringUtils;
 import com.b2international.commons.options.OptionsBuilder;
 import com.b2international.snowowl.core.ApplicationContext;
@@ -41,6 +41,7 @@ import com.b2international.snowowl.core.CoreTerminologyBroker;
 import com.b2international.snowowl.core.api.IBranchPath;
 import com.b2international.snowowl.core.api.ILookupService;
 import com.b2international.snowowl.core.domain.BranchContext;
+import com.b2international.snowowl.core.domain.IComponent;
 import com.b2international.snowowl.core.events.bulk.BulkRequest;
 import com.b2international.snowowl.core.events.bulk.BulkResponse;
 import com.b2international.snowowl.core.exceptions.ConflictException;
@@ -203,8 +204,13 @@ public class SnomedRefSetEditingContext extends BaseSnomedEditingContext {
 	}
 	
 	@Override
-	protected <T extends EObject> LongValueMap<String> getStorageKeys(Collection<String> componentIds, Class<T> type) {
-		return getSnomedEditingContext().getStorageKeys(componentIds, type);
+	protected String getId(CDOObject component) {
+		return getSnomedEditingContext().getId(component);
+	}
+	
+	@Override
+	protected <T extends CDOObject> Iterable<? extends IComponent> fetchComponents(Collection<String> componentIds, Class<T> type) {
+		return getSnomedEditingContext().fetchComponents(componentIds, type);
 	}
 
 	public SnomedEditingContext getSnomedEditingContext() {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/Rf2EffectiveTimeSlice.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/Rf2EffectiveTimeSlice.java
@@ -160,7 +160,7 @@ final class Rf2EffectiveTimeSlice {
 	public void doImport(String userId, BranchContext context, boolean createVersions) throws Exception {
 		Stopwatch w = Stopwatch.createStarted();
 		System.err.println("Importing components from " + effectiveTime);
-		try (Rf2TransactionContext tx = new Rf2TransactionContext(context.service(TransactionContextProvider.class).get(context, userId), storageKeysByComponent, storageKeysByRefSet, loadOnDemand)) {
+		try (Rf2TransactionContext tx = new Rf2TransactionContext(context.service(TransactionContextProvider.class).get(context, userId, null, DatastoreLockContextDescriptions.ROOT), storageKeysByComponent, storageKeysByRefSet, loadOnDemand)) {
 			final Iterator<LongSet> importPlan = getImportPlan().iterator();
 			while (importPlan.hasNext()) {
 				LongSet componentsToImportInBatch = importPlan.next();

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/Rf2TransactionContext.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/Rf2TransactionContext.java
@@ -206,7 +206,7 @@ final class Rf2TransactionContext extends DelegatingBranchContext implements Tra
 	}
 	
 	@Override
-	public <T extends EObject> Map<String, T> lookup(Collection<String> componentIds, Class<T> type) {
+	public <T extends CDOObject> Map<String, T> lookup(Collection<String> componentIds, Class<T> type) {
 		final Map<String, T> resolvedComponentById = newHashMap();
 		Set<String> unresolvedComponentIds = newHashSet();
 

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/Rf2TransactionContext.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/Rf2TransactionContext.java
@@ -106,6 +106,11 @@ final class Rf2TransactionContext extends DelegatingBranchContext implements Tra
 	}
 	
 	@Override
+	public long commit() {
+		throw new UnsupportedOperationException("TODO implement me");
+	}
+	
+	@Override
 	public long commit(String userId, String commitComment, String parentContextDescription) {
 		try {
 			if (this.editingContext.isDirty()) {

--- a/snomed/com.b2international.snowowl.snomed.exporter.server/src/com/b2international/snowowl/snomed/exporter/server/dsv/SnomedSimpleTypeRefSetExcelExporter.java
+++ b/snomed/com.b2international.snowowl.snomed.exporter.server/src/com/b2international/snowowl/snomed/exporter/server/dsv/SnomedSimpleTypeRefSetExcelExporter.java
@@ -112,7 +112,6 @@ public class SnomedSimpleTypeRefSetExcelExporter extends AbstractTerminologyExpo
 		}
 	}
 
-	@Override
 	protected CDOEditingContext getEditingContext() {
 		return context;
 	}


### PR DESCRIPTION
This PR improves and simplifies some of the generic Java APIs provided by Snow Owl.

Improvements:
- Make TerminologyImportResult Serializable and replace storageKeys with
component IDs instead.
- Creating a code system on a non-existing branch is now possible (this was required to enable star shaped branching strategy in certain terminology tooling implementations)
- Move `getTerminologyComponentId` to `IComponent` interface
- It is now possible to reuse a deleted branch by sending a create request with the same parent and name. Under the hood the server will recreate a completely new empty branch and override the existing Branch document (NOTE: the content that was available on the deleted branch is still accessible using low-level APIs).