### PR TITLE
Improve RF2 export request performance

### DIFF
--- a/commons/com.b2international.index.api/src/com/b2international/index/revision/RevisionIndex.java
+++ b/commons/com.b2international.index.api/src/com/b2international/index/revision/RevisionIndex.java
@@ -15,10 +15,6 @@
  */
 package com.b2international.index.revision;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
-import java.util.Arrays;
-
 import com.b2international.index.admin.Administrable;
 import com.b2international.index.admin.IndexAdmin;
 import com.google.common.base.Strings;
@@ -132,13 +128,14 @@ public interface RevisionIndex extends Administrable<IndexAdmin> {
 	 * @return
 	 * @throws IllegalArgumentException - if the given path cannot be parsed as a revision range path expression
 	 */
-	static String[] getRevisionRangePaths(String revisionRangePath) {
-		final String[] branches = revisionRangePath.split("\\.\\.\\.");
-		checkArgument(branches.length == 2 && !Strings.isNullOrEmpty(branches[0]) && !Strings.isNullOrEmpty(branches[1]), 
-				"Diff notation ('%s') requires two full branch paths. Got %s.", RevisionIndex.REV_RANGE, Arrays.toString(branches));
-		return branches;
+	static String[] getRevisionRangePaths(final String revisionRangePath) {
+		if (!isRevRangePath(revisionRangePath)) {
+			throw new IllegalArgumentException(
+					String.format("Diff notation ('%s') requires two full branch paths. Got %s.", RevisionIndex.REV_RANGE, revisionRangePath));
+		}
+		return revisionRangePath.split("\\.\\.\\.");
 	}
-
+	
 	/**
 	 * Returns <code>true</code> if the given branch path can evaluate to its base segments.
 	 * @param branchPath
@@ -154,7 +151,11 @@ public interface RevisionIndex extends Administrable<IndexAdmin> {
 	 * @return
 	 */
 	static boolean isRevRangePath(String revisionRangePath) {
-		return revisionRangePath.contains(REV_RANGE);
+		if (revisionRangePath.contains(REV_RANGE)) {
+			String[] branches = revisionRangePath.split("\\.\\.\\.");
+			return branches.length == 2 && !Strings.isNullOrEmpty(branches[0]) && !Strings.isNullOrEmpty(branches[1]);
+		}
+		return false;
 	}
 
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/date/DateFormats.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/date/DateFormats.java
@@ -56,5 +56,10 @@ public abstract class DateFormats {
 	 * The most detailed time format which includes time up to millisecond resolution. Value: {@value}
 	 */
 	public static final String FULL = "yyyyMMddHHmmssSSS";
+	
+	/**
+	 * ISO-8601 compliant date format with the assumption of zero UTC offset
+	 */
+	public static final String ISO_8601_UTC = "yyyyMMdd'T'HHmmss'Z'";
 
 }


### PR DESCRIPTION
- precompute all necessary language codes for each branch path
- precompute all version branches and revision ranges
- use UTC timezone, ISO 8601 format and add current hour in the
effective date of the release archive