### PR TITLE
SO-3300: Fix simple type refset header issues

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/internal/rf2/SnomedRefSetDSVExportClientRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/internal/rf2/SnomedRefSetDSVExportClientRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/dsv/SnomedDSVExportRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/dsv/SnomedDSVExportRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/snomed/com.b2international.snowowl.snomed.exporter.server/src/com/b2international/snowowl/snomed/exporter/server/dsv/MapTypeRefSetDSVExporter.java
+++ b/snomed/com.b2international.snowowl.snomed.exporter.server/src/com/b2international/snowowl/snomed/exporter/server/dsv/MapTypeRefSetDSVExporter.java
@@ -24,16 +24,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.eclipse.net4j.util.om.monitor.OMMonitor;
 
 import com.b2international.commons.FileUtils;
 import com.b2international.commons.StringUtils;
-import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.index.Hits;
 import com.b2international.index.query.Expressions;
 import com.b2international.index.query.Expressions.ExpressionBuilder;
@@ -48,7 +44,6 @@ import com.b2international.snowowl.core.api.SnowowlServiceException;
 import com.b2international.snowowl.datastore.BranchPathUtils;
 import com.b2international.snowowl.eventbus.IEventBus;
 import com.b2international.snowowl.snomed.SnomedConstants.Concepts;
-import com.b2international.snowowl.snomed.core.domain.Acceptability;
 import com.b2international.snowowl.snomed.core.domain.SnomedConcept;
 import com.b2international.snowowl.snomed.core.domain.SnomedCoreComponent;
 import com.b2international.snowowl.snomed.core.domain.SnomedDescription;

--- a/snomed/com.b2international.snowowl.snomed.exporter.server/src/com/b2international/snowowl/snomed/exporter/server/dsv/SnomedSimpleTypeRefSetDSVExporter.java
+++ b/snomed/com.b2international.snowowl.snomed.exporter.server/src/com/b2international/snowowl/snomed/exporter/server/dsv/SnomedSimpleTypeRefSetDSVExporter.java
@@ -76,6 +76,8 @@ import com.google.common.collect.Sets;
 
 public class SnomedSimpleTypeRefSetDSVExporter implements IRefSetDSVExporter {
 
+	private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+
 	private String refSetId;
 	private boolean includeDescriptionId;
 	private boolean includeRelationshipId;
@@ -92,8 +94,6 @@ public class SnomedSimpleTypeRefSetDSVExporter implements IRefSetDSVExporter {
 
 	private List<ExtendedLocale> locales;
 	private String exportPath;
-	
-	private final String lineSeparator;
 
 	/**
 	 * Creates a new instance with the export parameters. Called by the SnomedSimpleTypeRefSetDSVExportServerIndication.
@@ -112,7 +112,6 @@ public class SnomedSimpleTypeRefSetDSVExporter implements IRefSetDSVExporter {
 		this.delimiter = exportSetting.getDelimiter();
 		this.branchPath = BranchPathUtils.createPath(exportSetting.getBranchPath());
 		exportPath = exportSetting.getExportPath();
-		lineSeparator = System.getProperty("line.separator");
 		groupedRelationships = Maps.newTreeMap();
 		groupedOnlyItems = Lists.newArrayList();
 	}
@@ -172,7 +171,7 @@ public class SnomedSimpleTypeRefSetDSVExporter implements IRefSetDSVExporter {
 				}
 			}
 			
-			sb.append(lineSeparator);
+			sb.append(LINE_SEPARATOR);
 			os.writeBytes(sb.toString());
 
 			async.stop();
@@ -276,7 +275,7 @@ public class SnomedSimpleTypeRefSetDSVExporter implements IRefSetDSVExporter {
 						stringBuffer.append(joinResultsWithDelimiters(relationships, groupedRelationships.get(groupId).get(relationshipId), delimiter, includeRelationshipId));
 					}
 				}
-				stringBuffer.append(lineSeparator);
+				stringBuffer.append(LINE_SEPARATOR);
 				os.writeBytes(stringBuffer.toString());
 				remainderMonitor.worked(1);
 			}

--- a/snomed/com.b2international.snowowl.snomed.exporter.server/src/com/b2international/snowowl/snomed/exporter/server/dsv/SnomedSimpleTypeRefSetDSVExporter.java
+++ b/snomed/com.b2international.snowowl.snomed.exporter.server/src/com/b2international/snowowl/snomed/exporter/server/dsv/SnomedSimpleTypeRefSetDSVExporter.java
@@ -92,6 +92,8 @@ public class SnomedSimpleTypeRefSetDSVExporter implements IRefSetDSVExporter {
 
 	private List<ExtendedLocale> locales;
 	private String exportPath;
+	
+	private final String lineSeparator;
 
 	/**
 	 * Creates a new instance with the export parameters. Called by the SnomedSimpleTypeRefSetDSVExportServerIndication.
@@ -110,6 +112,7 @@ public class SnomedSimpleTypeRefSetDSVExporter implements IRefSetDSVExporter {
 		this.delimiter = exportSetting.getDelimiter();
 		this.branchPath = BranchPathUtils.createPath(exportSetting.getBranchPath());
 		exportPath = exportSetting.getExportPath();
+		lineSeparator = System.getProperty("line.separator");
 		groupedRelationships = Maps.newTreeMap();
 		groupedOnlyItems = Lists.newArrayList();
 	}
@@ -143,7 +146,7 @@ public class SnomedSimpleTypeRefSetDSVExporter implements IRefSetDSVExporter {
 
 			file.createNewFile();
 
-			SnomedConcepts referencedComponents = getReferencedComponentConcepts(refSetId,includeInactiveMembers);
+			SnomedConcepts referencedComponents = getReferencedComponentConcepts(refSetId, includeInactiveMembers);
 			createHeaderList(referencedComponents);
 
 			// write the header to the file
@@ -156,8 +159,7 @@ public class SnomedSimpleTypeRefSetDSVExporter implements IRefSetDSVExporter {
 			}
 
 			if (includeDescriptionId || includeRelationshipId || includeInactiveMembers) {
-				sb.append(System.getProperty("line.separator"));
-				// sb.length > 0 works not, because the first element of the meta header can be empty string.
+				// sb.length > 0 doesn't work, because the first element of the meta header can be empty string.
 				boolean fistElement = true;
 
 				for (String headerListElement : headerList) {
@@ -169,7 +171,8 @@ public class SnomedSimpleTypeRefSetDSVExporter implements IRefSetDSVExporter {
 					sb.append(headerListElement);
 				}
 			}
-			sb.append(System.getProperty("line.separator"));
+			
+			sb.append(lineSeparator);
 			os.writeBytes(sb.toString());
 
 			async.stop();
@@ -273,7 +276,7 @@ public class SnomedSimpleTypeRefSetDSVExporter implements IRefSetDSVExporter {
 						stringBuffer.append(joinResultsWithDelimiters(relationships, groupedRelationships.get(groupId).get(relationshipId), delimiter, includeRelationshipId));
 					}
 				}
-				stringBuffer.append(System.getProperty("line.separator"));
+				stringBuffer.append(lineSeparator);
 				os.writeBytes(stringBuffer.toString());
 				remainderMonitor.worked(1);
 			}


### PR DESCRIPTION
This pull request fixes shifting headers in case of simple type refset dsv export, if any of the optional flags are toggled (includeDescriptionId, includeRelationshipId, includeInactiveMembers)