### PR TITLE
SO-4092: fix special search key pattern matching error

### DIFF
--- a/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/request/SearchResourceRequestTest.java
+++ b/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/request/SearchResourceRequestTest.java
@@ -106,4 +106,15 @@ public class SearchResourceRequestTest {
 				.build(), actual);
 	}
 	
+	@Test
+	public void specialOptionKeyWithExtraParenthesis() throws Exception {
+		final Options options = Options.builder()
+				.put(OptionKey.SPECIAL, "@field(value (extra))")
+				.build();
+		final Options actual = SearchResourceRequest.processSpecialOptionKey(options, OptionKey.SPECIAL);
+		assertEquals(Options.builder()
+				.put("FIELD", "value (extra)")
+				.build(), actual);
+	}
+	
 }


### PR DESCRIPTION
Use simple String manipulation instead of regex when parsing a special
option key's value for field and value instances.

Example search string that fails with the old pattern matcher: `@ecl(123123 (finding))`