### PR TITLE
Support for childOf HierarchyInclusionType in MRCM rules

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.api.rest.tests/src/com/b2international/snowowl/snomed/api/japi/io/SnomedRefSetDSVExportTest.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest.tests/src/com/b2international/snowowl/snomed/api/japi/io/SnomedRefSetDSVExportTest.java
@@ -200,7 +200,7 @@ public class SnomedRefSetDSVExportTest {
 	private Set<String> ancestorsOf(SnomedConcepts concepts) {
 		return concepts.getItems()
 					.stream()
-					.flatMap(item -> SnomedConcept.GET_ANCESTORS.apply(item).stream())
+					.flatMap(item -> SnomedConcept.GET_PARENTS.apply(item).stream())
 					.collect(Collectors.toSet());
 	}
 

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/domain/SnomedConcept.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/domain/SnomedConcept.java
@@ -95,7 +95,7 @@ public final class SnomedConcept extends SnomedCoreComponent implements Definiti
 	}
 	
 	/**
-	 * Helper function to get ancestors of a given {@link SnomedConcept}.
+	 * Helper function to get ancestors of a given {@link SnomedConcept}, both stated and inferred.
 	 */
 	public static final Function<SnomedConcept, Set<String>> GET_ANCESTORS = (concept) -> {
 		final Set<String> ancestors = newHashSet();
@@ -110,6 +110,20 @@ public final class SnomedConcept extends SnomedCoreComponent implements Definiti
 		}
 		for (long ancestor : concept.getStatedAncestorIds()) {
 			ancestors.add(Long.toString(ancestor));
+		}
+		return ancestors;
+	};
+
+	/**
+	 * Helper function to get only direct parents of a given {@link SnomedConcept}, both stated and inferred.
+	 */
+	public static final Function<SnomedConcept, Set<String>> GET_PARENTS = (concept) -> {
+		final Set<String> ancestors = newHashSet();
+		for (long parent : concept.getParentIds()) {
+			ancestors.add(Long.toString(parent));
+		}
+		for (long parent : concept.getStatedParentIds()) {
+			ancestors.add(Long.toString(parent));
 		}
 		return ancestors;
 	};

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/domain/constraint/SnomedHierarchyDefinition.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/domain/constraint/SnomedHierarchyDefinition.java
@@ -59,6 +59,8 @@ public final class SnomedHierarchyDefinition extends SnomedConceptSetDefinition 
 		switch (inclusionType) {
 		case SELF: 
 			return conceptId;
+		case CHILD:
+			return String.format("<!%s", conceptId);
 		case DESCENDANT: 
 			return String.format("<%s", conceptId); 
 		case SELF_OR_DESCENDANT: 

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/constraint/SnomedConstraintDocument.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/constraint/SnomedConstraintDocument.java
@@ -79,10 +79,11 @@ public final class SnomedConstraintDocument extends RevisionDocument implements 
 		 * are looking for applicable constraints.
 		 */
 		final Set<String> selfIds = newHashSet();
+		final Set<String> childIds = newHashSet();
 		final Set<String> descendantIds = newHashSet();
 		final Set<String> refSetIds = newHashSet();
 		final Set<String> relationshipKeys = newHashSet(); // "typeId=destinationId" format
-		collectIds(constraint.getDomain(), selfIds, descendantIds, refSetIds, relationshipKeys);
+		collectIds(constraint.getDomain(), selfIds, childIds, descendantIds, refSetIds, relationshipKeys);
 
 		return new Builder()
 				.id(constraint.getUuid())
@@ -120,7 +121,8 @@ public final class SnomedConstraintDocument extends RevisionDocument implements 
 	 *            type-destination values
 	 */
 	private static void collectIds(final ConceptSetDefinition definition, 
-			final Set<String> selfIds, 
+			final Set<String> selfIds,
+			final Set<String> childIds,
 			final Set<String> descendantIds, 
 			final Set<String> refSetIds, 
 			final Set<String> relationshipKeys) {
@@ -136,6 +138,9 @@ public final class SnomedConstraintDocument extends RevisionDocument implements 
 				switch (inclusionType) {
 					case SELF:
 						selfIds.add(focusConceptId);
+						break;
+					case CHILDREN:
+						childIds.add(focusConceptId);
 						break;
 					case DESCENDANT:
 						descendantIds.add(focusConceptId);
@@ -168,7 +173,7 @@ public final class SnomedConstraintDocument extends RevisionDocument implements 
 			@Override
 			public ConceptSetDefinition caseCompositeConceptSetDefinition(final CompositeConceptSetDefinition definition) {
 				for (final ConceptSetDefinition childdefinition : definition.getChildren()) {
-					collectIds(childdefinition, selfIds, descendantIds, refSetIds, relationshipKeys);
+					collectIds(childdefinition, selfIds, childIds, descendantIds, refSetIds, relationshipKeys);
 				}
 				return definition;
 			}
@@ -337,6 +342,7 @@ public final class SnomedConstraintDocument extends RevisionDocument implements 
 	public static final class Fields extends RevisionDocument.Fields {
 		public static final String PREDICATE_TYPE = "predicateType";
 		public static final String SELF_IDS = "selfIds";
+		public static final String CHILD_IDS = "childIds";
 		public static final String DESCENDANT_IDS = "descendantIds";
 		public static final String REFSET_IDS = "refSetIds";
 		public static final String RELATIONSHIP_KEYS = "relationshipKeys";
@@ -355,6 +361,10 @@ public final class SnomedConstraintDocument extends RevisionDocument implements 
 			return matchAny(Fields.SELF_IDS, selfIds);
 		}
 
+		public static Expression childIds(final Collection<String> childIds) {
+			return matchAny(Fields.CHILD_IDS, childIds);
+		}
+		
 		public static Expression descendantIds(final Collection<String> descendantIds) {
 			return matchAny(Fields.DESCENDANT_IDS, descendantIds);
 		}

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/constraint/SnomedConstraintDocument.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/constraint/SnomedConstraintDocument.java
@@ -139,7 +139,7 @@ public final class SnomedConstraintDocument extends RevisionDocument implements 
 					case SELF:
 						selfIds.add(focusConceptId);
 						break;
-					case CHILDREN:
+					case CHILD:
 						childIds.add(focusConceptId);
 						break;
 					case DESCENDANT:

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/constraint/SnomedConstraintDocument.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/constraint/SnomedConstraintDocument.java
@@ -100,6 +100,7 @@ public final class SnomedConstraintDocument extends RevisionDocument implements 
 				.predicateType(predicateType)
 				.selfIds(selfIds)
 				.descendantIds(descendantIds)
+				.childIds(childIds)
 				.refSetIds(refSetIds)
 				.relationshipKeys(relationshipKeys);
 	}
@@ -225,6 +226,7 @@ public final class SnomedConstraintDocument extends RevisionDocument implements 
 
 		private SnomedConstraintPredicateType predicateType;
 		private Collection<String> selfIds;
+		private Collection<String> childIds;
 		private Collection<String> descendantIds;
 		private Collection<String> refSetIds;
 		private Collection<String> relationshipKeys;
@@ -287,6 +289,11 @@ public final class SnomedConstraintDocument extends RevisionDocument implements 
 			this.selfIds = selfIds;
 			return getSelf();
 		}
+		
+		public Builder childIds(Collection<String> childIds) {
+			this.childIds = childIds;
+			return getSelf();
+		}
 
 		public Builder descendantIds(final Collection<String> descendantIds) {
 			this.descendantIds = descendantIds;
@@ -316,6 +323,7 @@ public final class SnomedConstraintDocument extends RevisionDocument implements 
 					predicate, 
 					predicateType, 
 					selfIds, 
+					childIds,
 					descendantIds, 
 					refSetIds,
 					relationshipKeys);
@@ -394,6 +402,7 @@ public final class SnomedConstraintDocument extends RevisionDocument implements 
 	// Used when looking for applicable constraints for a concept
 	private final SnomedConstraintPredicateType predicateType;
 	private final Set<String> selfIds;
+	private final Set<String> childIds;
 	private final Set<String> descendantIds;
 	private final Set<String> refSetIds;
 	private final Set<String> relationshipKeys;
@@ -411,6 +420,7 @@ public final class SnomedConstraintDocument extends RevisionDocument implements 
 			PredicateFragment predicate,
 			SnomedConstraintPredicateType predicateType, 
 			Collection<String> selfIds, 
+			Collection<String> childIds,
 			Collection<String> descendantIds,
 			Collection<String> refSetIds, 
 			Collection<String> relationshipKeys) {
@@ -428,6 +438,7 @@ public final class SnomedConstraintDocument extends RevisionDocument implements 
 		this.predicate = predicate;
 		this.predicateType = predicateType;
 		this.selfIds = Collections3.toImmutableSet(selfIds);
+		this.childIds = Collections3.toImmutableSet(childIds);
 		this.descendantIds = Collections3.toImmutableSet(descendantIds);
 		this.refSetIds = Collections3.toImmutableSet(refSetIds);
 		this.relationshipKeys = Collections3.toImmutableSet(relationshipKeys);
@@ -478,6 +489,13 @@ public final class SnomedConstraintDocument extends RevisionDocument implements 
 	 */
 	public Set<String> getSelfIds() {
 		return selfIds;
+	}
+	
+	/**
+	 * Returns all SNOMED CT identifiers where this predicate can be applied on the direct children of the given identifier.
+	 */
+	public Set<String> getChildIds() {
+		return childIds;
 	}
 
 	/**

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConstraintSearchRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConstraintSearchRequest.java
@@ -15,7 +15,7 @@
  */
 package com.b2international.snowowl.snomed.datastore.request;
 
-import static com.b2international.snowowl.snomed.datastore.index.constraint.SnomedConstraintDocument.Expressions.descendantIds;
+import static com.b2international.snowowl.snomed.datastore.index.constraint.SnomedConstraintDocument.Expressions.*;
 import static com.b2international.snowowl.snomed.datastore.index.constraint.SnomedConstraintDocument.Expressions.refSetIds;
 import static com.b2international.snowowl.snomed.datastore.index.constraint.SnomedConstraintDocument.Expressions.relationshipKeys;
 import static com.b2international.snowowl.snomed.datastore.index.constraint.SnomedConstraintDocument.Expressions.selfIds;
@@ -38,35 +38,36 @@ import com.b2international.snowowl.snomed.datastore.index.constraint.SnomedConst
 final class SnomedConstraintSearchRequest extends SearchIndexResourceRequest<BranchContext, SnomedConstraints, SnomedConstraintDocument> {
 
 	public enum OptionKey {
-		
+
 		/**
-		 * Match MRCM constraints that are applicable to concepts having the given
-		 * identifiers.
+		 * Match MRCM constraints that are applicable to concepts having the given identifiers.
 		 */
 		SELF,
-		
+
 		/**
-		 * Match MRCM constraints that are applicable to concepts that are descendants
-		 * of other concepts with the given identifiers.
+		 * Match MRCM constraints that are applicable to concepts that are direct children of other concepts with the given identifiers. identifiers.
+		 */
+		CHILD,
+
+		/**
+		 * Match MRCM constraints that are applicable to concepts that are descendants of other concepts with the given identifiers.
 		 */
 		DESCENDANT,
-		
+
 		/**
-		 * Match MRCM constraints that are applicable to concepts that are members of 
-		 * reference sets with the specified identifiers.
+		 * Match MRCM constraints that are applicable to concepts that are members of reference sets with the specified identifiers.
 		 */
-		REFSET, 
-		
+		REFSET,
+
 		/**
-		 * Match MRCM constraints that are applicable to concepts that have a relationship
-		 * with the specified type and destination identifiers.
+		 * Match MRCM constraints that are applicable to concepts that have a relationship with the specified type and destination identifiers.
 		 */
 		RELATIONSHIP,
-		
+
 		/**
 		 * Match MRCM constraints that has any of the given {@link PredicateType}.
 		 */
-		TYPE
+		TYPE,
 	}
 	
 	@Override
@@ -77,6 +78,10 @@ final class SnomedConstraintSearchRequest extends SearchIndexResourceRequest<Bra
 		
 		if (containsKey(OptionKey.SELF)) {
 			queryBuilder.filter(selfIds(getCollection(OptionKey.SELF, String.class)));
+		}
+		
+		if (containsKey(OptionKey.CHILD)) {
+			queryBuilder.filter(childIds(getCollection(OptionKey.CHILD, String.class)));
 		}
 		
 		if (containsKey(OptionKey.DESCENDANT)) {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConstraintSearchRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConstraintSearchRequestBuilder.java
@@ -49,7 +49,7 @@ public final class SnomedConstraintSearchRequestBuilder
 	}
 	
 	public SnomedConstraintSearchRequestBuilder filterByChildIds(Collection<String> childIds) {
-		return addOption(SnomedConstraintSearchRequest.OptionKey.SELF, childIds);
+		return addOption(SnomedConstraintSearchRequest.OptionKey.CHILD, childIds);
 	}
 	
 	public SnomedConstraintSearchRequestBuilder filterByDescendantId(String descendantId) {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConstraintSearchRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConstraintSearchRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,8 +44,16 @@ public final class SnomedConstraintSearchRequestBuilder
 		return addOption(SnomedConstraintSearchRequest.OptionKey.SELF, selfIds);
 	}
 	
-	public SnomedConstraintSearchRequestBuilder filterByDescendantId(String descendantd) {
-		return addOption(SnomedConstraintSearchRequest.OptionKey.DESCENDANT, descendantd);
+	public SnomedConstraintSearchRequestBuilder filterByChildId(String childId) {
+		return addOption(SnomedConstraintSearchRequest.OptionKey.CHILD, childId);
+	}
+	
+	public SnomedConstraintSearchRequestBuilder filterByChildIds(Collection<String> childIds) {
+		return addOption(SnomedConstraintSearchRequest.OptionKey.SELF, childIds);
+	}
+	
+	public SnomedConstraintSearchRequestBuilder filterByDescendantId(String descendantId) {
+		return addOption(SnomedConstraintSearchRequest.OptionKey.DESCENDANT, descendantId);
 	}
 	
 	public SnomedConstraintSearchRequestBuilder filterByDescendantIds(Collection<String> descendantIds) {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedRequests.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedRequests.java
@@ -468,6 +468,10 @@ public abstract class SnomedRequests {
 					constraintBulkRequestBuilder.add(SnomedRequests.prepareSearchConstraint().all().filterBySelfIds(selfIds));
 				}
 				
+				if (!CompareUtils.isEmpty(ruleParentIds)) {
+					constraintBulkRequestBuilder.add(SnomedRequests.prepareSearchConstraint().all().filterByChildIds(ruleParentIds));
+				}
+				
 				if (!CompareUtils.isEmpty(descendantDomainIds)) {
 					constraintBulkRequestBuilder.add(SnomedRequests.prepareSearchConstraint().all().filterByDescendantIds(descendantDomainIds));
 				}

--- a/snomed/com.b2international.snowowl.snomed.mrcm.model/META-INF/MANIFEST.MF
+++ b/snomed/com.b2international.snowowl.snomed.mrcm.model/META-INF/MANIFEST.MF
@@ -1,10 +1,11 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Snow Owl MRCM Model
+Bundle-Name: %pluginName
 Bundle-SymbolicName: com.b2international.snowowl.snomed.mrcm.model;singleton:=true
+Automatic-Module-Name: com.b2international.snowowl.snomed.mrcm.model
 Bundle-Version: 6.11.0.qualifier
 Bundle-ClassPath: .
-Bundle-Vendor: B2i Healthcare
+Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.9.0",

--- a/snomed/com.b2international.snowowl.snomed.mrcm.model/model/mrcm.ecore
+++ b/snomed/com.b2international.snowowl.snomed.mrcm.model/model/mrcm.ecore
@@ -215,7 +215,11 @@
         <details key="documentation" value="Include the specified concept and all its subtype concepts."/>
       </eAnnotations>
     </eLiterals>
-    <eLiterals name="CHILD" value="3" literal="CHILD"/>
+    <eLiterals name="CHILD" value="3" literal="CHILD">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Include the direct children of the specified concept."/>
+      </eAnnotations>
+    </eLiterals>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EEnum" name="ConstraintStrength">
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">

--- a/snomed/com.b2international.snowowl.snomed.mrcm.model/model/mrcm.ecore
+++ b/snomed/com.b2international.snowowl.snomed.mrcm.model/model/mrcm.ecore
@@ -215,7 +215,7 @@
         <details key="documentation" value="Include the specified concept and all its subtype concepts."/>
       </eAnnotations>
     </eLiterals>
-    <eLiterals name="CHILDREN" value="3"/>
+    <eLiterals name="CHILD" value="3" literal="CHILD"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EEnum" name="ConstraintStrength">
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">

--- a/snomed/com.b2international.snowowl.snomed.mrcm.model/model/mrcm.ecore
+++ b/snomed/com.b2international.snowowl.snomed.mrcm.model/model/mrcm.ecore
@@ -215,6 +215,7 @@
         <details key="documentation" value="Include the specified concept and all its subtype concepts."/>
       </eAnnotations>
     </eLiterals>
+    <eLiterals name="CHILDREN" value="3"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EEnum" name="ConstraintStrength">
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">

--- a/snomed/com.b2international.snowowl.snomed.mrcm.model/model/mrcm.genmodel
+++ b/snomed/com.b2international.snowowl.snomed.mrcm.model/model/mrcm.genmodel
@@ -3,8 +3,8 @@
     xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" copyrightText="Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg&#xD;&#xA;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#xD;&#xA;you may not use this file except in compliance with the License.&#xD;&#xA;You may obtain a copy of the License at&#xD;&#xA;&#xD;&#xA;     http://www.apache.org/licenses/LICENSE-2.0&#xD;&#xA;&#xD;&#xA;Unless required by applicable law or agreed to in writing, software&#xD;&#xA;distributed under the License is distributed on an &quot;AS IS&quot; BASIS, &#xD;&#xA;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xD;&#xA;See the License for the specific language governing permissions and&#xD;&#xA;limitations under the License."
     modelDirectory="/com.b2international.snowowl.snomed.mrcm.model/src" modelPluginID="com.b2international.snowowl.snomed.mrcm.model"
     modelName="Mrcm" rootExtendsInterface="org.eclipse.emf.cdo.CDOObject" rootExtendsClass="org.eclipse.emf.internal.cdo.CDOObjectImpl"
-    reflectiveDelegation="true" importerID="org.eclipse.emf.importer.cdo" featureDelegation="Reflective"
-    complianceLevel="6.0" copyrightFields="false">
+    reflectiveDelegation="true" importerID="org.eclipse.emf.importer.ecore" featureDelegation="Reflective"
+    complianceLevel="6.0" copyrightFields="false" runtimeVersion="2.12">
   <foreignModel>mrcm.ecore</foreignModel>
   <modelPluginVariables>CDO=org.eclipse.emf.cdo</modelPluginVariables>
   <genPackages prefix="Mrcm" basePackage="com.b2international.snowowl.snomed" disposableProviderFactory="true"
@@ -24,6 +24,7 @@
       <genEnumLiterals ecoreEnumLiteral="mrcm.ecore#//HierarchyInclusionType/SELF"/>
       <genEnumLiterals ecoreEnumLiteral="mrcm.ecore#//HierarchyInclusionType/DESCENDANT"/>
       <genEnumLiterals ecoreEnumLiteral="mrcm.ecore#//HierarchyInclusionType/SELF_OR_DESCENDANT"/>
+      <genEnumLiterals ecoreEnumLiteral="mrcm.ecore#//HierarchyInclusionType/CHILDREN"/>
     </genEnums>
     <genEnums typeSafeEnumCompatible="false" ecoreEnum="mrcm.ecore#//ConstraintStrength">
       <genEnumLiterals ecoreEnumLiteral="mrcm.ecore#//ConstraintStrength/MANDATORY_CM"/>

--- a/snomed/com.b2international.snowowl.snomed.mrcm.model/model/mrcm.genmodel
+++ b/snomed/com.b2international.snowowl.snomed.mrcm.model/model/mrcm.genmodel
@@ -24,7 +24,7 @@
       <genEnumLiterals ecoreEnumLiteral="mrcm.ecore#//HierarchyInclusionType/SELF"/>
       <genEnumLiterals ecoreEnumLiteral="mrcm.ecore#//HierarchyInclusionType/DESCENDANT"/>
       <genEnumLiterals ecoreEnumLiteral="mrcm.ecore#//HierarchyInclusionType/SELF_OR_DESCENDANT"/>
-      <genEnumLiterals ecoreEnumLiteral="mrcm.ecore#//HierarchyInclusionType/CHILDREN"/>
+      <genEnumLiterals ecoreEnumLiteral="mrcm.ecore#//HierarchyInclusionType/CHILD"/>
     </genEnums>
     <genEnums typeSafeEnumCompatible="false" ecoreEnum="mrcm.ecore#//ConstraintStrength">
       <genEnumLiterals ecoreEnumLiteral="mrcm.ecore#//ConstraintStrength/MANDATORY_CM"/>

--- a/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/ConstraintForm.java
+++ b/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/ConstraintForm.java
@@ -37,6 +37,9 @@ public enum ConstraintForm implements Enumerator {
 	 * The '<em><b>ALL FORMS</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * The constraint should be true in all forms.
+	 * <!-- end-model-doc -->
 	 * @see #ALL_FORMS_VALUE
 	 * @generated
 	 * @ordered
@@ -47,6 +50,9 @@ public enum ConstraintForm implements Enumerator {
 	 * The '<em><b>DISTRIBUTION FORM</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * The constraint should be tested in the distribution form.
+	 * <!-- end-model-doc -->
 	 * @see #DISTRIBUTION_FORM_VALUE
 	 * @generated
 	 * @ordered
@@ -57,6 +63,9 @@ public enum ConstraintForm implements Enumerator {
 	 * The '<em><b>STATED FORM</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * The constraint should be tested in the stated form.
+	 * <!-- end-model-doc -->
 	 * @see #STATED_FORM_VALUE
 	 * @generated
 	 * @ordered
@@ -67,6 +76,9 @@ public enum ConstraintForm implements Enumerator {
 	 * The '<em><b>CLOSE TO USER FORM</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * The constraint should be tested in the close to user form.
+	 * <!-- end-model-doc -->
 	 * @see #CLOSE_TO_USER_FORM_VALUE
 	 * @generated
 	 * @ordered
@@ -77,6 +89,9 @@ public enum ConstraintForm implements Enumerator {
 	 * The '<em><b>LONG NORMAL FORM</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * The constraint should be tested in the long normal form.
+	 * <!-- end-model-doc -->
 	 * @see #LONG_NORMAL_FORM_VALUE
 	 * @generated
 	 * @ordered
@@ -87,6 +102,9 @@ public enum ConstraintForm implements Enumerator {
 	 * The '<em><b>SHORT NORMAL FORM</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * The constraint should be tested in the short normal form.
+	 * <!-- end-model-doc -->
 	 * @see #SHORT_NORMAL_FORM_VALUE
 	 * @generated
 	 * @ordered

--- a/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/ConstraintStrength.java
+++ b/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/ConstraintStrength.java
@@ -37,6 +37,9 @@ public enum ConstraintStrength implements Enumerator {
 	 * The '<em><b>MANDATORY CM</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Mandatory concept model constraint.
+	 * <!-- end-model-doc -->
 	 * @see #MANDATORY_CM_VALUE
 	 * @generated
 	 * @ordered
@@ -47,6 +50,9 @@ public enum ConstraintStrength implements Enumerator {
 	 * The '<em><b>RECOMMENDED CM</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Recommended concept model constraint based on best practice editorial rules.
+	 * <!-- end-model-doc -->
 	 * @see #RECOMMENDED_CM_VALUE
 	 * @generated
 	 * @ordered
@@ -57,6 +63,9 @@ public enum ConstraintStrength implements Enumerator {
 	 * The '<em><b>ADVISORY CM</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Advisory concept model constraint based on editorial conventions.
+	 * <!-- end-model-doc -->
 	 * @see #ADVISORY_CM_VALUE
 	 * @generated
 	 * @ordered
@@ -67,6 +76,9 @@ public enum ConstraintStrength implements Enumerator {
 	 * The '<em><b>MANDATORY PC</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Mandatory constraint on post-coordinated refinement.
+	 * <!-- end-model-doc -->
 	 * @see #MANDATORY_PC_VALUE
 	 * @generated
 	 * @ordered
@@ -77,6 +89,9 @@ public enum ConstraintStrength implements Enumerator {
 	 * The '<em><b>INFORMATION MODEL PC</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Constraint of post-coordinated refinement that is specific to use in a particular information model. The information model is identified by the 'scope' attribute.
+	 * <!-- end-model-doc -->
 	 * @see #INFORMATION_MODEL_PC_VALUE
 	 * @generated
 	 * @ordered
@@ -87,6 +102,9 @@ public enum ConstraintStrength implements Enumerator {
 	 * The '<em><b>USE CASE SPECIFIC PC</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Constraint of post-coordinated refinement that is specific to a particular use case. The use case is identified by the 'scope' attribute.
+	 * <!-- end-model-doc -->
 	 * @see #USE_CASE_SPECIFIC_PC_VALUE
 	 * @generated
 	 * @ordered
@@ -97,6 +115,9 @@ public enum ConstraintStrength implements Enumerator {
 	 * The '<em><b>IMPLEMENTATION SPECIFIC PC</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Constraint of post-coordinated refinement that is specific to a particular application or local implementation. The implementation is identified by the 'scope' attribute.
+	 * <!-- end-model-doc -->
 	 * @see #IMPLEMENTATION_SPECIFIC_PC_VALUE
 	 * @generated
 	 * @ordered

--- a/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/DependencyOperator.java
+++ b/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/DependencyOperator.java
@@ -37,6 +37,9 @@ public enum DependencyOperator implements Enumerator {
 	 * The '<em><b>ONE</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Return true if one and only one child predicate in the composite predicate returns true.
+	 * <!-- end-model-doc -->
 	 * @see #ONE_VALUE
 	 * @generated
 	 * @ordered
@@ -47,6 +50,9 @@ public enum DependencyOperator implements Enumerator {
 	 * The '<em><b>SOME</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Return true if at least one child predicate in the composite predicate returns true.
+	 * <!-- end-model-doc -->
 	 * @see #SOME_VALUE
 	 * @generated
 	 * @ordered
@@ -57,6 +63,9 @@ public enum DependencyOperator implements Enumerator {
 	 * The '<em><b>ALL</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Return true if all tests in the composite predicate return true.
+	 * <!-- end-model-doc -->
 	 * @see #ALL_VALUE
 	 * @generated
 	 * @ordered

--- a/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/GroupRule.java
+++ b/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/GroupRule.java
@@ -37,6 +37,9 @@ public enum GroupRule implements Enumerator {
 	 * The '<em><b>UNGROUPED</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Test cardinality or interdependency between ungrouped relationships.
+	 * <!-- end-model-doc -->
 	 * @see #UNGROUPED_VALUE
 	 * @generated
 	 * @ordered
@@ -47,6 +50,9 @@ public enum GroupRule implements Enumerator {
 	 * The '<em><b>SINGLE GROUP</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Test cardinality or interdependency between Relationships in each relationship group.
+	 * <!-- end-model-doc -->
 	 * @see #SINGLE_GROUP_VALUE
 	 * @generated
 	 * @ordered
@@ -57,6 +63,9 @@ public enum GroupRule implements Enumerator {
 	 * The '<em><b>ALL GROUPS</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Test cardinality or interdependency between all relationships irrespective of whether they are grouped or ungrouped.
+	 * <!-- end-model-doc -->
 	 * @see #ALL_GROUPS_VALUE
 	 * @generated
 	 * @ordered
@@ -67,6 +76,9 @@ public enum GroupRule implements Enumerator {
 	 * The '<em><b>MULTIPLE GROUPS</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Test cardinality or interdependency between relationship groups that match the predicates in the referenced dependency predicate.
+	 * <!-- end-model-doc -->
 	 * @see #MULTIPLE_GROUPS_VALUE
 	 * @generated
 	 * @ordered

--- a/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/HierarchyInclusionType.java
+++ b/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/HierarchyInclusionType.java
@@ -74,6 +74,9 @@ public enum HierarchyInclusionType implements Enumerator {
 	 * The '<em><b>CHILD</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Include the direct children of the specified concept.
+	 * <!-- end-model-doc -->
 	 * @see #CHILD_VALUE
 	 * @generated
 	 * @ordered
@@ -130,6 +133,9 @@ public enum HierarchyInclusionType implements Enumerator {
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Include the direct children of the specified concept.
+	 * <!-- end-model-doc -->
 	 * @see #CHILD
 	 * @model
 	 * @generated

--- a/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/HierarchyInclusionType.java
+++ b/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/HierarchyInclusionType.java
@@ -71,14 +71,14 @@ public enum HierarchyInclusionType implements Enumerator {
 	 * @ordered
 	 */
 	SELF_OR_DESCENDANT(2, "SELF_OR_DESCENDANT", "SELF_OR_DESCENDANT"), /**
-	 * The '<em><b>CHILDREN</b></em>' literal object.
+	 * The '<em><b>CHILD</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #CHILDREN_VALUE
+	 * @see #CHILD_VALUE
 	 * @generated
 	 * @ordered
 	 */
-	CHILDREN(3, "CHILDREN", "CHILDREN");
+	CHILD(3, "CHILD", "CHILD");
 
 	/**
 	 * The '<em><b>SELF</b></em>' literal value.
@@ -123,19 +123,19 @@ public enum HierarchyInclusionType implements Enumerator {
 	public static final int SELF_OR_DESCENDANT_VALUE = 2;
 
 	/**
-	 * The '<em><b>CHILDREN</b></em>' literal value.
+	 * The '<em><b>CHILD</b></em>' literal value.
 	 * <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>CHILDREN</b></em>' literal object isn't clear,
+	 * If the meaning of '<em><b>CHILD</b></em>' literal object isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @see #CHILDREN
+	 * @see #CHILD
 	 * @model
 	 * @generated
 	 * @ordered
 	 */
-	public static final int CHILDREN_VALUE = 3;
+	public static final int CHILD_VALUE = 3;
 
 	/**
 	 * An array of all the '<em><b>Hierarchy Inclusion Type</b></em>' enumerators.
@@ -148,7 +148,7 @@ public enum HierarchyInclusionType implements Enumerator {
 			SELF,
 			DESCENDANT,
 			SELF_OR_DESCENDANT,
-			CHILDREN,
+			CHILD,
 		};
 
 	/**
@@ -208,7 +208,7 @@ public enum HierarchyInclusionType implements Enumerator {
 			case SELF_VALUE: return SELF;
 			case DESCENDANT_VALUE: return DESCENDANT;
 			case SELF_OR_DESCENDANT_VALUE: return SELF_OR_DESCENDANT;
-			case CHILDREN_VALUE: return CHILDREN;
+			case CHILD_VALUE: return CHILD;
 		}
 		return null;
 	}

--- a/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/HierarchyInclusionType.java
+++ b/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/HierarchyInclusionType.java
@@ -37,6 +37,9 @@ public enum HierarchyInclusionType implements Enumerator {
 	 * The '<em><b>SELF</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Include the specified concept.
+	 * <!-- end-model-doc -->
 	 * @see #SELF_VALUE
 	 * @generated
 	 * @ordered
@@ -47,6 +50,9 @@ public enum HierarchyInclusionType implements Enumerator {
 	 * The '<em><b>DESCENDANT</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Include subtype descendants of the specified concept.
+	 * <!-- end-model-doc -->
 	 * @see #DESCENDANT_VALUE
 	 * @generated
 	 * @ordered
@@ -57,11 +63,22 @@ public enum HierarchyInclusionType implements Enumerator {
 	 * The '<em><b>SELF OR DESCENDANT</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Include the specified concept and all its subtype concepts.
+	 * <!-- end-model-doc -->
 	 * @see #SELF_OR_DESCENDANT_VALUE
 	 * @generated
 	 * @ordered
 	 */
-	SELF_OR_DESCENDANT(2, "SELF_OR_DESCENDANT", "SELF_OR_DESCENDANT");
+	SELF_OR_DESCENDANT(2, "SELF_OR_DESCENDANT", "SELF_OR_DESCENDANT"), /**
+	 * The '<em><b>CHILDREN</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #CHILDREN_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	CHILDREN(3, "CHILDREN", "CHILDREN");
 
 	/**
 	 * The '<em><b>SELF</b></em>' literal value.
@@ -106,6 +123,21 @@ public enum HierarchyInclusionType implements Enumerator {
 	public static final int SELF_OR_DESCENDANT_VALUE = 2;
 
 	/**
+	 * The '<em><b>CHILDREN</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of '<em><b>CHILDREN</b></em>' literal object isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @see #CHILDREN
+	 * @model
+	 * @generated
+	 * @ordered
+	 */
+	public static final int CHILDREN_VALUE = 3;
+
+	/**
 	 * An array of all the '<em><b>Hierarchy Inclusion Type</b></em>' enumerators.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -116,6 +148,7 @@ public enum HierarchyInclusionType implements Enumerator {
 			SELF,
 			DESCENDANT,
 			SELF_OR_DESCENDANT,
+			CHILDREN,
 		};
 
 	/**
@@ -175,6 +208,7 @@ public enum HierarchyInclusionType implements Enumerator {
 			case SELF_VALUE: return SELF;
 			case DESCENDANT_VALUE: return DESCENDANT;
 			case SELF_OR_DESCENDANT_VALUE: return SELF_OR_DESCENDANT;
+			case CHILDREN_VALUE: return CHILDREN;
 		}
 		return null;
 	}

--- a/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/impl/MrcmPackageImpl.java
+++ b/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/impl/MrcmPackageImpl.java
@@ -239,7 +239,7 @@ public class MrcmPackageImpl extends EPackageImpl implements MrcmPackage {
 
 	/**
 	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
-	 * 
+	 *
 	 * <p>This method is used to initialize {@link MrcmPackage#eINSTANCE} when that field is accessed.
 	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
 	 * <!-- begin-user-doc -->
@@ -253,7 +253,8 @@ public class MrcmPackageImpl extends EPackageImpl implements MrcmPackage {
 		if (isInited) return (MrcmPackage)EPackage.Registry.INSTANCE.getEPackage(MrcmPackage.eNS_URI);
 
 		// Obtain or create and register package
-		MrcmPackageImpl theMrcmPackage = (MrcmPackageImpl)(EPackage.Registry.INSTANCE.get(eNS_URI) instanceof MrcmPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI) : new MrcmPackageImpl());
+		Object registeredMrcmPackage = EPackage.Registry.INSTANCE.get(eNS_URI);
+		MrcmPackageImpl theMrcmPackage = registeredMrcmPackage instanceof MrcmPackageImpl ? (MrcmPackageImpl)registeredMrcmPackage : new MrcmPackageImpl();
 
 		isInited = true;
 
@@ -266,7 +267,6 @@ public class MrcmPackageImpl extends EPackageImpl implements MrcmPackage {
 		// Mark meta-data to indicate it can't be changed
 		theMrcmPackage.freeze();
 
-  
 		// Update the registry and return the package
 		EPackage.Registry.INSTANCE.put(MrcmPackage.eNS_URI, theMrcmPackage);
 		return theMrcmPackage;
@@ -1004,6 +1004,7 @@ public class MrcmPackageImpl extends EPackageImpl implements MrcmPackage {
 		addEEnumLiteral(hierarchyInclusionTypeEEnum, HierarchyInclusionType.SELF);
 		addEEnumLiteral(hierarchyInclusionTypeEEnum, HierarchyInclusionType.DESCENDANT);
 		addEEnumLiteral(hierarchyInclusionTypeEEnum, HierarchyInclusionType.SELF_OR_DESCENDANT);
+		addEEnumLiteral(hierarchyInclusionTypeEEnum, HierarchyInclusionType.CHILDREN);
 
 		initEEnum(constraintStrengthEEnum, ConstraintStrength.class, "ConstraintStrength");
 		addEEnumLiteral(constraintStrengthEEnum, ConstraintStrength.MANDATORY_CM);

--- a/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/impl/MrcmPackageImpl.java
+++ b/snomed/com.b2international.snowowl.snomed.mrcm.model/src/com/b2international/snowowl/snomed/mrcm/impl/MrcmPackageImpl.java
@@ -1004,7 +1004,7 @@ public class MrcmPackageImpl extends EPackageImpl implements MrcmPackage {
 		addEEnumLiteral(hierarchyInclusionTypeEEnum, HierarchyInclusionType.SELF);
 		addEEnumLiteral(hierarchyInclusionTypeEEnum, HierarchyInclusionType.DESCENDANT);
 		addEEnumLiteral(hierarchyInclusionTypeEEnum, HierarchyInclusionType.SELF_OR_DESCENDANT);
-		addEEnumLiteral(hierarchyInclusionTypeEEnum, HierarchyInclusionType.CHILDREN);
+		addEEnumLiteral(hierarchyInclusionTypeEEnum, HierarchyInclusionType.CHILD);
 
 		initEEnum(constraintStrengthEEnum, ConstraintStrength.class, "ConstraintStrength");
 		addEEnumLiteral(constraintStrengthEEnum, ConstraintStrength.MANDATORY_CM);


### PR DESCRIPTION
This PR adds a new hierarchy inclusion type, CHILD (corresponding ECL expression is `childOf`), and all the necessary changes to handle it when using `com.b2international.snowowl.snomed.datastore.request.SnomedRequests.prepareGetApplicablePredicates(...)`.

JIRA ticket: https://snowowl.atlassian.net/browse/SO-3346