### PR TITLE
OWLAP-178 OWL Expression ConceptId and GCI filters

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/ModelAttributeParameterExpanderExt.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/ModelAttributeParameterExpanderExt.java
@@ -46,7 +46,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 
 import springfox.documentation.builders.ParameterBuilder;

--- a/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/SnomedReferenceSetMemberRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/SnomedReferenceSetMemberRestService.java
@@ -26,20 +26,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.async.DeferredResult;
 
 import com.b2international.commons.CompareUtils;
 import com.b2international.commons.http.ExtendedLocale;
+import com.b2international.commons.options.Options;
 import com.b2international.commons.options.OptionsBuilder;
 import com.b2international.snowowl.core.domain.PageableCollectionResource;
 import com.b2international.snowowl.core.domain.TransactionContext;
@@ -116,8 +108,20 @@ public class SnomedReferenceSetMemberRestService extends AbstractRestService {
 				.setLocales(extendedLocales)
 				.sortBy(extractSortFields(params.getSort()));
 		
+		OptionsBuilder propFilter = Options.builder();
 		if (!CompareUtils.isEmpty(params.getTargetComponent())) {
-			req.filterByProps(OptionsBuilder.newBuilder().put(SnomedRf2Headers.FIELD_TARGET_COMPONENT, params.getTargetComponent()).build());
+			propFilter.put(SnomedRf2Headers.FIELD_TARGET_COMPONENT_ID, params.getTargetComponent());
+		}
+		if (params.getOwlExpression() != null && !CompareUtils.isEmpty(params.getOwlExpression().getConceptId())) {
+			propFilter.put(SnomedRefSetMemberSearchRequestBuilder.OWL_EXPRESSION_CONCEPTID, params.getOwlExpression().getConceptId());
+		}
+		if (params.getOwlExpression() != null && params.getOwlExpression().getGci() != null) {
+			propFilter.put(SnomedRefSetMemberSearchRequestBuilder.OWL_EXPRESSION_GCI, params.getOwlExpression().getGci());
+		}
+		
+		Options propFilters = propFilter.build();
+		if (!propFilters.isEmpty()) {
+			req.filterByProps(propFilters);
 		}
 		
 		return DeferredResults.wrap(req.build(repositoryId, branchPath).execute(bus));

--- a/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/domain/SnomedOwlExpressionFilters.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/domain/SnomedOwlExpressionFilters.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.snomed.api.rest.domain;
+
+import java.util.List;
+
+import io.swagger.annotations.ApiParam;
+
+/**
+ * @since 6.16
+ */
+public final class SnomedOwlExpressionFilters {
+
+	@ApiParam(value = "Special filter to match concept IDs in an owlExpression")
+	private List<String> conceptId;
+	@ApiParam(value = "Special filter to match GCI/non-GCI axioms")
+	private Boolean gci;
+	
+	public List<String> getConceptId() {
+		return conceptId;
+	}
+	
+	public void setConceptId(List<String> conceptId) {
+		this.conceptId = conceptId;
+	}
+	
+	public Boolean getGci() {
+		return gci;
+	}
+	
+	public void setGci(Boolean gci) {
+		this.gci = gci;
+	}
+	
+}

--- a/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/domain/SnomedReferenceSetMemberRestSearch.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/domain/SnomedReferenceSetMemberRestSearch.java
@@ -48,6 +48,9 @@ public final class SnomedReferenceSetMemberRestSearch {
 	@ApiParam(value="The target component identifier(s) to match in case of association refset members")
 	private List<String> targetComponent;
 	
+	@ApiParam(value="Special filters for owlExpression axiom values")
+	private SnomedOwlExpressionFilters owlExpression; 
+	
 	@ApiParam(value="The scrollKeepAlive to start a scroll using this query")
 	private String scrollKeepAlive;
 	
@@ -65,7 +68,7 @@ public final class SnomedReferenceSetMemberRestSearch {
 	
 	@ApiParam(value="Sort keys")
 	private List<String> sort;
-
+	
 	public Set<String> getId() {
 		return id;
 	}
@@ -117,11 +120,19 @@ public final class SnomedReferenceSetMemberRestSearch {
 	public List<String> getTargetComponent() {
 		return targetComponent;
 	}
-
+	
 	public void setTargetComponent(List<String> targetComponent) {
 		this.targetComponent = targetComponent;
 	}
-
+	
+	public SnomedOwlExpressionFilters getOwlExpression() {
+		return owlExpression;
+	}
+	
+	public void setOwlExpression(SnomedOwlExpressionFilters owlExpression) {
+		this.owlExpression = owlExpression;
+	}
+	
 	public String getScrollKeepAlive() {
 		return scrollKeepAlive;
 	}

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedRefSetMemberSearchRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedRefSetMemberSearchRequest.java
@@ -76,7 +76,7 @@ final class SnomedRefSetMemberSearchRequest extends SnomedSearchRequest<SnomedRe
 		 */
 		PROPS
 	}
-	
+
 	SnomedRefSetMemberSearchRequest() {}
 	
 	@Override
@@ -175,6 +175,12 @@ final class SnomedRefSetMemberSearchRequest extends SnomedSearchRequest<SnomedRe
 			}
 			if (propKeys.remove(SnomedRf2Headers.FIELD_MRCM_GROUPED)) {
 				queryBuilder.filter(grouped(propsFilter.getBoolean(SnomedRf2Headers.FIELD_MRCM_GROUPED)));
+			}
+			if (propKeys.remove(SnomedRefSetMemberSearchRequestBuilder.OWL_EXPRESSION_CONCEPTID)) {
+				queryBuilder.filter(owlExpressionConcept(propsFilter.getCollection(SnomedRefSetMemberSearchRequestBuilder.OWL_EXPRESSION_CONCEPTID, String.class)));
+			}
+			if (propKeys.remove(SnomedRefSetMemberSearchRequestBuilder.OWL_EXPRESSION_GCI)) {
+				queryBuilder.filter(gciAxiom(propsFilter.getBoolean(SnomedRefSetMemberSearchRequestBuilder.OWL_EXPRESSION_GCI)));
 			}
 			final Collection<DataType> dataTypes = propsFilter.getCollection(SnomedRefSetMemberIndexEntry.Fields.DATA_TYPE, DataType.class);
 			if (propKeys.remove(SnomedRefSetMemberIndexEntry.Fields.DATA_TYPE)) {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedRefSetMemberSearchRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedRefSetMemberSearchRequestBuilder.java
@@ -38,6 +38,9 @@ public final class SnomedRefSetMemberSearchRequestBuilder
 		extends SnomedSearchRequestBuilder<SnomedRefSetMemberSearchRequestBuilder, SnomedReferenceSetMembers>
 		implements RevisionIndexRequestBuilder<SnomedReferenceSetMembers> {
 
+	public static final String OWL_EXPRESSION_CONCEPTID = "owlExpression.conceptId";
+	public static final String OWL_EXPRESSION_GCI = "owlExpression.gci";
+
 	SnomedRefSetMemberSearchRequestBuilder() {
 		super();
 	}


### PR DESCRIPTION
This PR adds support for the `owlExpression.conceptId` and `owlExpression.gci` filter parameters on both `GET /:path/members` and `POST /:path/members/search` endpoints. 
Also, it makes this feature available to the high-level Java API to search members by these properties.