### PR TITLE
INFRA-42: Shrink size of Snow Owl OSS docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,39 +1,41 @@
-FROM centos:7
+FROM b2ihealthcare/centos:7 AS builder
 
-ARG SNOWOWL_RPM_PACKAGE
+ARG SNOWOWL_INSTALL_PACKAGE
+
+RUN groupadd -g 1000 snowowl && \
+    adduser -u 1000 -g 1000 -d /usr/share/snowowl snowowl
+
+WORKDIR /usr/share/snowowl
+
+COPY ${SNOWOWL_INSTALL_PACKAGE} ${SNOWOWL_INSTALL_PACKAGE}
+RUN tar zxf ${SNOWOWL_INSTALL_PACKAGE} --strip-components=1 && rm -f ${SNOWOWL_INSTALL_PACKAGE}
+RUN chmod 0775 configuration resources serviceability
+COPY config/snowowl.yml configuration/
+RUN chmod 0660 configuration/snowowl.yml
+
+FROM b2ihealthcare/centos:7
+
 ARG BUILD_TIMESTAMP
 ARG VERSION
 ARG GIT_REVISION
-
-# Install java-11-openjdk as a pre requirement
-RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
-    yum update --setopt=tsflags=nodocs -y -q -e 0 && \
-    yum install --setopt=tsflags=nodocs -y -q -e 0 java-11-openjdk && \
-    yum clean all
-
-# Set JAVA_HOME environment variable
-ENV JAVA_HOME /etc/alternatives/jre
 
 RUN groupadd -g 1000 snowowl && \
     adduser -u 1000 -g 1000 -G 0 -d /usr/share/snowowl snowowl && \
     chmod 0775 /usr/share/snowowl && \
     chgrp 0 /usr/share/snowowl
 
-# Install Snow Owl rpm package
 WORKDIR /usr/share/snowowl
-COPY ${SNOWOWL_RPM_PACKAGE} ${SNOWOWL_RPM_PACKAGE}
-RUN rpm --install ${SNOWOWL_RPM_PACKAGE} && rm -f ${SNOWOWL_RPM_PACKAGE}
+COPY --from=builder --chown=1000:0 /usr/share/snowowl /usr/share/snowowl
+RUN ln -s /usr/share/snowowl/configuration /etc/snowowl && \
+    ln -s /usr/share/snowowl/resources /var/lib/snowowl && \
+    ln -s /usr/share/snowowl/serviceability /var/log/snowowl
 
-COPY --chown=1000:0 config/snowowl.yml /usr/share/snowowl/configuration/snowowl.yml
-COPY --chown=1000:0 bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
-# Openshift overrides USER and uses ones with randomly uid>1024 and gid=0
-# Allow ENTRYPOINT (and SO) to run even with a different user
-RUN chgrp 0 /usr/local/bin/docker-entrypoint.sh && \
-    chmod g=u /etc/passwd && \
+RUN chmod g=u /etc/passwd && \
     chmod 0775 /usr/local/bin/docker-entrypoint.sh
 
-# Expose necessary ports used by Snow OWl
+# Expose necessary ports used by Snow Owl
 EXPOSE 2036 8080
 
 LABEL org.label-schema.build-date="${BUILD_TIMESTAMP}" \
@@ -55,6 +57,8 @@ LABEL org.label-schema.build-date="${BUILD_TIMESTAMP}" \
   org.opencontainers.image.documentation="https://docs.b2i.sg/snow-owl" \
   org.opencontainers.image.source="https://github.com/b2ihealthcare/snow-owl" \
   org.opencontainers.image.vendor="B2i Healthcare"
+
+USER snowowl:root
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 # Dummy overridable parameter parsed by entrypoint

--- a/docker/bin/docker-entrypoint.sh
+++ b/docker/bin/docker-entrypoint.sh
@@ -11,17 +11,4 @@ if [[ "$1" != "sowrapper" ]]; then
 	exec "$@"
 fi
 
-if [[ "$(id -u)" == "0" ]]; then
-
-	# If running as root, mutate the ownership of bind-mounts
-	chown -HR 1000:0 /var/log/snowowl
-	chown -HR 1000:0 /var/lib/snowowl
-	chown -HR 1000:0 /etc/snowowl
-
-	exec chroot --userspec=1000 / /usr/share/snowowl/bin/snowowl.sh
-
-else
-
-	exec /usr/share/snowowl/bin/snowowl.sh
-
-fi
+exec /usr/share/snowowl/bin/snowowl.sh


### PR DESCRIPTION
- use prebuilt CentOS 7 image as a base. The base image comes with daily package updates and AdoptOpenJDK11 pre-installed
- use multistage build to get rid of install layers
- use simple tar.gz artifact to extract and install Snow Owl
- set explicit user and group ID
- removed enforced ownership mutation in case of bind-mounts. It is now the responsibility of the user to setup necessary permissions for log, data and configuration dirs.