### PR TITLE
SO-4081: add shortcuts to ECL evaluator

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequestTest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequestTest.java
@@ -355,30 +355,21 @@ public class SnomedEclEvaluationRequestTest extends BaseRevisionIndexTest {
 	@Test
 	public void selfAndOther() throws Exception {
 		final Expression actual = eval(ROOT_ID + " AND " + OTHER_ID);
-		final Expression expected = Expressions.builder()
-				.filter(id(ROOT_ID))
-				.filter(id(OTHER_ID))
-				.build();
+		final Expression expected = Expressions.matchNone();
 		assertEquals(expected, actual);
 	}
 	
 	@Test
 	public void selfAndOtherWithCommaAsOperator() throws Exception {
 		final Expression actual = eval(ROOT_ID + " , " + OTHER_ID);
-		final Expression expected = Expressions.builder()
-				.filter(id(ROOT_ID))
-				.filter(id(OTHER_ID))
-				.build();
+		final Expression expected = Expressions.matchNone();
 		assertEquals(expected, actual);
 	}
 	
 	@Test
 	public void selfOrOther() throws Exception {
 		final Expression actual = eval(ROOT_ID + " OR " + OTHER_ID);
-		final Expression expected = Expressions.builder()
-				.should(id(ROOT_ID))
-				.should(id(OTHER_ID))
-				.build();
+		final Expression expected = ids(ImmutableSet.of(ROOT_ID, OTHER_ID));
 		assertEquals(expected, actual);
 	}
 	

--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclShortcutTest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclShortcutTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.snomed.core.ecl;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.eclipse.xtext.parser.IParser;
+import org.eclipse.xtext.serializer.ISerializer;
+import org.eclipse.xtext.validation.IResourceValidator;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.b2international.collections.PrimitiveCollectionModule;
+import com.b2international.index.Index;
+import com.b2international.index.query.Expression;
+import com.b2international.index.query.Expressions;
+import com.b2international.index.revision.BaseRevisionIndexTest;
+import com.b2international.index.revision.RevisionIndex;
+import com.b2international.snowowl.core.domain.BranchContext;
+import com.b2international.snowowl.core.request.RevisionIndexReadRequest;
+import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
+import com.b2international.snowowl.snomed.core.tree.Trees;
+import com.b2international.snowowl.snomed.datastore.config.SnomedCoreConfiguration;
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument;
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedDescriptionIndexEntry;
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedRefSetMemberIndexEntry;
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedRelationshipIndexEntry;
+import com.b2international.snowowl.snomed.datastore.request.SnomedRequests;
+import com.b2international.snowowl.snomed.ecl.Ecl;
+import com.b2international.snowowl.snomed.ecl.EclStandaloneSetup;
+import com.b2international.snowowl.test.commons.snomed.TestBranchContext;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Injector;
+
+/**
+ * @since 7.7
+ */
+public class SnomedEclShortcutTest extends BaseRevisionIndexTest {
+
+	private static final Injector INJECTOR = new EclStandaloneSetup().createInjectorAndDoEMFRegistration();
+	
+	private static final String ROOT_ID = Concepts.ROOT_CONCEPT;
+	
+	private BranchContext context;
+	
+	@Override
+	protected void configureMapper(ObjectMapper mapper) {
+		super.configureMapper(mapper);
+		mapper.setSerializationInclusion(Include.NON_NULL);
+		mapper.registerModule(new PrimitiveCollectionModule());
+	}
+	
+	@Before
+	public void setup() {
+		SnomedCoreConfiguration config = new SnomedCoreConfiguration();
+		config.setConcreteDomainSupported(true);
+		
+		context = TestBranchContext.on(MAIN)
+				.with(EclParser.class, new DefaultEclParser(INJECTOR.getInstance(IParser.class), INJECTOR.getInstance(IResourceValidator.class)))
+				.with(EclSerializer.class, new DefaultEclSerializer(INJECTOR.getInstance(ISerializer.class)))
+				.with(Index.class, rawIndex())
+				.with(RevisionIndex.class, index())
+				.with(SnomedCoreConfiguration.class, config)
+				.build();
+	}
+	
+	@Override
+	protected Collection<Class<?>> getTypes() {
+		return ImmutableSet.of(SnomedConceptDocument.class, SnomedDescriptionIndexEntry.class, SnomedRelationshipIndexEntry.class, SnomedRefSetMemberIndexEntry.class);
+	}
+	
+	private Expression eval(String expression) {
+		return new RevisionIndexReadRequest<>(SnomedRequests.prepareEclEvaluation(expression)
+				.setExpressionForm(Trees.INFERRED_FORM)
+				.build())
+				.execute(context)
+				.getSync();
+	}
+	
+	@Test
+	public void queryMinusAll() throws Exception {
+		final Expression actual = eval(ROOT_ID + " MINUS *");
+		final Expression expected = Expressions.matchNone();
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void queryMinusNestedAll() throws Exception {
+		final Expression actual = eval(ROOT_ID + " MINUS (*)");
+		final Expression expected = Expressions.matchNone();
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void queryOrAll() throws Exception {
+		final Expression actual = eval(ROOT_ID + " OR *");
+		final Expression expected = Expressions.matchAll();
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void queryAndAll() throws Exception {
+		final Expression actual = eval(ROOT_ID + " AND *");
+		final Expression expected = SnomedConceptDocument.Expressions.id(ROOT_ID);
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void queryAndNestedAll() throws Exception {
+		final Expression actual = eval(ROOT_ID + " AND (*)");
+		final Expression expected = SnomedConceptDocument.Expressions.id(ROOT_ID);
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void idsOnlyOrExpression() throws Exception {
+		final Set<String> ids = ImmutableSet.of(ROOT_ID, Concepts.ABBREVIATION, Concepts.ACCEPTABILITY, Concepts.AMBIGUOUS);
+		final Expression actual = eval(Ecl.or(ids));
+		final Expression expected = SnomedConceptDocument.Expressions.ids(ids);
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void idsOnlyAndExpression() throws Exception {
+		final Set<String> ids = ImmutableSet.of(ROOT_ID, Concepts.ABBREVIATION, Concepts.ACCEPTABILITY, Concepts.AMBIGUOUS);
+		final Expression actual = eval(Ecl.and(ids));
+		final Expression expected = Expressions.matchNone();
+		assertEquals(expected, actual);
+	}
+	
+}

--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/datastore/AllSnomedDatastoreTests.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/datastore/AllSnomedDatastoreTests.java
@@ -21,6 +21,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import com.b2international.snowowl.snomed.core.ecl.SnomedEclEvaluationRequestTest;
 import com.b2international.snowowl.snomed.core.ecl.SnomedEclRewriterTest;
+import com.b2international.snowowl.snomed.core.ecl.SnomedEclShortcutTest;
 import com.b2international.snowowl.snomed.core.ecl.SnomedStatedEclEvaluationTest;
 import com.b2international.snowowl.snomed.core.ql.SnomedQueryEvaluationRequestTest;
 import com.b2international.snowowl.snomed.core.ql.SnomedQueryLabelerRequestTest;
@@ -75,7 +76,8 @@ import com.b2international.snowowl.snomed.validation.SnomedQueryValidationRuleEv
 	// QL test cases
 	SnomedQueryEvaluationRequestTest.class,
 	SnomedQueryValidationRuleEvaluatorTest.class,
-	SnomedQueryLabelerRequestTest.class
+	SnomedQueryLabelerRequestTest.class,
+	SnomedEclShortcutTest.class
 })
 public class AllSnomedDatastoreTests {
 

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptSearchRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptSearchRequest.java
@@ -186,17 +186,32 @@ public class SnomedConceptSearchRequest extends SnomedComponentSearchRequest<Sno
 
 		if (containsKey(OptionKey.ECL)) {
 			final String ecl = getString(OptionKey.ECL);
-			queryBuilder.filter(EclExpression.of(ecl, Trees.INFERRED_FORM).resolveToExpression(context).getSync(3, TimeUnit.MINUTES));
+			Expression eclExpression = EclExpression.of(ecl, Trees.INFERRED_FORM).resolveToExpression(context).getSync(3, TimeUnit.MINUTES);
+			if (eclExpression.isMatchNone()) {
+				throw new NoResultException();
+			} else if (!eclExpression.isMatchAll()) {
+				queryBuilder.filter(eclExpression);
+			}
 		}
 		
 		if (containsKey(OptionKey.STATED_ECL)) {
 			final String ecl = getString(OptionKey.STATED_ECL);
-			queryBuilder.filter(EclExpression.of(ecl, Trees.STATED_FORM).resolveToExpression(context).getSync(3, TimeUnit.MINUTES));
+			Expression statedEclExpression = EclExpression.of(ecl, Trees.STATED_FORM).resolveToExpression(context).getSync(3, TimeUnit.MINUTES);
+			if (statedEclExpression.isMatchNone()) {
+				throw new NoResultException();
+			} else if (!statedEclExpression.isMatchAll()) {
+				queryBuilder.filter(statedEclExpression);
+			}
 		}
 		
 		if (containsKey(OptionKey.QUERY)) {
 			final String ql = getString(OptionKey.QUERY);
-			queryBuilder.filter(SnomedQueryExpression.of(ql).resolveToExpression(context).getSync(3, TimeUnit.MINUTES));
+			Expression queryExpression = SnomedQueryExpression.of(ql).resolveToExpression(context).getSync(3, TimeUnit.MINUTES);
+			if (queryExpression.isMatchNone()) {
+				throw new NoResultException();
+			} else if (!queryExpression.isMatchAll()) {
+				queryBuilder.filter(queryExpression);
+			}
 		}
 		
 		Expression searchProfileQuery = null;

--- a/snomed/com.b2international.snowowl.snomed.ecl/src/com/b2international/snowowl/snomed/ecl/Ecl.java
+++ b/snomed/com.b2international.snowowl.snomed.ecl/src/com/b2international/snowowl/snomed/ecl/Ecl.java
@@ -27,6 +27,7 @@ public final class Ecl {
 	public static final String ANY = "*";
 	public static final int MAX_CARDINALITY = -1;
 	public static final Joiner OR_JOINER = Joiner.on(" OR ");
+	public static final Joiner AND_JOINER = Joiner.on(",");
 	
 	private Ecl() {}
 
@@ -37,9 +38,17 @@ public final class Ecl {
 	public static String or(Collection<String> eclExpressions) {
 		return OR_JOINER.join(eclExpressions);
 	}
+	
+	public static String and(String...eclExpressions) {
+		return AND_JOINER.join(eclExpressions);
+	}
+	
+	public static String and(Collection<String> eclExpressions) {
+		return AND_JOINER.join(eclExpressions);
+	}
 
 	public static String exclude(String from, String exclusion) {
 		return String.format("(%s) MINUS (%s)", from, exclusion);
 	}
-	
+
 }

--- a/snomed/com.b2international.snowowl.snomed.ecl/src/com/b2international/snowowl/snomed/ecl/Ecl.java
+++ b/snomed/com.b2international.snowowl.snomed.ecl/src/com/b2international/snowowl/snomed/ecl/Ecl.java
@@ -27,7 +27,7 @@ public final class Ecl {
 	public static final String ANY = "*";
 	public static final int MAX_CARDINALITY = -1;
 	public static final Joiner OR_JOINER = Joiner.on(" OR ");
-	public static final Joiner AND_JOINER = Joiner.on(",");
+	public static final Joiner AND_JOINER = Joiner.on(" AND ");
 	
 	private Ecl() {}
 


### PR DESCRIPTION
ID1 OR ID2 OR IDN will result in flattenned ids(ID1, ID2, IDN)
expression (even when using parens).
ID1 AND ID2 AND IDN will result in match NONE expression (even when
using parens).
X MINUS * will resultl in match NONE expression (even when using
parens).
`<`,`<<`,`<!`,`>`,`>>`,`>!`,`^` operators now detect if an any
expression is wrapped in parenthesis (eg. `<(*)`).