### PR TITLE
Introduce CodeSystemURI and CodeSystemResourceRequest

### DIFF
--- a/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/uri/CodeSystemURITest.java
+++ b/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/uri/CodeSystemURITest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.uri;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * @since 7.5
+ */
+public class CodeSystemURITest {
+
+	@Test
+	public void latestReleasedImplicit() throws Exception {
+		final CodeSystemURI uri = new CodeSystemURI("SNOMEDCT");
+		assertEquals("SNOMEDCT", uri.getCodeSystem());
+		assertEquals(CodeSystemURI.LATEST, uri.getPath());
+	}
+	
+	@Test
+	public void latestReleasedExplicit() throws Exception {
+		final CodeSystemURI uri = new CodeSystemURI("SNOMEDCT/LATEST");
+		assertEquals("SNOMEDCT", uri.getCodeSystem());
+		assertEquals(CodeSystemURI.LATEST, uri.getPath());
+	}
+	
+	@Test
+	public void explicitVersion() throws Exception {
+		final CodeSystemURI uri = new CodeSystemURI("SNOMEDCT/2019-07-31");
+		assertEquals("SNOMEDCT", uri.getCodeSystem());
+		assertEquals("2019-07-31", uri.getPath());
+	}
+	
+	@Test
+	public void extensionVersion() throws Exception {
+		final CodeSystemURI uri = new CodeSystemURI("SNOMEDCT-EXT/2019-10-31");
+		assertEquals("SNOMEDCT-EXT", uri.getCodeSystem());
+		assertEquals("2019-10-31", uri.getPath());
+	}
+	
+	@Test
+	public void explicitBranch() throws Exception {
+		final CodeSystemURI uri = new CodeSystemURI("SNOMEDCT-EXT/a/b");
+		assertEquals("SNOMEDCT-EXT", uri.getCodeSystem());
+		assertEquals("a/b", uri.getPath());
+	}
+	
+}

--- a/core/com.b2international.snowowl.core/META-INF/MANIFEST.MF
+++ b/core/com.b2international.snowowl.core/META-INF/MANIFEST.MF
@@ -43,5 +43,6 @@ Export-Package: com.b2international.snowowl.core,
  com.b2international.snowowl.core.request,
  com.b2international.snowowl.core.setup,
  com.b2international.snowowl.core.terminology,
+ com.b2international.snowowl.core.uri,
  com.b2international.snowowl.core.validation
 Import-Package: org.slf4j;version="1.7.25"

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/events/Request.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/events/Request.java
@@ -106,6 +106,15 @@ public interface Request<C extends ServiceProvider, R> extends Serializable {
 
 	/**
 	 * @param <T>
+	 * @param type
+	 * @return
+	 */
+	default <T> T getNestedRequest(Class<T> type) {
+		return Request.getNestedRequest(this, type);
+	}
+	
+	/**
+	 * @param <T>
 	 * @param req
 	 * @param type
 	 * @return

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/events/Request.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/events/Request.java
@@ -104,4 +104,19 @@ public interface Request<C extends ServiceProvider, R> extends Serializable {
 		return ImmutableList.of(this);
 	}
 
+	/**
+	 * @param <T>
+	 * @param req
+	 * @param type
+	 * @return
+	 */
+	static <T> T getNestedRequest(Request<?, ?> req, Class<T> type) {
+		if (type.isInstance(req)) {
+			return type.cast(req);
+		} else if (req instanceof DelegatingRequest<?, ?, ?>) {
+			return getNestedRequest(((DelegatingRequest) req).next(), type);
+		}
+		return null;
+	}
+
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/uri/CodeSystemURI.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/uri/CodeSystemURI.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.uri;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.b2international.commons.CompareUtils;
+import com.b2international.commons.exceptions.BadRequestException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * @since 7.5
+ */
+public final class CodeSystemURI implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@JsonIgnore
+	private static final Pattern URI_PATTERN = Pattern.compile("^([^\\/]+)(([\\/]{1}[^\\/\\s]+)*)$");
+	
+	/**
+	 * Represents the latest released version of a code system.
+	 */
+	public static final String LATEST = "LATEST";
+	
+	/**
+	 * Represents the latest development version of a code system.
+	 */
+	public static final String HEAD = "HEAD";
+	
+	private final String uri;
+	private final String codeSystem;
+	private final String path;
+	
+	@JsonCreator
+	public CodeSystemURI(String uri) throws BadRequestException {
+		final Matcher matcher = URI_PATTERN.matcher(uri);
+		if (!matcher.matches()) {
+			throw new BadRequestException("Malformed CodeSystem URI value: '%s'", uri);
+		}
+		this.uri = uri;
+		this.codeSystem = matcher.group(1);
+		this.path = CompareUtils.isEmpty(matcher.group(2)) ? LATEST : matcher.group(2).substring(1); // removes the leading slash character
+	}
+	
+	public String getUri() {
+		return uri;
+	}
+	
+	public String getCodeSystem() {
+		return codeSystem;
+	}
+	
+	public String getPath() {
+		return path;
+	}
+	
+	public boolean isLatest() {
+		return LATEST.equals(getPath());
+	}
+	
+	public boolean isHead() {
+		return HEAD.equals(getPath());
+	}
+	
+	@Override
+	public int hashCode() {
+		return Objects.hash(uri);
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) return true;
+		if (obj == null) return false;
+		if (getClass() != obj.getClass()) return false;
+		CodeSystemURI other = (CodeSystemURI) obj;
+		return Objects.equals(uri, other.uri);
+	}
+
+	@JsonValue
+	@Override
+	public String toString() {
+		return getUri();
+	}
+	
+}

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/request/CodeSystemResourceRequest.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/request/CodeSystemResourceRequest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.datastore.request;
+
+import com.b2international.snowowl.core.ServiceProvider;
+import com.b2international.snowowl.core.domain.BranchContext;
+import com.b2international.snowowl.core.events.DelegatingRequest;
+import com.b2international.snowowl.core.events.Request;
+import com.b2international.snowowl.core.request.SearchResourceRequest;
+import com.b2international.snowowl.core.uri.CodeSystemURI;
+import com.b2international.snowowl.datastore.CodeSystemEntry;
+import com.b2international.snowowl.datastore.CodeSystemVersionEntry;
+import com.b2international.snowowl.terminologyregistry.core.request.CodeSystemRequests;
+import com.b2international.snowowl.terminologyregistry.core.request.CodeSystemVersionSearchRequestBuilder;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @since 7.5
+ */
+public final class CodeSystemResourceRequest<R> extends DelegatingRequest<ServiceProvider, BranchContext, R> {
+
+	private static final long serialVersionUID = 1L;
+	
+	@JsonProperty
+	private final CodeSystemURI uri;
+	
+	private transient CodeSystemEntry codeSystem;
+	
+	private transient String branchPath;
+	
+	CodeSystemResourceRequest(String codeSystemUri, Request<BranchContext, R> next) {
+		super(next);
+		this.uri = new CodeSystemURI(codeSystemUri);
+	}
+
+	@Override
+	public R execute(ServiceProvider context) {
+		return new RepositoryRequest<R>(getRepositoryId(context),
+			new BranchRequest<R>(getBranchPath(context),
+				next()
+			)
+		).execute(context);
+	}
+
+	public CodeSystemEntry getCodeSystem(ServiceProvider context) {
+		if (codeSystem == null) {
+			codeSystem = CodeSystemRequests.getCodeSystem(context, uri.getCodeSystem());
+		}
+		return codeSystem;
+	}
+	
+	public String getRepositoryId(ServiceProvider context) {
+		return getCodeSystem(context).getRepositoryUuid();
+	}
+	
+	public String getBranchPath(ServiceProvider context) {
+		if (branchPath == null) {
+			CodeSystemVersionSearchRequestBuilder versionSearch = CodeSystemRequests.prepareSearchCodeSystemVersion()
+				.one()
+				.filterByCodeSystemShortName(codeSystem.getShortName());
+			
+			if (uri.isHead()) {
+				// use code system working branch directly when HEAD is specified
+				branchPath = codeSystem.getBranchPath();
+			} else {
+				if (uri.isLatest()) {
+					// fetch the latest code system version if LATEST is specified in the URI
+					versionSearch.sortBy(SearchResourceRequest.SortField.descending(CodeSystemVersionEntry.Fields.EFFECTIVE_DATE));
+				} else {
+					// try to fetch the path as exact version if not the special LATEST is specified in the URI
+					versionSearch.filterByVersionId(uri.getPath());
+				}
+				// determine the final branch path, if based on the version search we find a version, then use that, otherwise use the defined path as relative branch of the code system working branch
+				branchPath = versionSearch
+						.build(codeSystem.getRepositoryUuid())
+						.getRequest()
+						.execute(context)
+						.stream()
+						.findFirst()
+						.map(CodeSystemVersionEntry::getPath)
+						.orElse(codeSystem.getRelativeBranchPath(uri.getPath()));
+			}
+			
+		}
+		return branchPath;
+	}
+
+}

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/request/CodeSystemResourceRequest.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/request/CodeSystemResourceRequest.java
@@ -68,14 +68,15 @@ public final class CodeSystemResourceRequest<R> extends DelegatingRequest<Servic
 	
 	public String getBranchPath(ServiceProvider context) {
 		if (branchPath == null) {
-			CodeSystemVersionSearchRequestBuilder versionSearch = CodeSystemRequests.prepareSearchCodeSystemVersion()
-				.one()
-				.filterByCodeSystemShortName(codeSystem.getShortName());
 			
 			if (uri.isHead()) {
 				// use code system working branch directly when HEAD is specified
 				branchPath = codeSystem.getBranchPath();
 			} else {
+				CodeSystemVersionSearchRequestBuilder versionSearch = CodeSystemRequests.prepareSearchCodeSystemVersion()
+						.one()
+						.filterByCodeSystemShortName(codeSystem.getShortName());
+				
 				if (uri.isLatest()) {
 					// fetch the latest code system version if LATEST is specified in the URI
 					versionSearch.sortBy(SearchResourceRequest.SortField.descending(CodeSystemVersionEntry.Fields.EFFECTIVE_DATE));

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/request/RepositoryCommitRequestBuilder.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/request/RepositoryCommitRequestBuilder.java
@@ -17,7 +17,6 @@ package com.b2international.snowowl.datastore.request;
 
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.domain.TransactionContext;
-import com.b2international.snowowl.core.events.AsyncRequest;
 import com.b2international.snowowl.core.events.BaseRequestBuilder;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.events.RequestBuilder;
@@ -28,7 +27,8 @@ import com.b2international.snowowl.datastore.oplock.impl.DatastoreLockContextDes
  * 
  * @since 4.5
  */
-public class RepositoryCommitRequestBuilder extends BaseRequestBuilder<RepositoryCommitRequestBuilder, BranchContext, CommitResult> implements AllowedHealthStates {
+public class RepositoryCommitRequestBuilder extends BaseRequestBuilder<RepositoryCommitRequestBuilder, BranchContext, CommitResult>
+		implements RevisionIndexRequestBuilder<CommitResult>, AllowedHealthStates {
 
 	private String author;
 	private String commitComment = "";
@@ -54,9 +54,10 @@ public class RepositoryCommitRequestBuilder extends BaseRequestBuilder<Repositor
 		this.commitComment = commitComment;
 		return getSelf();
 	}
-	
+
 	/**
 	 * Subclasses may override to provide additional request where the wrapper request requires {@link TransactionContext} for its functionality.
+	 * 
 	 * @return
 	 */
 	protected Request<TransactionContext, ?> getBody() {
@@ -74,7 +75,7 @@ public class RepositoryCommitRequestBuilder extends BaseRequestBuilder<Repositor
 		this.preparationTime = preparationTime;
 		return getSelf();
 	}
-	
+
 	public final RepositoryCommitRequestBuilder setParentContextDescription(String parentContextDescription) {
 		this.parentContextDescription = parentContextDescription;
 		return getSelf();
@@ -84,18 +85,5 @@ public class RepositoryCommitRequestBuilder extends BaseRequestBuilder<Repositor
 	protected final Request<BranchContext, CommitResult> doBuild() {
 		return new TransactionalRequest(author, commitComment, getBody(), preparationTime, parentContextDescription);
 	}
-	
-	public AsyncRequest<CommitResult> build(String repositoryId, String branch) {
-		return new AsyncRequest<>(
-			new RepositoryRequest<>(repositoryId,
-				new HealthCheckingRequest<>(
-					new BranchRequest<>(branch,
-						new RevisionIndexReadRequest<CommitResult>(build())
-					),
-					allowedHealthstates()
-				)
-			)
-		);
-	}
-	
+
 }

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/request/RevisionIndexRequestBuilder.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/request/RevisionIndexRequestBuilder.java
@@ -16,9 +16,10 @@
 package com.b2international.snowowl.datastore.request;
 
 import com.b2international.index.revision.RevisionSearcher;
+import com.b2international.snowowl.core.branch.Branch;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.events.AsyncRequest;
-import com.b2international.snowowl.core.events.RequestBuilder;
+import com.google.common.base.Strings;
 
 /**
  * Provides a default method for wrapping {@link BranchContext}-based requests
@@ -29,14 +30,32 @@ import com.b2international.snowowl.core.events.RequestBuilder;
  * @since 5.7
  * @param <R> - the return type
  */
-public interface RevisionIndexRequestBuilder<R> extends RequestBuilder<BranchContext, R> {
+public interface RevisionIndexRequestBuilder<R> extends BranchRequestBuilder<R> {
 
+	@Override
 	default AsyncRequest<R> build(String repositoryId, String branch) {
-		return new AsyncRequest<>(
-			new RepositoryRequest<>(repositoryId,
-				new BranchRequest<>(branch, 
-					new RevisionIndexReadRequest<>(build())
+		// if the branch starts with MAIN, then it is an explicit branch path with a repositoryId
+		if (Strings.nullToEmpty(branch).startsWith(Branch.MAIN_PATH)) {
+			return new AsyncRequest<>(
+				new RepositoryRequest<>(repositoryId,
+					new HealthCheckingRequest<>(
+						new BranchRequest<>(branch, 
+							new RevisionIndexReadRequest<>(build())
+						),
+						allowedHealthstates()
+					)
 				)
+			);
+		} else {
+			return build(branch);
+		}
+	}
+	
+	default AsyncRequest<R> build(String codeSystemUri) {
+		return new AsyncRequest<>(
+			new CodeSystemResourceRequest<>(
+				codeSystemUri,
+				new RevisionIndexReadRequest<>(build())
 			)
 		);
 	}

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/request/TransactionalRequestBuilder.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/datastore/request/TransactionalRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,15 @@ import com.b2international.snowowl.core.events.RequestBuilder;
  */
 public interface TransactionalRequestBuilder<R> extends RequestBuilder<TransactionContext, R> {
 
+	default AsyncRequest<CommitResult> build(String codeSystemUri, 
+			String author,
+			String commitComment) {
+		return commit()
+				.setAuthor(author)
+				.setCommitComment(commitComment)
+				.build(codeSystemUri);
+	}
+	
 	default AsyncRequest<CommitResult> build(String repositoryId, 
 			String branch, 
 			String author,

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/terminologyregistry/core/request/CodeSystemRequests.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/terminologyregistry/core/request/CodeSystemRequests.java
@@ -20,10 +20,8 @@ import java.util.stream.Collectors;
 
 import com.b2international.commons.exceptions.BadRequestException;
 import com.b2international.snowowl.core.Repositories;
-import com.b2international.snowowl.core.RepositoryInfo;
 import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.datastore.CodeSystemEntry;
-import com.b2international.snowowl.datastore.request.RepositoryRequest;
 import com.b2international.snowowl.datastore.request.RepositoryRequests;
 import com.b2international.snowowl.datastore.request.version.CodeSystemVersionCreateRequestBuilder;
 
@@ -71,11 +69,13 @@ public class CodeSystemRequests {
 		
 		return repositories.getItems()
 			.stream()
-			.filter( repository -> RepositoryInfo.Health.GREEN == repository.health() || RepositoryInfo.Health.YELLOW == repository.health() )
 			.flatMap(repository -> {
-				return new RepositoryRequest<>(repository.id(), CodeSystemRequests.prepareSearchCodeSystem()
+				return CodeSystemRequests.prepareSearchCodeSystem()
 						.all()
-						.build()).execute(context).stream();
+						.build(repository.id())
+						.getRequest()
+						.execute(context)
+						.stream();
 			})
 			.collect(Collectors.toList());
 	}
@@ -88,12 +88,14 @@ public class CodeSystemRequests {
 			
 		return repositories.getItems()
 			.stream()
-			.filter( repository -> RepositoryInfo.Health.GREEN == repository.health() || RepositoryInfo.Health.YELLOW == repository.health() )
 			.flatMap(repository -> {
-				return new RepositoryRequest<>(repository.id(), CodeSystemRequests.prepareSearchCodeSystem()
+				return CodeSystemRequests.prepareSearchCodeSystem()
 						.one()
 						.filterById(codeSystem)
-						.build()).execute(context).stream();
+						.build(repository.id())
+						.getRequest()
+						.execute(context)
+						.stream();
 			})
 			.findFirst()
 			.orElseThrow(() -> new BadRequestException("CodeSystem '%s' cannot be found", codeSystem));

--- a/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/terminologyregistry/core/request/CodeSystemRequests.java
+++ b/core/com.b2international.snowowl.datastore/src/com/b2international/snowowl/terminologyregistry/core/request/CodeSystemRequests.java
@@ -71,7 +71,7 @@ public class CodeSystemRequests {
 		
 		return repositories.getItems()
 			.stream()
-			.filter( repository -> RepositoryInfo.Health.GREEN == repository.health() )
+			.filter( repository -> RepositoryInfo.Health.GREEN == repository.health() || RepositoryInfo.Health.YELLOW == repository.health() )
 			.flatMap(repository -> {
 				return new RepositoryRequest<>(repository.id(), CodeSystemRequests.prepareSearchCodeSystem()
 						.all()
@@ -88,7 +88,7 @@ public class CodeSystemRequests {
 			
 		return repositories.getItems()
 			.stream()
-			.filter( repository -> RepositoryInfo.Health.GREEN == repository.health() )
+			.filter( repository -> RepositoryInfo.Health.GREEN == repository.health() || RepositoryInfo.Health.YELLOW == repository.health() )
 			.flatMap(repository -> {
 				return new RepositoryRequest<>(repository.id(), CodeSystemRequests.prepareSearchCodeSystem()
 						.one()

--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/datastore/AllSnomedDatastoreTests.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/datastore/AllSnomedDatastoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import com.b2international.snowowl.snomed.core.tree.TerminologyTreeTest;
 import com.b2international.snowowl.snomed.datastore.id.memory.DefaultSnomedIdentifierServiceRegressionTest;
 import com.b2international.snowowl.snomed.datastore.id.memory.DefaultSnomedIdentifierServiceTest;
 import com.b2international.snowowl.snomed.datastore.index.change.ConceptChangeProcessorAxiomTest;
-import com.b2international.snowowl.snomed.datastore.index.change.ConceptChangeProcessorTest;
 import com.b2international.snowowl.snomed.datastore.index.change.DescriptionChangeProcessorTest;
 import com.b2international.snowowl.snomed.datastore.index.change.PreferredDescriptionPreCommitHookTest;
 import com.b2international.snowowl.snomed.datastore.index.change.RelationshipChangeProcessorTest;

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedTransactionalRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedTransactionalRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,11 +33,6 @@ public interface SnomedTransactionalRequestBuilder<R> extends TransactionalReque
 		return build(repositoryId, branch, userId, commitComment, null);
 	}
 	
-	@Override
-	default SnomedRepositoryCommitRequestBuilder commit() {
-		return (SnomedRepositoryCommitRequestBuilder) new SnomedRepositoryCommitRequestBuilder().setBody(build());
-	}
-
 	default AsyncRequest<CommitResult> build(String repositoryId, 
 			String branch, 
 			String author,
@@ -49,5 +44,10 @@ public interface SnomedTransactionalRequestBuilder<R> extends TransactionalReque
 				.setAuthor(author)
 				.setCommitComment(commitComment)
 				.build(repositoryId, branch);
+	}
+	
+	@Override
+	default SnomedRepositoryCommitRequestBuilder commit() {
+		return (SnomedRepositoryCommitRequestBuilder) new SnomedRepositoryCommitRequestBuilder().setBody(build());
 	}
 }

--- a/tests/com.b2international.snowowl.test.commons/src/com/b2international/snowowl/test/commons/snomed/TestBranchContext.java
+++ b/tests/com.b2international.snowowl.test.commons/src/com/b2international/snowowl/test/commons/snomed/TestBranchContext.java
@@ -39,6 +39,7 @@ import com.b2international.snowowl.core.events.DelegatingRequest;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.datastore.BranchPathUtils;
 import com.b2international.snowowl.datastore.request.BranchRequest;
+import com.b2international.snowowl.datastore.request.HealthCheckingRequest;
 import com.b2international.snowowl.datastore.request.RepositoryRequest;
 import com.b2international.snowowl.eventbus.EventBusUtil;
 import com.b2international.snowowl.eventbus.IEventBus;
@@ -114,7 +115,8 @@ public final class TestBranchContext extends DelegatingContext implements Branch
 			bus.registerHandler(Request.ADDRESS, message -> {
 				try {
 					final RepositoryRequest<?> repoReq = message.body(RepositoryRequest.class);
-					final BranchRequest<?> branchReq = ReflectionUtils.getField(DelegatingRequest.class, repoReq, "next");
+					final HealthCheckingRequest<?> healthReq = ReflectionUtils.getField(DelegatingRequest.class, repoReq, "next");
+					final BranchRequest<?> branchReq = ReflectionUtils.getField(DelegatingRequest.class, healthReq, "next");
 					final Request<BranchContext, ?> innerReq = ReflectionUtils.getField(DelegatingRequest.class, branchReq, "next");
 					message.reply(innerReq.execute(context));
 				} catch (WrappedException e1) {


### PR DESCRIPTION
Support `build(uri)` request builder method on selected SNOMED CT APIs.
This allows clients to call the API with a CodeSystemURI String
representation instead of specifying the repositoryId and branch to
delegate the request to.
CodeSystemURI represents a String in format of `<CODESYSTEM>[/<PATH>]`,
where:
- `<CODESYSTEM>` is the shortName ID of a Code System
- `<PATH>` is one of the following values:
  * `LATEST` - special value that represents the latest released version
of the codesystem. This is the default value if PATH is omitted.
Examples: `SNOMEDCT` (implicit latest) or `SNOMEDCT/LATEST` (explicit
latest).
  * `HEAD` - special value that represents the latest development
version of the codesystem. Examples: `SNOMEDCT/HEAD`
  * `<versionId>` - an explicit `versionId` that matches one existing
version of the Code System. Examples: `SNOMEDCT/2019-01-31` or
`SNOMEDCT-UK/2019-10-31`
  * `<branch_path>` - any other path value will be treated as relative
path to the CodeSystem's current working branch
(`CodeSystem.branchPath`). Examples: `SNOMEDCT/a/b`.

This new feature is available in all endpoints that require a `/:path`
parameter.