### PR TITLE
Make term mutable in description update request

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.api.rest.tests/src/com/b2international/snowowl/snomed/api/rest/components/SnomedDescriptionApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest.tests/src/com/b2international/snowowl/snomed/api/rest/components/SnomedDescriptionApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,8 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 import java.util.Map;
@@ -79,7 +80,6 @@ import com.b2international.snowowl.snomed.datastore.SnomedEditingContext;
 import com.b2international.snowowl.snomed.datastore.id.ISnomedIdentifierService;
 import com.b2international.snowowl.snomed.datastore.id.domain.IdentifierStatus;
 import com.b2international.snowowl.snomed.datastore.id.domain.SctId;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedDescriptionIndexEntry;
 import com.b2international.snowowl.snomed.datastore.request.SnomedRequests;
 import com.b2international.snowowl.snomed.snomedrefset.SnomedLanguageRefSetMember;
 import com.b2international.snowowl.snomed.snomedrefset.SnomedRefSet;
@@ -661,21 +661,22 @@ public class SnomedDescriptionApiTest extends AbstractSnomedApiTest {
 	}
 	
 	@Test
-	public void updateReleasedDescriptionTerm() throws Exception {
-		String descriptionId = createNewDescription(branchPath);
-		Map<?, ?> update = ImmutableMap.builder()
-				.put(SnomedRf2Headers.FIELD_TERM, "updatedUnreleasedDescriptionTerm")
+	public void shouldUpdateReleasedDescriptionTerm() throws Exception {
+		final String descriptionId = createNewDescription(branchPath);
+		final String newTerm = "updatedUnreleasedDescriptionTerm";
+		final Map<?, ?> update = ImmutableMap.builder()
+				.put(SnomedRf2Headers.FIELD_TERM, newTerm)
 				.put("commitComment", "Update unreleased description term")
 				.build();
 		
 		// release component
 		createCodeSystemAndVersion(branchPath, "SNOMEDCT-RELDESC-TERM", "v1", "20170301");
 
-		updateComponent(branchPath, SnomedComponentType.DESCRIPTION, descriptionId, update).statusCode(400);
+		updateComponent(branchPath, SnomedComponentType.DESCRIPTION, descriptionId, update).statusCode(204);
 		
 		getComponent(branchPath, SnomedComponentType.DESCRIPTION, descriptionId)
 			.statusCode(200)
-			.body(SnomedRf2Headers.FIELD_TERM, equalTo(SnomedRestFixtures.DEFAULT_TERM));
+			.body(SnomedRf2Headers.FIELD_TERM, equalTo(newTerm));
 	}
 	
 	@Test
@@ -735,6 +736,5 @@ public class SnomedDescriptionApiTest extends AbstractSnomedApiTest {
 			.getTotal();
 		assertThat(numberOfResults).isZero();
 	}
-	
 	
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedDescriptionUpdateRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedDescriptionUpdateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -256,7 +256,6 @@ public final class SnomedDescriptionUpdateRequest extends SnomedComponentUpdateR
 		}
 		
 		if (!description.getTerm().equals(term)) {
-			checkUpdateOnReleased(description, SnomedRf2Headers.FIELD_TERM, term);
 			description.setTerm(term);
 			return true;
 		}


### PR DESCRIPTION
This pull request makes the term mutable on released descriptions since the official release file specification states so: https://confluence.ihtsdotools.org/display/DOCRELFMT/4.2.2+Description+File+Specification