### PR TITLE
SO-2959: Properly prevent deletion of released components

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.api.rest.tests/src/com/b2international/snowowl/snomed/api/rest/components/SnomedRelationshipApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest.tests/src/com/b2international/snowowl/snomed/api/rest/components/SnomedRelationshipApiTest.java
@@ -64,7 +64,7 @@ import com.google.common.collect.Iterables;
  */
 public class SnomedRelationshipApiTest extends AbstractSnomedApiTest {
 
-	private static final String ROOT_ISA_RELATIONSHIP_ID = "1019504021";
+	private static final String RELEASED_ISA_RELATIONSHIP_ID = "1019504021";
 
 	@Test
 	public void createRelationshipNonExistentBranch() {
@@ -444,7 +444,7 @@ public class SnomedRelationshipApiTest extends AbstractSnomedApiTest {
 		
 		String relationshipId = createNewRelationship(branchPath);
 		
-		getComponent(branchPath, SnomedComponentType.RELATIONSHIP, ROOT_ISA_RELATIONSHIP_ID)
+		getComponent(branchPath, SnomedComponentType.RELATIONSHIP, RELEASED_ISA_RELATIONSHIP_ID)
 			.statusCode(200)
 			.body("released", equalTo(true));
 		
@@ -455,7 +455,7 @@ public class SnomedRelationshipApiTest extends AbstractSnomedApiTest {
 		final BulkRequestBuilder<TransactionContext> bulk = BulkRequest.create();
 		
 		bulk.add(SnomedRequests.prepareDeleteRelationship(relationshipId));
-		bulk.add(SnomedRequests.prepareDeleteRelationship(ROOT_ISA_RELATIONSHIP_ID));
+		bulk.add(SnomedRequests.prepareDeleteRelationship(RELEASED_ISA_RELATIONSHIP_ID));
 
 		SnomedRequests.prepareCommit()
 			.setBody(bulk)

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDeletionPlan.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDeletionPlan.java
@@ -25,8 +25,8 @@ import java.util.TreeSet;
 import org.eclipse.emf.cdo.CDOObject;
 
 import com.b2international.snowowl.datastore.utils.ComponentUtils2;
-import com.b2international.snowowl.snomed.Description;
-import com.google.common.collect.Sets;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Iterables;
 
 /**
  * A DTO about the projected outcome of a delete operation in SNOMED CT.
@@ -35,9 +35,6 @@ public class SnomedDeletionPlan {
 
 	private final List<String> rejectionReasons = new ArrayList<String>();
 	
-	//	deleting concepts that are member of description type refset may affect concept descriptions.
-	private Collection<Description> descriptionsToUpdate = Sets.newHashSet();
-
 	// keep deletedItems sorted by type for nicer display to the user
 	private final Set<CDOObject> deletedItems = new TreeSet<CDOObject>(ComponentUtils2.CDO_OBJECT_COMPARATOR);
 	
@@ -45,13 +42,14 @@ public class SnomedDeletionPlan {
 	public List<String> getRejectionReasons() {
 		return rejectionReasons;
 	}
+	
 	public void addRejectionReason(final String rejectionReason) {
 		rejectionReasons.add(rejectionReason);
 	}
 
 	/** @return true if the requested plan cannot be executed because a concept or a relationship cannot be deleted */
 	public boolean isRejected() {
-		return rejectionReasons.size() > 0 || isEmpty();
+		return rejectionReasons.size() > 0;
 	}
 
 	/** @return true if there are any concepts or relationships in the delete plan */
@@ -84,11 +82,8 @@ public class SnomedDeletionPlan {
 		deletedItems.addAll(items);
 	}
 	
-	public Collection<Description> getDirtyDescriptions() {
-		return Collections.unmodifiableCollection(descriptionsToUpdate);
-	}
-	
-	public void addDirtyDescription(Description... descriptions) {
-		descriptionsToUpdate.addAll(Sets.newHashSet(descriptions));
+	@Override
+	public String toString() {
+		return rejectionReasons.size() < 2 ? Iterables.getFirst(rejectionReasons, "") : Joiner.on(", ").join(rejectionReasons);
 	}
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDeletionPlan.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDeletionPlan.java
@@ -26,7 +26,6 @@ import org.eclipse.emf.cdo.CDOObject;
 
 import com.b2international.snowowl.datastore.utils.ComponentUtils2;
 import com.google.common.base.Joiner;
-import com.google.common.collect.Iterables;
 
 /**
  * A DTO about the projected outcome of a delete operation in SNOMED CT.
@@ -84,6 +83,6 @@ public class SnomedDeletionPlan {
 	
 	@Override
 	public String toString() {
-		return rejectionReasons.size() < 2 ? Iterables.getFirst(rejectionReasons, "") : Joiner.on(", ").join(rejectionReasons);
+		return Joiner.on(", ").join(rejectionReasons);
 	}
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDeletionPlanMessages.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDeletionPlanMessages.java
@@ -24,7 +24,7 @@ public final class SnomedDeletionPlanMessages {
 
 	public static final String COMPONENT_IS_RELEASED_MESSAGE = "The %s '%s' has been released, and cannot be deleted.";
 	
-	public static final String UNABLE_TO_DELETE_CONCEPT_MESSAGE = "Cannot delete concept: '%s'.";
+	public static final String UNABLE_TO_DELETE_CONCEPT_DUE_TO_RELEASED_INBOUND_RSHIP_MESSAGE = "Cannot delete concept: '%s' because it has a released inbound relationship: '%s'.";
 	
 	public static final String UNABLE_TO_DELETE_DESCRIPTION_TYPE_CONCEPT_MESSAGE = "Cannot delete concept: '%s' because it is used as a description type.";
 	

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDeletionPlanMessages.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDeletionPlanMessages.java
@@ -26,11 +26,11 @@ public final class SnomedDeletionPlanMessages {
 	
 	public static final String UNABLE_TO_DELETE_CONCEPT_MESSAGE = "Cannot delete concept: '%s'.";
 	
+	public static final String UNABLE_TO_DELETE_DESCRIPTION_TYPE_CONCEPT_MESSAGE = "Cannot delete concept: '%s' because it is used as a description type.";
+	
 	public static final String UNABLE_TO_DELETE_CONCEPT_DUE_TO_ISA_RSHIP_MESSAGE = "Concept '%s' would be deleted when the last active 'Is a' relationship is deleted.";
 	
 	public static final String UNABLE_TO_DELETE_RELATIONSHIP_MESSAGE = "Cannot relationship concept: '%s'.";
-	
-	public static final String UNABLE_TO_DELETE_ONLY_FSN_DESCRIPTION_MESSAGE = "Cannot delete a description if it is the only fully specified name of a concept.";
 	
 	public static final String UNABLE_TO_DELETE_REFERENCE_SET_MESSAGE = "Cannot delete reference set: '%s'.";
 	

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedEditingContext.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedEditingContext.java
@@ -784,6 +784,9 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 	@Override
 	public void preCommit() {
 		
+		
+		if (deletionPlan.isRejected()) throw new ConflictException(deletionPlan.toString());
+		
 		if (!deletionPlan.isRejected() && !deletionPlan.isEmpty()) {
 			
 			final Set<String> deletedIds = deletionPlan.getDeletedItems()
@@ -799,7 +802,7 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 			}
 					
 			delete();
-		}
+		} 
 		
 		/*
 		 * Ensure that all new components (concepts, descriptions and relationships)
@@ -902,7 +905,6 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 	 * For the sake of acceptable execution speed, the <code>remove(int index)</code> function is used
 	 * instead of the <code>remove(object)</code>. This way, the CDO will not iterate through the large
 	 * number of data in the resources. 
-	 * @param deletionPlan the deletionplan containing all the objects to delete
 	 */
 	private void delete() {
 		// organize elements regarding their index
@@ -962,7 +964,7 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 				refSetEditingContext.getContents().remove(index);
 			}
 			else if (eObject instanceof SnomedRefSetMember) {
-				// get the refset and remove the member from it's list
+				// get the refset and remove the member from its list
 				SnomedRefSetMember member = (SnomedRefSetMember) eObject;	
 				SnomedRefSet refSet = member.getRefSet();
 	

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedEditingContext.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedEditingContext.java
@@ -120,7 +120,7 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 	private String nameSpace;
 	private boolean uniquenessCheckEnabled = true;
 	private Set<String> newComponentIds = Collections.synchronizedSet(Sets.<String>newHashSet());
-	private final SnomedDeletionPlan deletionPlan = new SnomedDeletionPlan();
+	private SnomedDeletionPlan deletionPlan = new SnomedDeletionPlan();
 
 	/**
 	 * Creates a new SNOMED CT core components editing context on the specified branch of the SNOMED CT repository.
@@ -784,11 +784,9 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 	@Override
 	public void preCommit() {
 		
-		
-		if (deletionPlan.isRejected()) throw new ConflictException(deletionPlan.toString());
-		
-		if (!deletionPlan.isRejected() && !deletionPlan.isEmpty()) {
-			
+		if (deletionPlan.isRejected()) {
+			throw new ConflictException(deletionPlan.toString());
+		} else if (!deletionPlan.isEmpty()) {
 			final Set<String> deletedIds = deletionPlan.getDeletedItems()
 				.stream()
 				.filter(FSMUtil::isTransient)
@@ -802,6 +800,7 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 			}
 					
 			delete();
+			deletionPlan = new SnomedDeletionPlan();
 		} 
 		
 		/*

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedEditingContext.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedEditingContext.java
@@ -542,66 +542,25 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 	@Override
 	public void delete(EObject object, boolean force) {
 		if (object instanceof Concept) {
-			delete((Concept) object, force);
+			tryDelete((Concept) object, force);
 		} else if (object instanceof Description) {
-			delete((Description) object, force);
+			tryDelete((Description) object, force);
 		} else if (object instanceof Relationship) {
-			delete((Relationship) object, force);
+			tryDelete((Relationship) object, force);
 		} else if (object instanceof SnomedRefSet) {
-			delete((SnomedRefSet) object, force);
+			tryDelete((SnomedRefSet) object, force);
 		} else if (object instanceof SnomedRefSetMember) {
-			delete((SnomedRefSetMember) object, force);
+			tryDelete((SnomedRefSetMember) object, force);
 		} else {
 			super.delete(object, force);
 		}
-	}
-	
-	private void delete(Concept concept, boolean force) {
-		
-		canDelete(concept, force);
-		
-		if (deletionPlan.isRejected()) {
-			throw new ConflictException(deletionPlan.toString());
-		}
-	}
-
-	private void delete(Description description, boolean force) {
-		
-		canDelete(description, force);
-		
-		if (deletionPlan.isRejected()) {
-			throw new ConflictException(deletionPlan.toString());
-		}
-	}
-
-	private void delete(Relationship relationship, boolean force) {
-		
-		canDelete(relationship, force);
-		
-		if (deletionPlan.isRejected()) {
-			throw new ConflictException(deletionPlan.toString());
-		}
-	}
-
-	private void delete(SnomedRefSet refSet, boolean force) {
-		
-		canDelete(refSet, force);
 		
 		if (deletionPlan.isRejected()) {
 			throw new ConflictException(deletionPlan.toString());
 		}
 	}
 	
-	private void delete(SnomedRefSetMember member, boolean force) {
-		
-		canDelete(member, force);
-		
-		if (deletionPlan.isRejected()) {
-			throw new ConflictException(deletionPlan.toString());
-		}
-	}
-	
-	private void canDelete(Concept concept, boolean force) {
+	private void tryDelete(Concept concept, boolean force) {
 		
 		// Check if concept is already released, and this is not a forced delete
 		if (concept.isReleased() && !force) {
@@ -609,35 +568,32 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 			return;
 		}
 		
-		// Also check inbound relationships, as these could have been released with different effective times
 		for (Relationship relationship : getInboundRelationships(concept.getId())) {
+			
 			if (relationship != null) {
 				
-				canDelete(relationship, force);
+				tryDelete(relationship, force);
 				
 				if (deletionPlan.isRejected()) {
 					deletionPlan.addRejectionReason(String.format(UNABLE_TO_DELETE_CONCEPT_MESSAGE, toString(concept)));
 					return;
 				}
+				
 			}
 		}
 		
-		/*
-		 * All other components below should become released when the concept is first released, which was handled 
-		 * above, so don't exit early via a rejection check.
-		 */
-		
 		for (Description description : concept.getDescriptions()) {
-			canDelete(description, force);
+			tryDelete(description, force);
 		}
 		
 		for (Relationship outboundRelationship : concept.getOutboundRelationships()) {
-			canDelete(outboundRelationship, force);
+			tryDelete(outboundRelationship, force);
 		}
 		
 		SnomedRefSet refSet = lookupIfExists(concept.getId(), SnomedRefSet.class);
+		
 		if (refSet != null) {
-			canDelete(refSet, force);
+			tryDelete(refSet, force);
 		}
 		
 		List<SnomedRefSetMember> referringMembers = refSetEditingContext.getReferringMembers(concept);
@@ -648,12 +604,12 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 		if (isDescriptionType.isPresent()) {
 			
 			boolean hasRelatedDescriptions = SnomedRequests.prepareSearchDescription()
-				.setLimit(1)
+				.setLimit(0)
 				.filterByType(concept.getId())
 				.build(SnomedDatastoreActivator.REPOSITORY_UUID, getBranch())
 				.execute(ApplicationContext.getServiceForClass(IEventBus.class))
 				.getSync()
-				.getItems().size() > 0;
+				.getTotal() > 0;
 			
 			if (hasRelatedDescriptions) {
 				deletionPlan.addRejectionReason(String.format(UNABLE_TO_DELETE_DESCRIPTION_TYPE_CONCEPT_MESSAGE, toString(concept)));
@@ -662,11 +618,14 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 			
 		}
 		
-		deletionPlan.markForDeletion(referringMembers);
+		for (SnomedRefSetMember member: referringMembers) {
+			tryDelete(member, force);
+		}
+		
 		deletionPlan.markForDeletion(concept);
 	}
 
-	private void canDelete(Description description, boolean force) {
+	private void tryDelete(Description description, boolean force) {
 			
 		// Check if description is already released, and this is not a forced delete
 		if (description.isReleased() && !force) {
@@ -674,19 +633,24 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 			return;
 		}
 		
-		deletionPlan.markForDeletion(refSetEditingContext.getReferringMembers(description));
+		for (SnomedRefSetMember member : refSetEditingContext.getReferringMembers(description)) {
+			tryDelete(member, force);
+		}
+		
 		deletionPlan.markForDeletion(description);
 	}
 
-	private void canDelete(Relationship relationship, boolean force) {
+	private void tryDelete(Relationship relationship, boolean force) {
 		
-		// Check if description is already released, and this is not a forced delete
+		// Check if relationship is already released, and this is not a forced delete
 		if (relationship.isReleased() && !force) {
 			deletionPlan.addRejectionReason(String.format(COMPONENT_IS_RELEASED_MESSAGE, "relationship", toString(relationship)));
 			return;
 		}
 		
-		deletionPlan.markForDeletion(refSetEditingContext.getReferringMembers(relationship));
+		for (SnomedRefSetMember member : refSetEditingContext.getReferringMembers(relationship)) {
+			tryDelete(member, force);
+		}
 		
 		if (relationship.getSource() != null) {
 			deletionPlan.markForDeletion(relationship);
@@ -694,11 +658,11 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 		
 	}
 
-	private void canDelete(SnomedRefSet refSet, boolean force) {
+	private void tryDelete(SnomedRefSet refSet, boolean force) {
 		
 		for (SnomedRefSetMember member : refSetEditingContext.getMembers(refSet)) {
 			
-			canDelete(member, force);
+			tryDelete(member, force);
 			
 			if (deletionPlan.isRejected()) {
 				deletionPlan.addRejectionReason(String.format(UNABLE_TO_DELETE_REFERENCE_SET_MESSAGE, refSet.getIdentifierId()));
@@ -710,7 +674,7 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 		deletionPlan.markForDeletion(refSet);
 	}
 	
-	private void canDelete(SnomedRefSetMember member, boolean force) {
+	private void tryDelete(SnomedRefSetMember member, boolean force) {
 			
 		if (member.isReleased() && !force) {
 			deletionPlan.addRejectionReason(String.format(COMPONENT_IS_RELEASED_MESSAGE, "member", member.getUuid()));

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedEditingContext.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedEditingContext.java
@@ -29,7 +29,7 @@ import static com.b2international.snowowl.snomed.SnomedConstants.Concepts.STATED
 import static com.b2international.snowowl.snomed.SnomedConstants.Concepts.SYNONYM;
 import static com.b2international.snowowl.snomed.datastore.SnomedDeletionPlanMessages.COMPONENT_IS_RELEASED_MESSAGE;
 import static com.b2international.snowowl.snomed.datastore.SnomedDeletionPlanMessages.UNABLE_TO_DELETE_CONCEPT_MESSAGE;
-import static com.b2international.snowowl.snomed.datastore.SnomedDeletionPlanMessages.UNABLE_TO_DELETE_ONLY_FSN_DESCRIPTION_MESSAGE;
+import static com.b2international.snowowl.snomed.datastore.SnomedDeletionPlanMessages.UNABLE_TO_DELETE_DESCRIPTION_TYPE_CONCEPT_MESSAGE;
 import static com.b2international.snowowl.snomed.datastore.SnomedDeletionPlanMessages.UNABLE_TO_DELETE_REFERENCE_SET_MESSAGE;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Collections.emptyList;
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.Nullable;
@@ -58,7 +59,6 @@ import com.b2international.index.revision.Revision;
 import com.b2international.snowowl.core.ApplicationContext;
 import com.b2international.snowowl.core.api.IBranchPath;
 import com.b2international.snowowl.core.api.ILookupService;
-import com.b2international.snowowl.core.api.SnowowlRuntimeException;
 import com.b2international.snowowl.core.api.SnowowlServiceException;
 import com.b2international.snowowl.core.domain.IComponent;
 import com.b2international.snowowl.core.exceptions.ComponentNotFoundException;
@@ -113,7 +113,7 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 	private String nameSpace;
 	private boolean uniquenessCheckEnabled = true;
 	private Set<String> newComponentIds = Collections.synchronizedSet(Sets.<String>newHashSet());
-	private SnomedDeletionPlan deletionPlan;
+	private final SnomedDeletionPlan deletionPlan = new SnomedDeletionPlan();
 
 	/**
 	 * Creates a new SNOMED CT core components editing context on the specified branch of the SNOMED CT repository.
@@ -557,58 +557,67 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 	}
 	
 	private void delete(Concept concept, boolean force) {
-		deletionPlan = canDelete(concept, deletionPlan, force);
-		if(deletionPlan.isRejected()) {
-			throw new ConflictException(deletionPlan.getRejectionReasons().toString());
+		
+		canDelete(concept, force);
+		
+		if (deletionPlan.isRejected()) {
+			throw new ConflictException(deletionPlan.toString());
 		}
 	}
 
 	private void delete(Description description, boolean force) {
-		deletionPlan = canDelete(description, deletionPlan, force);
-		if(deletionPlan.isRejected()) {
-			throw new ConflictException(deletionPlan.getRejectionReasons().toString());
+		
+		canDelete(description, force);
+		
+		if (deletionPlan.isRejected()) {
+			throw new ConflictException(deletionPlan.toString());
 		}
 	}
 
 	private void delete(Relationship relationship, boolean force) {
-		deletionPlan = canDelete(relationship, deletionPlan, force);
-		if(deletionPlan.isRejected()) {
-			throw new ConflictException(deletionPlan.getRejectionReasons().toString());
+		
+		canDelete(relationship, force);
+		
+		if (deletionPlan.isRejected()) {
+			throw new ConflictException(deletionPlan.toString());
 		}
 	}
 
 	private void delete(SnomedRefSet refSet, boolean force) {
-		deletionPlan = canDelete(refSet, deletionPlan, force);
+		
+		canDelete(refSet, force);
+		
 		if (deletionPlan.isRejected()) {
-			throw new ConflictException(deletionPlan.getRejectionReasons().toString());
+			throw new ConflictException(deletionPlan.toString());
 		}
 	}
 	
 	private void delete(SnomedRefSetMember member, boolean force) {
-		deletionPlan = canDelete(member, deletionPlan, force);
+		
+		canDelete(member, force);
+		
 		if (deletionPlan.isRejected()) {
-			throw new ConflictException(deletionPlan.getRejectionReasons().toString());
+			throw new ConflictException(deletionPlan.toString());
 		}
 	}
 	
-	public SnomedDeletionPlan canDelete(Concept concept, SnomedDeletionPlan deletionPlan, boolean force) {
-		if (deletionPlan == null) {
-			deletionPlan = new SnomedDeletionPlan();
-		}
+	private void canDelete(Concept concept, boolean force) {
 		
 		// Check if concept is already released, and this is not a forced delete
 		if (concept.isReleased() && !force) {
 			deletionPlan.addRejectionReason(String.format(COMPONENT_IS_RELEASED_MESSAGE, "concept", toString(concept)));
-			return deletionPlan;
+			return;
 		}
 		
 		// Also check inbound relationships, as these could have been released with different effective times
 		for (Relationship relationship : getInboundRelationships(concept.getId())) {
 			if (relationship != null) {
-				deletionPlan = canDelete(relationship, deletionPlan, force);
-				if (deletionPlan.getRejectionReasons().size() > 0) {
+				
+				canDelete(relationship, force);
+				
+				if (deletionPlan.isRejected()) {
 					deletionPlan.addRejectionReason(String.format(UNABLE_TO_DELETE_CONCEPT_MESSAGE, toString(concept)));
-					return deletionPlan;
+					return;
 				}
 			}
 		}
@@ -619,126 +628,96 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 		 */
 		
 		for (Description description : concept.getDescriptions()) {
-			deletionPlan = canDelete(description, deletionPlan, force);
+			canDelete(description, force);
 		}
 		
 		for (Relationship outboundRelationship : concept.getOutboundRelationships()) {
-			deletionPlan = canDelete(outboundRelationship, deletionPlan, force);
+			canDelete(outboundRelationship, force);
 		}
 		
 		SnomedRefSet refSet = lookupIfExists(concept.getId(), SnomedRefSet.class);
 		if (refSet != null) {
-			deletionPlan = canDelete(refSet, deletionPlan, force);
+			canDelete(refSet, force);
 		}
 		
 		List<SnomedRefSetMember> referringMembers = refSetEditingContext.getReferringMembers(concept);
 
-		// If this concept is a member of the description format reference set, descriptions of this type have to be updated
-		for (SnomedRefSetMember member : referringMembers) {
-			if (REFSET_DESCRIPTION_TYPE.equals(member.getRefSetIdentifierId())) {
-				for (SnomedDescriptionIndexEntry entry : getRelatedDescriptions(member.getReferencedComponentId())) {
-					final Description description = lookup(entry.getId(), Description.class);
-					if (null == description) {
-						throw new SnowowlRuntimeException("Description does not exist in store with ID: " + entry.getId());
-					} else {
-						deletionPlan.addDirtyDescription(description);
-					}
-				}
+		Optional<SnomedRefSetMember> isDescriptionType = referringMembers.stream()
+				.filter(member -> member.isActive() && member.getRefSetIdentifierId().equals(REFSET_DESCRIPTION_TYPE)).findAny();
+		
+		if (isDescriptionType.isPresent()) {
+			
+			boolean hasRelatedDescriptions = SnomedRequests.prepareSearchDescription()
+				.setLimit(1)
+				.filterByType(concept.getId())
+				.build(SnomedDatastoreActivator.REPOSITORY_UUID, getBranch())
+				.execute(ApplicationContext.getServiceForClass(IEventBus.class))
+				.getSync()
+				.getItems().size() > 0;
+			
+			if (hasRelatedDescriptions) {
+				deletionPlan.addRejectionReason(String.format(UNABLE_TO_DELETE_DESCRIPTION_TYPE_CONCEPT_MESSAGE, toString(concept)));
+				return;
 			}
+			
 		}
-
+		
 		deletionPlan.markForDeletion(referringMembers);
 		deletionPlan.markForDeletion(concept);
-		return deletionPlan;
 	}
 
-	public SnomedDeletionPlan canDelete(Description description, SnomedDeletionPlan deletionPlan, boolean force) {
-		// If the description is the target of the deletion, check validity
-		if (deletionPlan == null) {
-			deletionPlan = new SnomedDeletionPlan();
+	private void canDelete(Description description, boolean force) {
 			
-			// Check if description is already released, and this is not a forced delete
-			if (description.isReleased() && !force) {
-				deletionPlan.addRejectionReason(String.format(COMPONENT_IS_RELEASED_MESSAGE, "description", toString(description)));
-				return deletionPlan;
-			}
-			
-			// not the only fully specified name
-			if (FULLY_SPECIFIED_NAME.equals(description.getType().getId())) {
-				boolean hasOtherFullySpecifiedName = false;
-				final List<Description> otherDescriptions = description.getConcept().getDescriptions();
-				for (Description otherDescription: otherDescriptions) {
-					// another fully specified name exists that is not this description
-					if (FULLY_SPECIFIED_NAME.equals(otherDescription.getType().getId()) && description != otherDescription) {
-						hasOtherFullySpecifiedName = true;
-						break;
-					}
-				}
-				
-				if (!hasOtherFullySpecifiedName) {
-					deletionPlan.addRejectionReason(UNABLE_TO_DELETE_ONLY_FSN_DESCRIPTION_MESSAGE);
-					return deletionPlan;
-				}
-			}
-		} 
+		// Check if description is already released, and this is not a forced delete
+		if (description.isReleased() && !force) {
+			deletionPlan.addRejectionReason(String.format(COMPONENT_IS_RELEASED_MESSAGE, "description", toString(description)));
+			return;
+		}
 		
 		deletionPlan.markForDeletion(refSetEditingContext.getReferringMembers(description));
 		deletionPlan.markForDeletion(description);
-		return deletionPlan;
 	}
 
-	public SnomedDeletionPlan canDelete(Relationship relationship, SnomedDeletionPlan deletionPlan, boolean force) {
-		// If the relationship is the target of the deletion, check validity
-		if (deletionPlan == null) {
-			deletionPlan = new SnomedDeletionPlan();
+	private void canDelete(Relationship relationship, boolean force) {
 		
-			// Check if description is already released, and this is not a forced delete
-			if (relationship.isReleased() && !force) {
-				deletionPlan.addRejectionReason(String.format(COMPONENT_IS_RELEASED_MESSAGE, "relationship", toString(relationship)));
-				return deletionPlan;
-			}
+		// Check if description is already released, and this is not a forced delete
+		if (relationship.isReleased() && !force) {
+			deletionPlan.addRejectionReason(String.format(COMPONENT_IS_RELEASED_MESSAGE, "relationship", toString(relationship)));
+			return;
 		}
 		
-		deletionPlan.markForDeletion(refSetEditingContext.getReferringMembers(relationship));		
+		deletionPlan.markForDeletion(refSetEditingContext.getReferringMembers(relationship));
+		
 		if (relationship.getSource() != null) {
 			deletionPlan.markForDeletion(relationship);
 		}
-		return deletionPlan;
+		
 	}
 
-	public SnomedDeletionPlan canDelete(SnomedRefSet refSet, SnomedDeletionPlan deletionPlan, boolean force) {
-		// If the reference set is the target of the deletion, check validity for each member
-		if (deletionPlan == null) {
-			deletionPlan = new SnomedDeletionPlan();
+	private void canDelete(SnomedRefSet refSet, boolean force) {
+		
+		for (SnomedRefSetMember member : refSetEditingContext.getMembers(refSet)) {
 			
-			for (SnomedRefSetMember member : refSetEditingContext.getMembers(refSet)) {
-				deletionPlan = canDelete(member, deletionPlan, force);
-				if (deletionPlan.isRejected()) {
-					deletionPlan.addRejectionReason(String.format(UNABLE_TO_DELETE_REFERENCE_SET_MESSAGE, refSet.getIdentifierId()));
-					return deletionPlan;
-				}
+			canDelete(member, force);
+			
+			if (deletionPlan.isRejected()) {
+				deletionPlan.addRejectionReason(String.format(UNABLE_TO_DELETE_REFERENCE_SET_MESSAGE, refSet.getIdentifierId()));
+				return;
 			}
-		} else {
-			// Otherwise members can be deleted without individually checking each one
-			deletionPlan.markForDeletion(refSetEditingContext.getMembers(refSet));
+			
 		}
 		
 		deletionPlan.markForDeletion(refSet);
-		return deletionPlan;
 	}
 	
-	public SnomedDeletionPlan canDelete(SnomedRefSetMember member, SnomedDeletionPlan deletionPlan, boolean force) {
-		if (deletionPlan == null) {
-			deletionPlan = new SnomedDeletionPlan();
+	private void canDelete(SnomedRefSetMember member, boolean force) {
 			
-			if (member.isReleased() && !force) {
-				deletionPlan.addRejectionReason(String.format(COMPONENT_IS_RELEASED_MESSAGE, "member", member.getUuid()));
-				return deletionPlan;
-			}
+		if (member.isReleased() && !force) {
+			deletionPlan.addRejectionReason(String.format(COMPONENT_IS_RELEASED_MESSAGE, "member", member.getUuid()));
+			return;
 		}
 		
 		deletionPlan.markForDeletion(member);
-		return deletionPlan;
 	}
 
 	/**
@@ -748,7 +727,7 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 	 * number of data in the resources. 
 	 * @param deletionPlan the deletionplan containing all the objects to delete
 	 */
-	public void delete(SnomedDeletionPlan deletionPlan) {
+	private void delete() {
 		// organize elements regarding their index
 		final Multimap<Integer, EObject> itemMap = ArrayListMultimap.create();
 		
@@ -976,9 +955,11 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 	
 	@Override
 	public void preCommit() {
-		if (deletionPlan != null) {
-			delete(deletionPlan);
+		
+		if (!deletionPlan.isRejected() && !deletionPlan.isEmpty()) {
+			delete();
 		}
+		
 		/*
 		 * Ensure that all new components (concepts, descriptions and relationships)
 		 * have unique IDs both among themselves and the components already persisted in


### PR DESCRIPTION
- always use one SnomedDeletionPlan per SnomedEditingContext
- allow deleting the last FSN of a concept
- simplified validation of description type concepts
- added unit tests for concepts, relationships and descriptions
