### PR TITLE
SO-3262: Fix various refset import related issues

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.datastore.server/src/com/b2international/snowowl/datastore/server/snomed/ImportOnlySnomedTransactionContext.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.server/src/com/b2international/snowowl/datastore/server/snomed/ImportOnlySnomedTransactionContext.java
@@ -36,6 +36,7 @@ import com.b2international.snowowl.eventbus.IEventBus;
 import com.b2international.snowowl.snomed.datastore.SnomedDatastoreActivator;
 import com.b2international.snowowl.snomed.datastore.SnomedEditingContext;
 import com.b2international.snowowl.snomed.datastore.config.SnomedCoreConfiguration;
+import com.b2international.snowowl.snomed.datastore.request.Synonyms;
 import com.google.inject.Provider;
 
 /**
@@ -47,11 +48,13 @@ public class ImportOnlySnomedTransactionContext implements TransactionContext {
 	private final SnomedEditingContext editingContext;
 	private final RevisionSearcher searcher;
 	private Branch branch;
+	private final Synonyms synonyms;
 
 	public ImportOnlySnomedTransactionContext(final String userId, final RevisionSearcher searcher, final SnomedEditingContext editingContext) {
 		this.userId = userId;
 		this.searcher = searcher;
 		this.editingContext = editingContext;
+		this.synonyms = new Synonyms(this);
 	}
 
 	@Override
@@ -99,6 +102,8 @@ public class ImportOnlySnomedTransactionContext implements TransactionContext {
 			return type.cast(searcher);
 		} else if (type.isAssignableFrom(SnomedEditingContext.class)) {
 			return type.cast(editingContext);
+		} else if (type.isAssignableFrom(Synonyms.class)) {
+			return type.cast(synonyms);
 		}
 		return ApplicationContext.getInstance().getServiceChecked(type);
 	}

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/refset/automap/CsvVariableFieldCountParser.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/refset/automap/CsvVariableFieldCountParser.java
@@ -159,7 +159,7 @@ public class CsvVariableFieldCountParser implements ITableParser {
 		 * @see org.ihtsdo.lookup.parser.RecordLexerCallback#handleField(int)
 		 */
 		public void handleField(final int fieldCount, final StringBuilder field) {
-			line.add(field.toString());
+			line.add(field.toString().trim());
 		}
 
 		/*

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedEditingContext.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedEditingContext.java
@@ -23,6 +23,7 @@ import static com.b2international.snowowl.snomed.SnomedConstants.Concepts.IS_A;
 import static com.b2international.snowowl.snomed.SnomedConstants.Concepts.PRIMITIVE;
 import static com.b2international.snowowl.snomed.SnomedConstants.Concepts.REFSET_DESCRIPTION_TYPE;
 import static com.b2international.snowowl.snomed.SnomedConstants.Concepts.STATED_RELATIONSHIP;
+import static com.b2international.snowowl.snomed.SnomedConstants.Concepts.INFERRED_RELATIONSHIP;
 import static com.b2international.snowowl.snomed.SnomedConstants.Concepts.SYNONYM;
 import static com.b2international.snowowl.snomed.datastore.SnomedDeletionPlanMessages.COMPONENT_IS_RELEASED_MESSAGE;
 import static com.b2international.snowowl.snomed.datastore.SnomedDeletionPlanMessages.UNABLE_TO_DELETE_CONCEPT_DUE_TO_RELEASED_INBOUND_RSHIP_MESSAGE;
@@ -322,12 +323,19 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 		Description description = buildDefaultDescription(fullySpecifiedName, FULLY_SPECIFIED_NAME);
 		description.setConcept(concept);
 		
-		// add 'Is a' relationship to parent if specified
-		buildDefaultIsARelationship(parentConcept, concept);
+		// add 'Is a' relationships to parent if specified
+		buildDefaultIsARelationship(parentConcept, concept, STATED_RELATIONSHIP);
+		buildDefaultIsARelationship(parentConcept, concept, INFERRED_RELATIONSHIP);
 		
 		return concept;
 	}
 	
+	private void buildDefaultIsARelationship(Concept parentConcept, Concept concept, String charTypeId) {
+		Relationship relationship = buildDefaultRelationship(concept, findConceptById(IS_A), 
+				parentConcept, findConceptById(charTypeId));
+		relationship.setModule(concept.getModule());
+	}
+
 	
 	/**Returns with the currently used language type reference set, falls back to an existing language if the configured identifier can not be resolved.*/
 	public SnomedStructuralRefSet getLanguageRefSet(String languageReferenceSetId) {
@@ -743,16 +751,6 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 	
 	public static SnomedConfiguration getSnomedConfiguration() {
 		return ApplicationContext.getInstance().getService(SnomedConfiguration.class);
-	}
-	
-	private Relationship buildDefaultIsARelationship(Concept parentConcept, Concept concept) {
-		
-		Relationship relationship = buildDefaultRelationship(concept, findConceptById(IS_A), 
-				parentConcept, findConceptById(STATED_RELATIONSHIP));
-		
-		relationship.setModule(concept.getModule());
-		
-		return relationship;
 	}
 	
 	@Override

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptCreateRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptCreateRequest.java
@@ -140,9 +140,10 @@ public final class SnomedConceptCreateRequest extends BaseSnomedComponentCreateR
 	}
 
 	private void convertDescriptions(TransactionContext context, final String conceptId) {
+		TransactionContext newContext = context.inject().bind(Synonyms.class, new Synonyms(context)).build();
 		final Set<String> requiredDescriptionTypes = newHashSet(Concepts.FULLY_SPECIFIED_NAME, Concepts.REFSET_DESCRIPTION_ACCEPTABILITY_PREFERRED);
 		final Multiset<String> preferredLanguageRefSetIds = HashMultiset.create();
-		final Set<String> synonymAndDescendantIds = context.service(Synonyms.class).get();
+		final Set<String> synonymAndDescendantIds = newContext.service(Synonyms.class).get();
 
 		for (final SnomedDescriptionCreateRequest descriptionRequest : descriptions) {
 

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptCreateRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptCreateRequest.java
@@ -140,10 +140,9 @@ public final class SnomedConceptCreateRequest extends BaseSnomedComponentCreateR
 	}
 
 	private void convertDescriptions(TransactionContext context, final String conceptId) {
-		TransactionContext newContext = context.inject().bind(Synonyms.class, new Synonyms(context)).build();
 		final Set<String> requiredDescriptionTypes = newHashSet(Concepts.FULLY_SPECIFIED_NAME, Concepts.REFSET_DESCRIPTION_ACCEPTABILITY_PREFERRED);
 		final Multiset<String> preferredLanguageRefSetIds = HashMultiset.create();
-		final Set<String> synonymAndDescendantIds = newContext.service(Synonyms.class).get();
+		final Set<String> synonymAndDescendantIds = context.service(Synonyms.class).get();
 
 		for (final SnomedDescriptionCreateRequest descriptionRequest : descriptions) {
 

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/Synonyms.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/Synonyms.java
@@ -28,7 +28,7 @@ import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDoc
  * 
  * @since 6.5
  */
-class Synonyms {
+public final class Synonyms {
 
 	private final BranchContext context;
 	private Set<String> synonyms;

--- a/snomed/com.b2international.snowowl.snomed.importer.rf2/src/com/b2international/snowowl/snomed/importer/rf2/SnomedCompositeImporter.java
+++ b/snomed/com.b2international.snowowl.snomed.importer.rf2/src/com/b2international/snowowl/snomed/importer/rf2/SnomedCompositeImporter.java
@@ -193,6 +193,10 @@ public class SnomedCompositeImporter extends AbstractLoggingImporter {
 		final UncheckedCastFunction<AbstractImportUnit, ComponentImportUnit> castFunction = new UncheckedCastFunction<AbstractImportUnit, ComponentImportUnit>(ComponentImportUnit.class);
 		final List<ComponentImportUnit> units = Lists.newArrayList(Iterables.transform(compositeUnit.getUnits(), castFunction));
 		
+		if (units.size() == 0) {
+			return;
+		}
+		
 		subMonitor.setWorkRemaining(units.size() + 1);
 
 		if (isRefSetImport(units)) {

--- a/snomed/com.b2international.snowowl.snomed.importer.rf2/src/com/b2international/snowowl/snomed/importer/rf2/refset/AbstractSnomedRefSetImporter.java
+++ b/snomed/com.b2international.snowowl.snomed.importer.rf2/src/com/b2international/snowowl/snomed/importer/rf2/refset/AbstractSnomedRefSetImporter.java
@@ -223,6 +223,7 @@ public abstract class AbstractSnomedRefSetImporter<T extends AbstractRefSetRow, 
 	protected abstract M createMember();
 	
 	protected SnomedRefSet getOrCreateRefSet(final String refSetSctId, final String referencedComponentId) {
+		getImportContext().conceptVisited(refSetSctId);
 		
 		SnomedRefSet refSet = Iterables.getOnlyElement(getImportContext().getRefSetLookup().getComponents(Collections.singleton(refSetSctId)), null);
 		


### PR DESCRIPTION
1. Ensure changes are correctly reported at the end of import
2. Remove trailing white spaces from the last column in csv import to
ensure ids are read correctly
3. Fix index out of bounds exception in SnomedCompositeImporter
4. Ensure Synonym service is available in SnomedConceptCreateRequest
5. Make sure new reference set appears in the refset view by creating
both inferred and stated is a relationships to appropriate refset parent
concept on import