### PR TITLE
SO-4007 Restore effectiveTime during RF2 Delta imports

### DIFF
--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ServiceProvider.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ServiceProvider.java
@@ -111,7 +111,7 @@ public interface ServiceProvider {
 				.first()
 				.filter(RemoteJobEntry::isRunning)
 				.map(j -> j.getParameters(service(ObjectMapper.class)))
-				.filter(parametersPredice)
+				.filter(parametersPredicate)
 				.isPresent();
 	}
 

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ServiceProvider.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ServiceProvider.java
@@ -100,7 +100,7 @@ public interface ServiceProvider {
 		// check first if this context is running inside a job with the given jobKey
 		Optional<RemoteJob> job = optionalService(RemoteJob.class);
 		if (job.isPresent()) {
-			return Objects.equals(jobKey, job.get().getKey()) && parametersPredice.test(job.get().getParameters(service(ObjectMapper.class)));
+			return Objects.equals(jobKey, job.get().getKey()) && parametersPredicate.test(job.get().getParameters(service(ObjectMapper.class)));
 		}
 
 		// if not inside a job context or running in non-job context check the jobs index

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ServiceProvider.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ServiceProvider.java
@@ -17,6 +17,7 @@ package com.b2international.snowowl.core;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -26,6 +27,7 @@ import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.jobs.JobRequests;
 import com.b2international.snowowl.core.jobs.RemoteJob;
 import com.b2international.snowowl.core.jobs.RemoteJobEntry;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Provider;
 
 /**
@@ -87,18 +89,18 @@ public interface ServiceProvider {
 	}
 	
 	/**
-	 * Returns <code>true</code> if any job present with the given jobKey in {@link RemoteJobEntry#isRunning()} state and matches the given predicate, <code>false</code> otherwise.
+	 * Returns <code>true</code> if any job present with the given jobKey in {@link RemoteJobEntry#isRunning()} state and matches the given parameters predicate, <code>false</code> otherwise.
 	 * 
 	 * @param jobKey - the logical key assigned to the job
-	 * @param predicate - the predicate filter to further customize the search process
+	 * @param parametersPredice - the predicate to filter the job by its parameters
 	 * @return
 	 */
-	default boolean isJobRunning(String jobKey, Predicate<RemoteJobEntry> predicate) {
-		checkNotNull(predicate, "Predicate should not be null");
+	default boolean isJobRunning(String jobKey, Predicate<Map<String, Object>> parametersPredice) {
+		checkNotNull(parametersPredice, "Parameters Predicate should not be null");
 		// check first if this context is running inside a job with the given jobKey
 		Optional<RemoteJob> job = optionalService(RemoteJob.class);
-		if (job.isPresent() && Objects.equals(jobKey, job.get().getKey())) {
-			return true;
+		if (job.isPresent()) {
+			return Objects.equals(jobKey, job.get().getKey()) && parametersPredice.test(job.get().getParameters(service(ObjectMapper.class)));
 		}
 
 		// if not inside a job context or running in non-job context check the jobs index
@@ -108,7 +110,8 @@ public interface ServiceProvider {
 				.execute(this)
 				.first()
 				.filter(RemoteJobEntry::isRunning)
-				.filter(predicate)
+				.map(j -> j.getParameters(service(ObjectMapper.class)))
+				.filter(parametersPredice)
 				.isPresent();
 	}
 

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ServiceProvider.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ServiceProvider.java
@@ -92,11 +92,11 @@ public interface ServiceProvider {
 	 * Returns <code>true</code> if any job present with the given jobKey in {@link RemoteJobEntry#isRunning()} state and matches the given parameters predicate, <code>false</code> otherwise.
 	 * 
 	 * @param jobKey - the logical key assigned to the job
-	 * @param parametersPredice - the predicate to filter the job by its parameters
+	 * @param parametersPredicate - the predicate to filter the job by its parameters
 	 * @return
 	 */
-	default boolean isJobRunning(String jobKey, Predicate<Map<String, Object>> parametersPredice) {
-		checkNotNull(parametersPredice, "Parameters Predicate should not be null");
+	default boolean isJobRunning(String jobKey, Predicate<Map<String, Object>> parametersPredicate) {
+		checkNotNull(parametersPredicate, "Parameters predicate should not be null");
 		// check first if this context is running inside a job with the given jobKey
 		Optional<RemoteJob> job = optionalService(RemoteJob.class);
 		if (job.isPresent()) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/jobs/RemoteJob.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/jobs/RemoteJob.java
@@ -16,6 +16,7 @@
 package com.b2international.snowowl.core.jobs;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -160,8 +161,8 @@ public final class RemoteJob extends Job {
 		return response;
 	}
 
-	Request<ServiceProvider, ?> getRequest() {
-		return request;
+	public Map<String, Object> getParameters(ObjectMapper mapper) {
+		return mapper.convertValue(request, Map.class);
 	}
 	
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/jobs/RemoteJobTracker.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/jobs/RemoteJobTracker.java
@@ -259,7 +259,7 @@ public final class RemoteJobTracker implements IDisposableService {
 				// try to convert the request to a param object
 				String parameters;
 				try {
-					parameters = mapper.writeValueAsString(job.getRequest());
+					parameters = mapper.writeValueAsString(job.getParameters(mapper));
 				} catch (Throwable e) {
 					parameters = "";
 				}

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/SnomedRf2ImportRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/SnomedRf2ImportRequest.java
@@ -83,7 +83,7 @@ final class SnomedRf2ImportRequest implements Request<BranchContext, Rf2ImportRe
 	
 	@NotNull
 	@JsonProperty
-	private Rf2ReleaseType type;
+	private Rf2ReleaseType releaseType;
 	
 	@JsonProperty
 	private boolean createVersions = true;
@@ -92,8 +92,8 @@ final class SnomedRf2ImportRequest implements Request<BranchContext, Rf2ImportRe
 		this.rf2ArchiveId = rf2ArchiveId;
 	}
 	
-	void setReleaseType(Rf2ReleaseType type) {
-		this.type = type;
+	void setReleaseType(Rf2ReleaseType rf2ReleaseType) {
+		this.releaseType = rf2ReleaseType;
 	}
 	
 	void setCreateVersions(boolean createVersions) {
@@ -107,7 +107,7 @@ final class SnomedRf2ImportRequest implements Request<BranchContext, Rf2ImportRe
 		final File rf2Archive = fileReg.getAttachment(rf2ArchiveId);
 		
 		try (Locks locks = Locks.on(context).lock(DatastoreLockContextDescriptions.IMPORT)) {
-			return doImport(context, rf2Archive, new Rf2ImportConfiguration(type, createVersions));
+			return doImport(context, rf2Archive, new Rf2ImportConfiguration(releaseType, createVersions));
 		} catch (Exception e) {
 			if (e instanceof ApiException) {
 				throw (ApiException) e;
@@ -120,14 +120,14 @@ final class SnomedRf2ImportRequest implements Request<BranchContext, Rf2ImportRe
 		final boolean contentAvailable = context.service(ContentAvailabilityInfoProvider.class).isAvailable(context);
 		final boolean isMain = context.isMain();
 		
-		if (contentAvailable && Rf2ReleaseType.FULL.equals(type) && isMain) {
+		if (contentAvailable && Rf2ReleaseType.FULL.equals(releaseType) && isMain) {
 			throw new BadRequestException("Importing a full release of SNOMED CT "
 					+ "from an archive to MAIN branch is prohibited when SNOMED CT "
 					+ "ontology is already available on the terminology server. "
 					+ "Please perform either a delta or a snapshot import instead.");
 		}
 		
-		if (!contentAvailable && Rf2ReleaseType.DELTA.equals(type) && isMain) {
+		if (!contentAvailable && Rf2ReleaseType.DELTA.equals(releaseType) && isMain) {
 			throw new BadRequestException("Importing a delta release of SNOMED CT "
 					+ "from an archive to MAIN branch is prohibited when SNOMED CT "
 					+ "ontology is not available on the terminology server. "
@@ -191,7 +191,7 @@ final class SnomedRf2ImportRequest implements Request<BranchContext, Rf2ImportRe
 	}
 	
 	private boolean isLoadOnDemandEnabled() {
-		return Rf2ReleaseType.DELTA == type;
+		return Rf2ReleaseType.DELTA == releaseType;
 	}
 	
 	private void read(File rf2Archive, Rf2EffectiveTimeSlices slices, Rf2ValidationIssueReporter reporter) {
@@ -208,7 +208,7 @@ final class SnomedRf2ImportRequest implements Request<BranchContext, Rf2ImportRe
 			for (ZipEntry entry : Collections.list(zip.entries())) {
 				final String fileName = Paths.get(entry.getName()).getFileName().toString().toLowerCase();
 				if (fileName.endsWith(TXT_EXT)) {
-					if (fileName.contains(type.toString().toLowerCase())) {
+					if (fileName.contains(releaseType.toString().toLowerCase())) {
 						w.reset().start();
 						try (final InputStream in = zip.getInputStream(entry)) {
 							readFile(entry, in, oReader, slices, reporter);
@@ -248,7 +248,7 @@ final class SnomedRf2ImportRequest implements Request<BranchContext, Rf2ImportRe
 				
 				header = false;
 			} else {
-				if (Rf2ReleaseType.SNAPSHOT == type) {
+				if (Rf2ReleaseType.SNAPSHOT == releaseType) {
 					final String effectiveTime = Strings.isNullOrEmpty(line[1]) ? EffectiveTimes.UNSET_EFFECTIVE_TIME_LABEL : Rf2EffectiveTimeSlice.SNAPSHOT_SLICE;
 					resolver.register(line, effectiveTimeSlices.getOrCreate(effectiveTime), reporter);
 				} else {
@@ -270,7 +270,7 @@ final class SnomedRf2ImportRequest implements Request<BranchContext, Rf2ImportRe
 					.fileMmapPreclearDisable();
 			
 			// for non-delta releases increase the allocation size
-			if (type != Rf2ReleaseType.DELTA) {
+			if (releaseType != Rf2ReleaseType.DELTA) {
 				dbMaker = dbMaker
 					.allocateStartSize(256 * 1024*1024)  // 256MB
 				    .allocateIncrement(128 * 1024*1024);  // 128MB


### PR DESCRIPTION
This PR adds the ability to run the `effectiveTime` restore process during RF2 Delta imports.
This change will make sure that the `effectiveTime` field remains set to the proper latest released version `effectiveTime` even if an RF2 Delta import contains a row with the same properties but with the `effectiveTime` unset.