### PR TITLE
Add missing Swagger Docs alternate type rules

### DIFF
--- a/commons/com.b2international.commons.base/src/com/b2international/commons/http/ExtendedLocale.java
+++ b/commons/com.b2international.commons.base/src/com/b2international/commons/http/ExtendedLocale.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.Strings;
 
@@ -36,6 +37,7 @@ public final class ExtendedLocale implements Serializable {
 	
 	private static final Pattern EXTENDED_LOCALE_PATTERN = Pattern.compile("([a-zA-Z]{2})(-([a-zA-Z]{2}))?(-x-([1-9][0-9]{5,17}))?");
 
+	@JsonCreator
 	public static ExtendedLocale valueOf(String input) {
 		final Matcher matcher = EXTENDED_LOCALE_PATTERN.matcher(input);
 		if (matcher.matches()) {

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/BaseApiConfig.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/BaseApiConfig.java
@@ -19,6 +19,7 @@ import static springfox.documentation.schema.AlternateTypeRules.newRule;
 
 import java.security.Principal;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.context.annotation.Bean;
@@ -28,7 +29,9 @@ import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 
+import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.snowowl.core.events.util.Promise;
+import com.b2international.snowowl.core.uri.CodeSystemURI;
 import com.fasterxml.classmate.TypeResolver;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
@@ -116,6 +119,16 @@ public abstract class BaseApiConfig {
 				.ignoredParameterTypes(Principal.class)
 				.alternateTypeRules(
 					newRule(resolver.resolve(UUID.class), resolver.resolve(String.class)),
+					newRule(resolver.resolve(CodeSystemURI.class), resolver.resolve(String.class)),
+					newRule(resolver.resolve(ExtendedLocale.class), resolver.resolve(String.class)),
+					newRule(
+						resolver.resolve(List.class, resolver.resolve(CodeSystemURI.class)),
+						resolver.resolve(List.class, resolver.resolve(String.class))
+			        ),
+					newRule(
+						resolver.resolve(List.class, resolver.resolve(ExtendedLocale.class)),
+						resolver.resolve(List.class, resolver.resolve(String.class))
+			        ),
 					newRule(
 						resolver.resolve(Promise.class, WildcardType.class),
 			            resolver.resolve(WildcardType.class)


### PR DESCRIPTION
CodeSystemURI -> String
ExtendedLocale -> String
List<CodeSystemURI> -> List<String>
List<ExtendedLocale> -> List<String>