### PR TITLE
Make LDAP identity provider more customizable

### DIFF
--- a/core/com.b2international.snowowl.identity.ldap/src/com/b2international/snowowl/identity/ldap/LdapIdentityProvider.java
+++ b/core/com.b2international.snowowl.identity.ldap/src/com/b2international/snowowl/identity/ldap/LdapIdentityProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,12 @@ import com.google.common.collect.Iterators;
  *         baseDn: dc=snowowl,dc=b2international,dc=com
  *         rootDn: cn=admin,dc=snowowl,dc=b2international,dc=com
  *         rootDnPassword: adminpwd
+ *         userObjectClass: inetOrgPerson
+ *         roleObjectClass: groupOfUniqueNames
  *         userIdProperty: uid
+ *         memberProperty: uniqueMember
+ *         permissionProperty: description
+ *
  * </pre>
  * 
  * @since 5.11
@@ -85,19 +90,12 @@ final class LdapIdentityProvider implements IdentityProvider {
 	private static final String LDAP_CONNECTION_POOL = "com.sun.jndi.ldap.connect.pool";
 	
 	// Queries
-	private static final String ALL_USER_QUERY = "(objectClass=inetOrgPerson)";
-	private static final String ALL_ROLE = "(objectClass=role)";
-	private static final String USER_FILTER = "(&(objectClass=inetOrgPerson)({uid}={userName}))";
+	private static final String OBJECT_QUERY = "(objectClass=%s)";
+	private static final String USER_FILTER = "(&(objectClass=%s)(%s=%s))";
 	
-	// Query variable substitution
-	private static final String USER_NAME_PLACEHOLDER = "\\{userName\\}";
-	private static final String UID_PLACEHOLDER = "\\{uid\\}";
-
 	// Attributes
 	private static final String ATTRIBUTE_DN = "dn";
 	private static final String ATTR_CN = "cn";
-	private static final String ATTR_PERMISSION_ID = "permissionId";
-	private static final String ATTR_UNIQUE_MEMBER = "uniqueMember";
 	
 	private final LdapIdentityProviderConfig conf;
 	
@@ -132,7 +130,7 @@ final class LdapIdentityProvider implements IdentityProvider {
 		Preconditions.checkNotNull(context, "Directory context is null.");
 		Preconditions.checkNotNull(username, "Username is null.");
 
-		final String userFilterWithUsername = USER_FILTER.replaceAll(UID_PLACEHOLDER, conf.getUserIdProperty()).replaceAll(USER_NAME_PLACEHOLDER, username);
+		final String userFilterWithUsername = String.format(USER_FILTER, conf.getUserObjectClass(), conf.getUserIdProperty(), username);
 
 		NamingEnumeration<SearchResult> searchResultEnumeration = null;
 
@@ -179,8 +177,8 @@ final class LdapIdentityProvider implements IdentityProvider {
 			context = createLdapContext();
 			Collection<LdapRole> ldapRoles = getAllLdapRoles(context, baseDn);
 			
-			
-			searchResultEnumeration = context.search(baseDn, ALL_USER_QUERY, createSearchControls(ATTRIBUTE_DN, uidProp));
+			final String usersQuery = String.format(OBJECT_QUERY, conf.getUserObjectClass());
+			searchResultEnumeration = context.search(baseDn, usersQuery, createSearchControls(ATTRIBUTE_DN, uidProp));
 			for (final SearchResult searchResult : ImmutableList.copyOf(Iterators.forEnumeration(searchResultEnumeration))) {
 				final Attributes attributes = searchResult.getAttributes();
 
@@ -214,7 +212,8 @@ final class LdapIdentityProvider implements IdentityProvider {
 		NamingEnumeration<SearchResult> enumeration = null;
 		try {
 			final ImmutableList.Builder<LdapRole> results = ImmutableList.builder();
-			enumeration = context.search(baseDn, ALL_ROLE, createSearchControls(ATTR_CN, ATTR_PERMISSION_ID, ATTR_UNIQUE_MEMBER));
+			final String roleQuery = String.format(OBJECT_QUERY, conf.getRoleObjectClass());
+			enumeration = context.search(baseDn, roleQuery, createSearchControls(ATTR_CN, conf.getPermissionProperty(), conf.getMemberProperty()));
 			
 			NamingEnumeration<?> permissionEnumeration = null;
 			NamingEnumeration<?> uniqueMemberEnumeration = null;
@@ -227,8 +226,8 @@ final class LdapIdentityProvider implements IdentityProvider {
 				final ImmutableList.Builder<Permission> permissions = ImmutableList.builder();
 				
 				try {
-					permissionEnumeration = attributes.get(ATTR_PERMISSION_ID).getAll();
-					uniqueMemberEnumeration = attributes.get(ATTR_UNIQUE_MEMBER).getAll();
+					permissionEnumeration = attributes.get(conf.getPermissionProperty()).getAll();
+					uniqueMemberEnumeration = attributes.get(conf.getMemberProperty()).getAll();
 					
 					// process permissions
 					for (final Object permission : ImmutableList.copyOf(Iterators.forEnumeration(permissionEnumeration))) {

--- a/core/com.b2international.snowowl.identity.ldap/src/com/b2international/snowowl/identity/ldap/LdapIdentityProviderConfig.java
+++ b/core/com.b2international.snowowl.identity.ldap/src/com/b2international/snowowl/identity/ldap/LdapIdentityProviderConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,14 @@ public class LdapIdentityProviderConfig implements IdentityProviderConfig {
 	@NotEmpty private String baseDn = "dc=snowowl,dc=b2international,dc=com";
 	@NotEmpty private String rootDn = "cn=admin,dc=snowowl,dc=b2international,dc=com";
 	@NotEmpty private String rootDnPassword;
+	// Customizable objectClasses
+	@NotEmpty private String userObjectClass = "inetOrgPerson";
+	@NotEmpty private String roleObjectClass = "groupOfUniqueNames";
+	
+	// Customizable attributes
 	@NotEmpty private String userIdProperty = "uid";
+	@NotEmpty private String permissionProperty = "description";
+	@NotEmpty private String memberProperty = "uniqueMember";
 	
 	private boolean connectionPoolEnabled = false;
 	
@@ -83,6 +90,38 @@ public class LdapIdentityProviderConfig implements IdentityProviderConfig {
 	@JsonProperty("usePool")
 	public void setConnectionPoolEnabled(boolean connectionPoolEnabled) {
 		this.connectionPoolEnabled = connectionPoolEnabled;
+	}
+	
+	public String getUserObjectClass() {
+		return userObjectClass;
+	}
+	
+	public void setUserObjectClass(String userObjectClass) {
+		this.userObjectClass = userObjectClass;
+	}
+	
+	public String getRoleObjectClass() {
+		return roleObjectClass;
+	}
+	
+	public void setRoleObjectClass(String roleObjectClass) {
+		this.roleObjectClass = roleObjectClass;
+	}
+	
+	public String getMemberProperty() {
+		return memberProperty;
+	}
+	
+	public void setMemberProperty(String memberProperty) {
+		this.memberProperty = memberProperty;
+	}
+	
+	public String getPermissionProperty() {
+		return permissionProperty;
+	}
+	
+	public void setPermissionProperty(String permissionProperty) {
+		this.permissionProperty = permissionProperty;
 	}
 	
 }


### PR DESCRIPTION
* Support customization of user and role object classes (defaults are
`inetOrgPerson` and `groupOfUniqueNames`).
* Support customization of permission and member properties (defaults are
`description` and `uniqueMember`).