### PR TITLE
Path expressions not working

### DIFF
--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/version/VersioningRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/version/VersioningRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ public class VersioningRequest implements Request<TransactionContext, Boolean>, 
 				.description(config.getDescription())
 				.effectiveDate(config.getEffectiveTime().getTime())
 				.importDate(new Date().getTime())
-				.parentBranchPath(context.branchPath())
+				.parentBranchPath(context.path())
 				.versionId(config.getVersionId())
 				.codeSystemShortName(config.getCodeSystemShortName())
 				.repositoryUuid(context.id())

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/BranchContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/BranchContext.java
@@ -37,9 +37,8 @@ public interface BranchContext extends RepositoryContext {
 	 * returned by this method to other requests, so they execute on the same requested path.
 	 * 
 	 * @return
-	 * @since 5.9
 	 */
-	String branchPath();
+	String path();
 
 	@Override
 	default Builder<? extends BranchContext> inject() {
@@ -50,9 +49,9 @@ public interface BranchContext extends RepositoryContext {
 	 * @return <code>true</code> if this context is opened on the {@link Branch#MAIN_PATH}, <code>false</code> otherwise.
 	 */
 	default boolean isMain() {
-		return Branch.MAIN_PATH.equals(branchPath());
+		return Branch.MAIN_PATH.equals(branch().path());
 	}
-	
+
 	default TransactionContext openTransaction(BranchContext context) {
 		return openTransaction(context, DatastoreLockContextDescriptions.ROOT);
 	}
@@ -64,5 +63,5 @@ public interface BranchContext extends RepositoryContext {
 	default TransactionContext openTransaction(BranchContext context, String author, String commitComment, String parentLockContext) {
 		return new RepositoryTransactionContext(context, author, commitComment, parentLockContext);
 	}
-	
+
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/DelegatingBranchContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/DelegatingBranchContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,8 @@ public class DelegatingBranchContext extends DelegatingRepositoryContext impleme
 	}
 	
 	@Override
-	public String branchPath() {
-		return getDelegate().branchPath();
+	public String path() {
+		return getDelegate().path();
 	}
 	
 	@Override

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/RepositoryBranchContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/RepositoryBranchContext.java
@@ -24,10 +24,12 @@ import com.b2international.snowowl.core.branch.Branch;
  */
 public final class RepositoryBranchContext extends DelegatingRepositoryContext implements BranchContext {
 
+	private final String path;
 	private final Branch branch;
 
-	public RepositoryBranchContext(RepositoryContext context, Branch branch) {
+	public RepositoryBranchContext(RepositoryContext context, String path, Branch branch) {
 		super(context);
+		this.path = path;
 		this.branch = checkNotNull(branch, "branch");
 	}
 	
@@ -37,8 +39,9 @@ public final class RepositoryBranchContext extends DelegatingRepositoryContext i
 	}
 	
 	@Override
-	public String branchPath() {
-		return branch.path();
+	public String path() {
+		// XXX make sure we return the original path expression requested by the client 
+		return path;
 	}
 
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/RepositoryContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/RepositoryContext.java
@@ -57,23 +57,23 @@ public interface RepositoryContext extends ServiceProvider, RepositoryInfo {
 		return new DelegatingContext.Builder<>(RepositoryContext.class, this);
 	}
 	
-	default BranchContext openBranch(RepositoryContext context, String branch) {
-		return context.service(ContextConfigurer.class).configure(new RepositoryBranchContext(context, ensureAvailability(context, branch)));
+	default BranchContext openBranch(RepositoryContext context, String path) {
+		return context.service(ContextConfigurer.class).configure(new RepositoryBranchContext(context, path, ensureAvailability(context, path)));
 	}
 
-	private Branch ensureAvailability(RepositoryContext context, String branchPath) {
+	private Branch ensureAvailability(RepositoryContext context, String path) {
 		final List<String> branchesToCheck = newArrayList();
-		if (RevisionIndex.isBranchAtPath(branchPath)) {
-			branchesToCheck.add(branchPath.split(RevisionIndex.AT_CHAR)[0]);
-		} else if (RevisionIndex.isBaseRefPath(branchPath)) {
-			branchesToCheck.add(branchPath.substring(0, branchPath.length() - 1));
-		} else if (RevisionIndex.isRevRangePath(branchPath)) {
-			branchesToCheck.addAll(ImmutableList.copyOf(RevisionIndex.getRevisionRangePaths(branchPath)));
+		if (RevisionIndex.isBranchAtPath(path)) {
+			branchesToCheck.add(path.split(RevisionIndex.AT_CHAR)[0]);
+		} else if (RevisionIndex.isBaseRefPath(path)) {
+			branchesToCheck.add(path.substring(0, path.length() - 1));
+		} else if (RevisionIndex.isRevRangePath(path)) {
+			branchesToCheck.addAll(ImmutableList.copyOf(RevisionIndex.getRevisionRangePaths(path)));
 		} else {
-			branchesToCheck.add(branchPath);
+			branchesToCheck.add(path);
 		}
 		
-		Branch branch = null; 
+		Branch branch = null;
 		for (String branchToCheck : branchesToCheck) {
 			branch = RepositoryRequests.branching().prepareGet(branchToCheck).build().execute(context);
 			

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/Locks.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/Locks.java
@@ -49,7 +49,7 @@ public final class Locks implements AutoCloseable {
 			this.context = checkNotNull(context, "Context is missing");
 			this.user = context.service(User.class).getUsername();
 			if (context instanceof BranchContext) {
-				this.branches = List.of(((BranchContext) context).branchPath()); 
+				this.branches = List.of(((BranchContext) context).branch().path()); 
 			}
 		}
 		

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryTransactionContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryTransactionContext.java
@@ -59,7 +59,6 @@ import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.domain.DelegatingBranchContext;
 import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.core.exceptions.ComponentNotFoundException;
-import com.b2international.snowowl.core.id.IDs;
 import com.b2international.snowowl.core.identity.User;
 import com.b2international.snowowl.core.internal.locks.DatastoreLockContext;
 import com.b2international.snowowl.core.internal.locks.DatastoreLockContextDescriptions;
@@ -94,7 +93,7 @@ public final class RepositoryTransactionContext extends DelegatingBranchContext 
 		this.author = author;
 		this.commitComment = commitComment;
 		this.parentLockContext = parentLockContext;
-		this.staging = context.service(RevisionIndex.class).prepareCommit(branchPath()).withContext(this);
+		this.staging = context.service(RevisionIndex.class).prepareCommit(path()).withContext(this);
 		bind(StagingArea.class, this.staging);
 	}
 	
@@ -258,15 +257,15 @@ public final class RepositoryTransactionContext extends DelegatingBranchContext 
 			return -1L;
 		}
 		final DatastoreLockContext lockContext = createLockContext(userId, parentContextDescription);
-		final DatastoreLockTarget lockTarget = createLockTarget(id(), branchPath());
+		final DatastoreLockTarget lockTarget = createLockTarget(id(), path());
 		IOperationLockManager locks = service(IOperationLockManager.class);
 		Commit commit = null;
 		try {
 			acquireLock(locks, lockContext, lockTarget);
 			final long timestamp = service(TimestampProvider.class).getTimestamp();
-			log().info("Persisting changes to {}@{}", branchPath(), timestamp);
+			log().info("Persisting changes to {}@{}", path(), timestamp);
 			commit = staging.commit(null, timestamp, userId, commitComment);
-			log().info("Changes have been successfully persisted to {}@{}.", branchPath(), timestamp);
+			log().info("Changes have been successfully persisted to {}@{}.", path(), timestamp);
 			return commit.getTimestamp();
 		} catch (final IndexException e) {
 			Throwable rootCause = Throwables.getRootCause(e);

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/RevisionIndexReadRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/RevisionIndexReadRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ public final class RevisionIndexReadRequest<B> extends DelegatingRequest<BranchC
 	
 	@Override
 	public B execute(final BranchContext context) {
-		final String branchPath = context.branchPath();
+		final String branchPath = context.path();
 		RevisionIndex index = context.service(RevisionIndex.class);
 		if (snapshot) {
 			return index.read(branchPath, searcher -> {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/validation/ValidateRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/validation/ValidateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ final class ValidateRequest implements Request<BranchContext, ValidationResult>,
 	}
 	
 	private ValidationResult doValidate(BranchContext context, Writer index) throws IOException {
-		final String branchPath = context.branchPath();
+		final String branchPath = context.path();
 		ValidationRuleSearchRequestBuilder req = ValidationRequests.rules().prepareSearch();
 
 		if (!CompareUtils.isEmpty(ruleIds)) {
@@ -225,7 +225,7 @@ final class ValidateRequest implements Request<BranchContext, ValidationResult>,
 		}
 		
 		// TODO return ValidationResult object with status and new issue IDs as set
-		return new ValidationResult(context.id(), context.branchPath());
+		return new ValidationResult(context.id(), context.path());
 	}
 
 	private Multimap<String, ComponentIdentifier> fetchWhiteListEntries(BranchContext context, final Set<String> ruleIds) {

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/branch/BranchCompareRequestTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/branch/BranchCompareRequestTest.java
@@ -19,6 +19,7 @@ import static com.b2international.snowowl.snomed.core.rest.SnomedComponentRestRe
 import static com.b2international.snowowl.snomed.core.rest.SnomedRestFixtures.createNewConcept;
 import static com.google.common.collect.Sets.newHashSet;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Set;
 
@@ -26,6 +27,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import com.b2international.index.revision.RevisionIndex;
 import com.b2international.snowowl.core.ComponentIdentifier;
 import com.b2international.snowowl.core.api.IBranchPath;
 import com.b2international.snowowl.core.branch.Branch;
@@ -143,6 +145,24 @@ public class BranchCompareRequestTest {
 		assertThat(compare.getNewComponents()).isEmpty();
 		assertThat(compare.getChangedComponents()).isEmpty();
 		assertThat(compare.getDeletedComponents()).containsAll(componentIdsToDelete);
+		
+		assertTrue("branchPath^ expression search should return the original concept state", SnomedRequests.prepareSearchConcept()
+			.one()
+			.filterById(concept.getComponentId())
+			.build(REPOSITORY_ID, taskBranchPath + RevisionIndex.BASE_REF_CHAR)
+			.execute(bus)
+			.getSync()
+			.first()
+			.isPresent());
+		
+		assertTrue("branchPath expression search should return nothing", SnomedRequests.prepareSearchConcept()
+			.one()
+			.filterById(concept.getComponentId())
+			.build(REPOSITORY_ID, taskBranchPath)
+			.execute(bus)
+			.getSync()
+			.first()
+			.isEmpty());
 	}
 	
 	@Test

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/branch/SnomedBranchRequestTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/branch/SnomedBranchRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,9 +64,6 @@ import com.google.common.collect.ImmutableMap;
 public class SnomedBranchRequestTest {
 
 	private static final String REPOSITORY_ID = SnomedDatastoreActivator.REPOSITORY_UUID;
-	
-//	private static final long POLL_TIMEOUT = TimeUnit.SECONDS.toMillis(30L);
-//	private static final long POLL_INTERVAL = TimeUnit.SECONDS.toMillis(1L);
 	
 	@Rule
 	public TestMethodNameRule methodName = new TestMethodNameRule(); 

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/branches/SnomedMergeApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/branches/SnomedMergeApiTest.java
@@ -801,7 +801,7 @@ public class SnomedMergeApiTest extends AbstractSnomedApiTest {
 		// rebase child branch with deletion over new relationship, this should succeed, but should also implicitly delete the relationship
 		merge(branchPath, a, "Rebased concept deletion over new inbound relationship").body("status", equalTo(Merge.Status.CONFLICTS.name()));
 		
-		// TODO when new conflict 
+		// TODO when new conflict??? 
 //		// relationships should be deleted along with the already deleted destination concept
 //		getComponent(a, SnomedComponentType.RELATIONSHIP, newInboundRelationshipToDeletedConcept).statusCode(404);
 	}
@@ -825,7 +825,7 @@ public class SnomedMergeApiTest extends AbstractSnomedApiTest {
 		// rebase child branch with deletion over new relationship, this should succeed, but should also implicitly delete the relationship
 		merge(branchPath, a, "Rebased concept deletion over new outbound and inbound relationships").body("status", equalTo(Merge.Status.CONFLICTS.name()));
 		
-		// when new conflict processing rules are in place enable
+		// when new conflict processing rules are in place enable???
 //		// relationships should be deleted along with the already deleted destination concept
 //		getComponent(a, SnomedComponentType.RELATIONSHIP, newOutboundRelationshipFromDeletedConcept).statusCode(404);
 //		getComponent(a, SnomedComponentType.RELATIONSHIP, newInboundRelationshipToDeletedConcept).statusCode(404);

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/EclExpression.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/EclExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ public final class EclExpression {
 			conceptPromise = SnomedRequests.prepareSearchConcept()
 					.all()
 					.filterByEcl(ecl)
-					.build(context.id(), context.branchPath())
+					.build(context.id(), context.path())
 					.execute(context.service(IEventBus.class));
 		}
 		return conceptPromise;
@@ -174,7 +174,7 @@ public final class EclExpression {
 				.filterByGroup(1, Integer.MAX_VALUE)
 				.setEclExpressionForm(expressionForm)
 				.setFields(SnomedRelationshipIndexEntry.Fields.ID, SnomedRelationshipIndexEntry.Fields.SOURCE_ID, SnomedRelationshipIndexEntry.Fields.GROUP)
-				.build(context.id(), context.branchPath())
+				.build(context.id(), context.path())
 				.execute(context.service(IEventBus.class))
 				.then(new Function<SnomedRelationships, Multimap<String, Integer>>() {
 					@Override
@@ -202,7 +202,7 @@ public final class EclExpression {
 					.filterByRefSetType(SnomedRefSetType.CONCRETE_DATA_TYPE)
 					.filterByProps(propFilter)
 					.setEclExpressionForm(expressionForm)
-					.build(context.id(), context.branchPath())
+					.build(context.id(), context.path())
 					.execute(context.service(IEventBus.class))
 					.then(members -> {
 						final Multimap<String, SnomedReferenceSetMember> relationshipsBySource = Multimaps.index(members, m -> m.getReferencedComponent().getId());

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclRefinementEvaluator.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclRefinementEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -500,7 +500,7 @@ final class SnomedEclRefinementEvaluator {
 		
 		// TODO: does this request need to support filtering by group?
 		return requestBuilder
-			.build(context.id(), context.branchPath())
+			.build(context.id(), context.path())
 			.execute(context.service(IEventBus.class));
 	}
 
@@ -599,7 +599,7 @@ final class SnomedEclRefinementEvaluator {
 			searchRelationships.filterByGroup(1, Integer.MAX_VALUE);
 		}
 		
-		Promise<Collection<Property>> relationshipSearch = searchRelationships.build(context.id(), context.branchPath())
+		Promise<Collection<Property>> relationshipSearch = searchRelationships.build(context.id(), context.path())
 			.execute(context.service(IEventBus.class))
 			.then(input -> input.stream().map(r -> new Property(r.getSourceId(), r.getTypeId(), r.getDestinationId(), r.getGroup())).collect(Collectors.toSet()));
 		

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/SnomedRf2ExportRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/SnomedRf2ExportRequest.java
@@ -227,7 +227,7 @@ final class SnomedRf2ExportRequest extends ResourceRequest<BranchContext, Export
 	
 	@Override
 	public ExportResult execute(final BranchContext context) {
-		final String referenceBranch = context.branchPath();
+		final String referenceBranch = context.path();
 		
 		// register export start time for later use
 		final long exportStartTime = Instant.now().toEpochMilli();
@@ -308,7 +308,7 @@ final class SnomedRf2ExportRequest extends ResourceRequest<BranchContext, Export
 	}
 
 	private Multimap<String, String> getLanguageCodes(BranchContext context, List<String> branchesToExport) {
-		final String referenceBranch = context.branchPath();
+		final String referenceBranch = context.path();
 		
 		List<String> branchesOrRanges = newArrayList(branchesToExport);
 		
@@ -522,7 +522,7 @@ final class SnomedRf2ExportRequest extends ResourceRequest<BranchContext, Export
 	}
 
 	private TreeSet<CodeSystemVersionEntry> getAllExportableCodeSystemVersions(final BranchContext context, final CodeSystemEntry codeSystemEntry) {
-		final String referenceBranch = context.branchPath();
+		final String referenceBranch = context.path();
 		final TreeSet<CodeSystemVersionEntry> visibleVersions = newTreeSet(EFFECTIVE_DATE_ORDERING);
 		collectExportableCodeSystemVersions(context, visibleVersions, codeSystemEntry, referenceBranch);
 		return visibleVersions;

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/SnomedRf2ImportRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/SnomedRf2ImportRequest.java
@@ -143,7 +143,7 @@ final class SnomedRf2ImportRequest implements Request<BranchContext, Rf2ImportRe
 	}
 
 	Rf2ImportResponse doImport(final BranchContext context, final File rf2Archive, final Rf2ImportConfiguration importconfig) throws Exception {
-		final String codeSystem = context.service(RepositoryCodeSystemProvider.class).get(context.branchPath()).getShortName();
+		final String codeSystem = context.service(RepositoryCodeSystemProvider.class).get(context.branch().path()).getShortName();
 		final Rf2ValidationIssueReporter reporter = new Rf2ValidationIssueReporter();
 		final Rf2ImportResponse response = new Rf2ImportResponse();
 		

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/OntologyExportRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/OntologyExportRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,7 +149,7 @@ final class OntologyExportRequest implements Request<BranchContext, String>, Bra
 	}
 
 	private OntologyException createExportFailedException(final BranchContext context, final Throwable e) {
-		return new OntologyException("Couldn't save ontology with module ID '" + ontologyModuleId + "' on branch '" + context.branchPath() + "'.", e);
+		return new OntologyException("Couldn't save ontology with module ID '" + ontologyModuleId + "' on branch '" + context.path() + "'.", e);
 	}
 
 	private OWLDocumentFormat getOWLDocumentFormat() {

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/SaveJobRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/SaveJobRequest.java
@@ -164,7 +164,7 @@ final class SaveJobRequest implements Request<BranchContext, Boolean>, BranchAcc
 		} catch (final Exception e) {
 			LOG.error("Unexpected error while persisting classification changes.", e);
 			tracker.classificationSaveFailed(classificationId);
-			throw new ReasonerApiException("Error while persisting classification changes on '%s'.", context.branchPath(), e);
+			throw new ReasonerApiException("Error while persisting classification changes on '%s'.", context.path(), e);
 		} finally {
 			monitor.done();
 		}

--- a/tests/com.b2international.snowowl.test.commons/src/com/b2international/snowowl/test/commons/snomed/TestBranchContext.java
+++ b/tests/com.b2international.snowowl.test.commons/src/com/b2international/snowowl/test/commons/snomed/TestBranchContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public final class TestBranchContext extends DelegatingContext implements Branch
 	}
 	
 	@Override
-	public String branchPath() {
+	public String path() {
 		return branch.path();
 	}
 	


### PR DESCRIPTION
This PR fixes the broken path expression support in the latest 7.5.0 release.
Now `branch^`, `branch@timestamp` and `branchA...branchB` expressions should work on all API routes again.