### PR TITLE
Branch rebase/merge missing content issue

### DIFF
--- a/commons/com.b2international.index.tests.tools/src/com/b2international/index/revision/BaseRevisionIndexTest.java
+++ b/commons/com.b2international.index.tests.tools/src/com/b2international/index/revision/BaseRevisionIndexTest.java
@@ -33,8 +33,6 @@ import com.b2international.commons.options.MetadataImpl;
 import com.b2international.index.Hits;
 import com.b2international.index.Index;
 import com.b2international.index.IndexResource;
-import com.b2international.index.IndexClient;
-import com.b2international.index.Indexes;
 import com.b2international.index.WithScore;
 import com.b2international.index.mapping.DocumentMapping;
 import com.b2international.index.query.Query;
@@ -130,12 +128,11 @@ public abstract class BaseRevisionIndexTest {
 		commit(branchPath, Arrays.asList(revisions));
 	}
 	
-	protected final void indexChange(final String branchPath, final Revision oldRevision, final Revision newRevision) {
+	protected final Commit indexChange(final String branchPath, final Revision oldRevision, final Revision newRevision) {
 		final long commitTimestamp = currentTime();
-		index().prepareCommit(branchPath)
+		return index().prepareCommit(branchPath)
 			.stageChange(oldRevision, newRevision)
-			.commit(commitTimestamp, UUID.randomUUID().toString(), "Commit")
-			.getTimestamp();
+			.commit(commitTimestamp, UUID.randomUUID().toString(), "Commit");
 	}
 	
 	protected final void indexRemove(final String branchPath, final Revision...removedRevisions) {
@@ -143,17 +140,14 @@ public abstract class BaseRevisionIndexTest {
 		StagingArea staging = index().prepareCommit(branchPath);
 		Arrays.asList(removedRevisions).forEach(staging::stageRemove);
 		staging
-			.commit(commitTimestamp, UUID.randomUUID().toString(), "Commit")
-			.getTimestamp();
+			.commit(commitTimestamp, UUID.randomUUID().toString(), "Commit");
 	}
 
-	protected final long commit(final String branchPath, final Collection<Revision> newRevisions) {
+	protected final Commit commit(final String branchPath, final Iterable<? extends Revision> newRevisions) {
 		final long commitTimestamp = currentTime();
 		StagingArea staging = index().prepareCommit(branchPath);
 		newRevisions.forEach(rev -> staging.stageNew(rev.getId(), rev));
-		return staging
-				.commit(commitTimestamp, UUID.randomUUID().toString(), "Commit")
-				.getTimestamp();
+		return staging.commit(commitTimestamp, UUID.randomUUID().toString(), "Commit");
 	}
 	
 	protected final void deleteRevision(final String branchPath, final Class<? extends Revision> type, final String key) {

--- a/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchAtTimestampQueryTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchAtTimestampQueryTest.java
@@ -61,8 +61,8 @@ public class RevisionBranchAtTimestampQueryTest extends BaseRevisionIndexTest {
 		final RevisionData rev1 = new RevisionData(STORAGE_KEY1, "field1", "field2");
 		final RevisionData rev2 = new RevisionData(STORAGE_KEY1, "field1Changed", "field2");
 		
-		long commit1 = commit(MAIN, Collections.singleton(rev1));
-		long commit2 = commit(MAIN, Collections.singleton(rev2));
+		long commit1 = commit(MAIN, Collections.singleton(rev1)).getTimestamp();
+		long commit2 = commit(MAIN, Collections.singleton(rev2)).getTimestamp();;
 		
 		assertDocEquals(rev2, getRevision(MAIN, RevisionData.class, STORAGE_KEY1));
 		assertDocEquals(rev1, getRevision("MAIN@"+commit1, RevisionData.class, STORAGE_KEY1));

--- a/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchMergeTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchMergeTest.java
@@ -15,12 +15,16 @@
  */
 package com.b2international.index.revision;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 
+import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.runners.MethodSorters;
 
 import com.b2international.commons.exceptions.BadRequestException;
 import com.b2international.index.revision.RevisionBranch.BranchState;
@@ -30,6 +34,7 @@ import com.google.common.collect.ImmutableList;
 /**
  * @since 7.0
  */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class RevisionBranchMergeTest extends BaseRevisionIndexTest {
 
 	private static final RevisionData NEW_DATA = new RevisionData(STORAGE_KEY1, "field1", "field2");
@@ -49,7 +54,7 @@ public class RevisionBranchMergeTest extends BaseRevisionIndexTest {
 	@Test
 	public void behindStateAfterParentCommit() throws Exception {
 		final String a = createBranch(MAIN, "a");
-		commit(MAIN, Collections.emptySet());
+		commit(MAIN, List.of(NEW_DATA));
 		assertState(a, MAIN, BranchState.BEHIND);
 	}
 	
@@ -80,25 +85,7 @@ public class RevisionBranchMergeTest extends BaseRevisionIndexTest {
 	}
 	
 	@Test
-	public void fastForwardMergeBranchWithNewRevisionToParent() throws Exception {
-		String child = createBranch(MAIN, "a");
-		// create a revision on child branch
-		indexRevision(child, NEW_DATA);
-		// after commit child branch becomes FORWARD
-		assertState(child, MAIN, BranchState.FORWARD);
-		// do the merge
-		branching().prepareMerge(child, MAIN).merge();
-		// after fast-forward merge
-		// 1. MAIN should be in UP_TO_DATE state compared to the child
-		assertState(MAIN, child, BranchState.UP_TO_DATE);
-		// 2. Child should be UP_TO_DATE state compared to the MAIN
-		assertState(child, MAIN, BranchState.UP_TO_DATE);
-		// 3. revision should be visible from MAIN branch
-		assertNotNull(getRevision(MAIN, RevisionData.class, STORAGE_KEY1));
-	}
-	
-	@Test
-	public void forwardMergeBranchExcludeAddition() throws Exception {
+	public void mergeExcludeNew() throws Exception {
 		String child = createBranch(MAIN, "a");
 		// create a revisions on child branch
 		indexRevision(child, NEW_DATA);
@@ -125,7 +112,7 @@ public class RevisionBranchMergeTest extends BaseRevisionIndexTest {
 	}
 	
 	@Test
-	public void forwardMergeBranchExcludeChange() throws Exception {
+	public void mergeExcludeChange() throws Exception {
 		indexRevision(MAIN, NEW_DATA);
 		indexRevision(MAIN, NEW_DATA2);
 		String child = createBranch(MAIN, "a");
@@ -153,7 +140,7 @@ public class RevisionBranchMergeTest extends BaseRevisionIndexTest {
 	}
 	
 	@Test
-	public void forwardMergeBrancExcludeDeletion() throws Exception {
+	public void mergeExcludeDelete() throws Exception {
 		indexRevision(MAIN, NEW_DATA);
 		indexRevision(MAIN, NEW_DATA2);
 		String child = createBranch(MAIN, "a");
@@ -192,6 +179,36 @@ public class RevisionBranchMergeTest extends BaseRevisionIndexTest {
 	}
 	
 	@Test
+	public void fastForwardMergeBranchWithNewRevisionToParent() throws Exception {
+		String child = createBranch(MAIN, "a");
+		// create a revision on child branch
+		indexRevision(child, NEW_DATA);
+		// after commit child branch becomes FORWARD
+		assertState(child, MAIN, BranchState.FORWARD);
+		// do the merge
+		branching().prepareMerge(child, MAIN).merge();
+		// after fast-forward merge
+		// 1. MAIN should be in UP_TO_DATE state compared to the child
+		assertState(MAIN, child, BranchState.UP_TO_DATE);
+		// 2. Child should be UP_TO_DATE state compared to the MAIN
+		assertState(child, MAIN, BranchState.UP_TO_DATE);
+		// 3. revision should be visible from MAIN branch
+		assertNotNull(getRevision(MAIN, RevisionData.class, STORAGE_KEY1));
+	}
+	
+	@Test
+	public void fastForwardMergeBranchWithChangedRevisionToParent() throws Exception {
+		indexRevision(MAIN, NEW_DATA);
+		String child = createBranch(MAIN, "a");
+		// create a revision on child branch
+		indexChange(child, NEW_DATA, CHANGED_DATA);
+		branching().prepareMerge(child, MAIN).merge();
+		// after merge revision should be visible from MAIN branch
+		RevisionData afterMerge = getRevision(MAIN, RevisionData.class, STORAGE_KEY1);
+		assertDocEquals(CHANGED_DATA, afterMerge);
+	}
+	
+	@Test
 	public void squashMergeBranchWithNewToParentWithNewNoConflict() throws Exception {
 		String a = createBranch(MAIN, "a");
 		indexRevision(MAIN, NEW_DATA);
@@ -222,18 +239,6 @@ public class RevisionBranchMergeTest extends BaseRevisionIndexTest {
 		assertNotNull(getRevision(a, RevisionData.class, STORAGE_KEY1));
 		// and state should be UP_TO_DATE
 		assertState(a, MAIN, BranchState.UP_TO_DATE);
-	}
-	
-	@Test
-	public void fastForwardMergeBranchWithChangedRevisionToParent() throws Exception {
-		indexRevision(MAIN, NEW_DATA);
-		String child = createBranch(MAIN, "a");
-		// create a revision on child branch
-		indexChange(child, NEW_DATA, CHANGED_DATA);
-		branching().prepareMerge(child, MAIN).merge();
-		// after merge revision should be visible from MAIN branch
-		RevisionData afterMerge = getRevision(MAIN, RevisionData.class, STORAGE_KEY1);
-		assertDocEquals(CHANGED_DATA, afterMerge);
 	}
 	
 	@Test
@@ -288,25 +293,6 @@ public class RevisionBranchMergeTest extends BaseRevisionIndexTest {
 		assertState(a, MAIN, BranchState.FORWARD);
 		// MAIN becomes behind compared to the A branch
 		assertState(MAIN, a, BranchState.BEHIND);
-	}
-	
-	@Test
-	public void rebaseFakeDivergedBranch() throws Exception {
-		indexRevision(MAIN, NEW_DATA);
-		final String a = createBranch(MAIN, "a");
-		// Simulate a request that does not check if even a single property has been changed
-		indexChange(a, NEW_DATA, NEW_DATA.toBuilder().build());
-		indexChange(MAIN, NEW_DATA, NEW_DATA.toBuilder().build());
-		// ...which means there are no changes, but the branches are still considered diverged
-		assertState(a, MAIN, BranchState.DIVERGED);
-		assertState(MAIN, a, BranchState.DIVERGED);
-		// do the rebase
-		branching().prepareMerge(MAIN, a).merge();
-		// revision should be visible on both side
-		assertNotNull(getRevision(a, RevisionData.class, STORAGE_KEY1));
-		assertNotNull(getRevision(MAIN, RevisionData.class, STORAGE_KEY1));
-		assertState(a, MAIN, BranchState.UP_TO_DATE);
-		assertState(MAIN, a, BranchState.UP_TO_DATE);
 	}
 	
 	@Test
@@ -393,8 +379,8 @@ public class RevisionBranchMergeTest extends BaseRevisionIndexTest {
 		branching().prepareMerge(branchA, MAIN).merge();
 		RevisionData mainRev = getRevision(MAIN, RevisionData.class, NEW_DATA.getId());
 		assertNotNull(mainRev);
-		assertState(branchA, MAIN, BranchState.UP_TO_DATE);
-		assertState(MAIN, branchA, BranchState.UP_TO_DATE);
+		assertState(branchA, MAIN, BranchState.BEHIND);
+		assertState(MAIN, branchA, BranchState.FORWARD);
 	}
 	
 	private void assertState(String branchPath, String compareWith, BranchState expectedState) {

--- a/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchingTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executors;
@@ -40,6 +41,7 @@ import com.b2international.index.IndexWrite;
 import com.b2international.index.query.Expressions;
 import com.b2international.index.query.Query;
 import com.b2international.index.revision.RevisionBranch.BranchState;
+import com.b2international.index.revision.RevisionFixtures.RevisionData;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
@@ -52,6 +54,8 @@ import com.google.common.util.concurrent.MoreExecutors;
  */
 public class RevisionBranchingTest extends BaseRevisionIndexTest {
 
+	private final RevisionData rev1 = new RevisionData(UUID.randomUUID().toString(), "field1", "field2");
+	
 	@Test
 	public void afterInit() throws Exception {
 		RevisionBranch main = getMainBranch();
@@ -65,7 +69,7 @@ public class RevisionBranchingTest extends BaseRevisionIndexTest {
 
 	@Test
 	public void commitUpdatesHeadTimestamp() throws Exception {
-		long timestamp = commit(MAIN, Collections.emptySet());
+		long timestamp = commit(MAIN, List.of(rev1)).getTimestamp();
 		assertThat(getMainBranch().getHeadTimestamp()).isEqualTo(timestamp);
 		assertThat(branching().getBranchState(MAIN)).isEqualTo(BranchState.UP_TO_DATE);
 	}
@@ -106,15 +110,15 @@ public class RevisionBranchingTest extends BaseRevisionIndexTest {
 	@Test
 	public void forwardStateAfterCommit() throws Exception {
 		final String path = createBranch(MAIN, "a");
-		commit(path, Collections.emptySet());
+		commit(path, List.of(rev1));
 		assertThat(branching().getBranchState(path)).isEqualTo(BranchState.FORWARD);
 	}
 	
 	@Test
 	public void divergedStateAfterParentAndBranchCommit() throws Exception {
 		final String path = createBranch(MAIN, "a");
-		commit(MAIN, Collections.emptySet());
-		commit(path, Collections.emptySet());
+		commit(MAIN, List.of(rev1));
+		commit(path, List.of(rev1));
 		
 		assertThat(branching().getBranchState(path)).isEqualTo(BranchState.DIVERGED);
 	}

--- a/commons/com.b2international.index/src/com/b2international/index/Writer.java
+++ b/commons/com.b2international.index/src/com/b2international/index/Writer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,4 +41,6 @@ public interface Writer {
 	void commit() throws IOException;
 
 	Searcher searcher();
+
+	boolean isEmpty();
 }

--- a/commons/com.b2international.index/src/com/b2international/index/es/EsDocumentWriter.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/EsDocumentWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,7 +124,7 @@ public class EsDocumentWriter implements Writer {
 
 	@Override
 	public void commit() throws IOException {
-		if (indexOperations.isEmpty() && deleteOperations.isEmpty() && bulkUpdateOperations.isEmpty() && bulkDeleteOperations.isEmpty()) {
+		if (isEmpty()) {
 			return;
 		}
 		
@@ -260,6 +260,11 @@ public class EsDocumentWriter implements Writer {
 
 		// refresh the index if there were only updates
 		admin.refresh(mappingsToRefresh);
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return indexOperations.isEmpty() && deleteOperations.isEmpty() && bulkUpdateOperations.isEmpty() && bulkDeleteOperations.isEmpty();
 	}
 
 	private int getConcurrencyLevel() {

--- a/commons/com.b2international.index/src/com/b2international/index/revision/BaseRevisionBranching.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/BaseRevisionBranching.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,6 @@ import com.b2international.index.query.Expressions;
 import com.b2international.index.query.Query;
 import com.b2international.index.query.Query.AfterWhereBuilder;
 import com.b2international.index.revision.RevisionBranch.BranchState;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -58,7 +57,6 @@ public abstract class BaseRevisionBranching {
 
 	private final RevisionIndex index;
 	private final TimestampProvider timestampProvider;
-	private final ObjectMapper mapper;
 	private final List<Consumer<String>> onBranchChange = newArrayListWithCapacity(1);
 	
 	private final LoadingCache<String, ReentrantLock> locks = CacheBuilder.newBuilder()
@@ -70,10 +68,9 @@ public abstract class BaseRevisionBranching {
 				}
 			});
 
-	public BaseRevisionBranching(RevisionIndex index, TimestampProvider timestampProvider, ObjectMapper mapper) {
+	public BaseRevisionBranching(RevisionIndex index, TimestampProvider timestampProvider) {
 		this.index = index;
 		this.timestampProvider = timestampProvider;
-		this.mapper = mapper;
 	}
 	
 	public long currentTime() {
@@ -362,11 +359,6 @@ public abstract class BaseRevisionBranching {
 	protected final RevisionBranch getBranchFromStore(final AfterWhereBuilder<RevisionBranch> query) {
 		return Iterables.getOnlyElement(search(query.limit(1).build()), null);
 	}
-	
-	protected final IndexWrite<Void> prepareReplace(final String path, final RevisionBranch value) {
-		return update(path, RevisionBranch.Scripts.REPLACE, ImmutableMap.of("replace", mapper.convertValue(value, Map.class)));
-	}
-
 	
 	/**
 	 * Updates the branch with the specified properties. Currently {@link Metadata} supported only.

--- a/commons/com.b2international.index/src/com/b2international/index/revision/Commit.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/Commit.java
@@ -15,7 +15,8 @@
  */
 package com.b2international.index.revision;
 
-import static com.b2international.index.query.Expressions.*;
+import static com.b2international.index.query.Expressions.exactMatch;
+import static com.b2international.index.query.Expressions.match;
 import static com.b2international.index.query.Expressions.matchAny;
 import static com.b2international.index.query.Expressions.matchRange;
 import static com.b2international.index.query.Expressions.matchTextAll;
@@ -193,12 +194,11 @@ public final class Commit implements WithScore {
 					.build();
 		}
 
-		public static Expression fastForwardMergeCommit() {
-			return match("squashMerge", false);
-		}
-		
-		public static Expression squashMergeCommit() {
-			return match("squashMerge", true);
+		public static Expression mergeFrom(long branchId, long mergeSourceTimestampStart, long mergeSourceTimestampEnd, boolean squash) {
+			return com.b2international.index.query.Expressions.builder()
+					.filter(match("squashMerge", squash))
+					.filter(matchRange("mergeSource", RevisionBranchPoint.toIpv6(branchId, mergeSourceTimestampStart), RevisionBranchPoint.toIpv6(branchId, mergeSourceTimestampEnd), true, true))
+					.build();
 		}
 		
 	}

--- a/commons/com.b2international.index/src/com/b2international/index/revision/DefaultRevisionBranching.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/DefaultRevisionBranching.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import com.b2international.index.query.Expressions;
 import com.b2international.index.query.Query;
 import com.b2international.index.query.SortBy;
 import com.b2international.index.query.SortBy.Order;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 
@@ -39,8 +38,8 @@ public final class DefaultRevisionBranching extends BaseRevisionBranching {
 	private final long mainHeadTimestamp;
 	private final long mainBranchId;
 
-	public DefaultRevisionBranching(RevisionIndex index, TimestampProvider timestampProvider, ObjectMapper mapper) {
-		super(index, timestampProvider, mapper);
+	public DefaultRevisionBranching(RevisionIndex index, TimestampProvider timestampProvider) {
+		super(index, timestampProvider);
 		this.mainBaseTimestamp = this.mainHeadTimestamp = currentTime();
 		this.mainBranchId = nextBranchId();
 	}

--- a/commons/com.b2international.index/src/com/b2international/index/revision/DefaultRevisionBranching.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/DefaultRevisionBranching.java
@@ -70,10 +70,8 @@ public final class DefaultRevisionBranching extends BaseRevisionBranching {
 	protected RevisionBranch doReopen(RevisionBranch parentBranch, String child, Metadata metadata) {
 		final long currentTime = currentTime();
 		final long newBranchId = nextBranchId();
-		final RevisionSegment parentLastSegment = parentBranch.getSegments().last();
 		final SortedSet<RevisionSegment> parentSegments = ImmutableSortedSet.<RevisionSegment>naturalOrder()
-			.addAll(parentBranch.getSegments().headSet(parentLastSegment))
-			.add(parentLastSegment.withEnd(currentTime))
+			.addAll(parentBranch.getSegments())
 			.build();
 		
 		final SortedSet<RevisionBranchPoint> initialMergeSources = parentSegments.stream()

--- a/commons/com.b2international.index/src/com/b2international/index/revision/DefaultRevisionBranching.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/DefaultRevisionBranching.java
@@ -70,8 +70,10 @@ public final class DefaultRevisionBranching extends BaseRevisionBranching {
 	protected RevisionBranch doReopen(RevisionBranch parentBranch, String child, Metadata metadata) {
 		final long currentTime = currentTime();
 		final long newBranchId = nextBranchId();
+		final RevisionSegment parentLastSegment = parentBranch.getSegments().last();
 		final SortedSet<RevisionSegment> parentSegments = ImmutableSortedSet.<RevisionSegment>naturalOrder()
-			.addAll(parentBranch.getSegments())
+			.addAll(parentBranch.getSegments().headSet(parentLastSegment))
+			.add(parentLastSegment.withEnd(currentTime))
 			.build();
 		
 		final SortedSet<RevisionBranchPoint> initialMergeSources = parentSegments.stream()

--- a/commons/com.b2international.index/src/com/b2international/index/revision/DefaultRevisionIndex.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/DefaultRevisionIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public final class DefaultRevisionIndex implements InternalRevisionIndex, Hooks 
 		this.index = index;
 		this.mapper = mapper;
 		this.admin = new RevisionIndexAdmin(this, index.admin());
-		this.branching = new DefaultRevisionBranching(this, timestampProvider, mapper);
+		this.branching = new DefaultRevisionBranching(this, timestampProvider);
 	}
 	
 	@Override

--- a/commons/com.b2international.index/src/com/b2international/index/revision/DefaultRevisionWriter.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/DefaultRevisionWriter.java
@@ -158,6 +158,11 @@ public class DefaultRevisionWriter implements RevisionWriter {
 		return searcher;
 	}
 	
+	@Override
+	public boolean isEmpty() {
+		return index.isEmpty();
+	}
+	
 	private String generateRevisionId() {
 		return UUID.randomUUID().toString();
 	}

--- a/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranch.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranch.java
@@ -60,7 +60,6 @@ import com.google.common.primitives.Longs;
 		+ "}")
 @Script(name=RevisionBranch.Scripts.WITH_DELETED, script="ctx._source.deleted = true")
 @Script(name=RevisionBranch.Scripts.WITH_METADATA, script="ctx._source.metadata = params.metadata")
-@Script(name=RevisionBranch.Scripts.REPLACE, script="ctx._source = params.replace")
 public final class RevisionBranch extends MetadataHolderImpl {
 
 	/**
@@ -165,7 +164,6 @@ public final class RevisionBranch extends MetadataHolderImpl {
 		public static final String WITH_DELETED = "withDeleted";
 		public static final String WITH_METADATA = "withMetadata";
 		public static final String WITH_MERGE_SOURCE = "withMergeSource";
-		public static final String REPLACE = "replace";
 	}
 	
 	public static Builder builder() {

--- a/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranch.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranch.java
@@ -51,7 +51,6 @@ import com.google.common.primitives.Longs;
 		+ "boolean found = false;"
 		+ "for (segment in ctx._source.segments) {"
 		+ "    if (segment.branchId == ctx._source.id) {"
-//		+ "        segment.start = params.baseTimestamp != null ? params.baseTimestamp : segment.start;"
 		+ "        segment.end = params.headTimestamp;"
 		+ "        found = true;"
 		+ "    }"

--- a/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranchMergeSource.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranchMergeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.SortedSet;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 
 /**
  * @since 7.0
@@ -51,6 +52,11 @@ public final class RevisionBranchMergeSource implements Serializable {
 	
 	public SortedSet<RevisionBranchPoint> getBranchPoints() {
 		return branchPoints;
+	}
+	
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(getClass()).add("timestamp", timestamp).add("branchPoints", branchPoints).add("squash", squash).toString();
 	}
 	
 }

--- a/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranchRef.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranchRef.java
@@ -146,7 +146,10 @@ final class RevisionBranchRef {
 		}
 		
 		while (segmentsIterator.hasNext()) {
-			differenceSegments.add(segmentsIterator.next());
+			RevisionSegment nextSegment = segmentsIterator.next();
+			if (!nextSegment.isEmpty()) {
+				differenceSegments.add(nextSegment);
+			}
 		}
 		
 		return new RevisionBranchRef(branchId, branchPath, differenceSegments);

--- a/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
@@ -437,7 +437,7 @@ public final class StagingArea {
 		deletedIdsByType.clear();
 		
 		// nothing to commit, break
-		if (details.isEmpty() && CompareUtils.isEmpty(mergeSources)) {
+		if (writer.isEmpty() && CompareUtils.isEmpty(mergeSources)) {
 			return null;
 		}
 		

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/BranchSearchRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/BranchSearchRequest.java
@@ -113,7 +113,7 @@ final class BranchSearchRequest extends SearchIndexResourceRequest<RepositoryCon
 				if (!branchesById.containsKey(parentPath)) {
 					branchesById.put(parentPath, branching.getBranch(parentPath));
 				}
-				state = doc.state(branchesById.get(parentPath));
+				state = branching.getBranchState(doc, branchesById.get(parentPath));
 			}
 			branches.add(new Branch(doc, state, BranchPathUtils.createPath(doc.getPath()), doc.getMergeSources()));
 		}


### PR DESCRIPTION
This PR fixes the branch state calculation issue, which incorrectly returns UP_TO_DATE state of a branch that has actual changes, but due to a recent synchronization with the parent branch, it states that it does not have any changes.

There are multiple places that have been changed to fix the issue:
* Introduced a new `squashMerge` boolean flag on Commit documents to detect if a commit was a squash merge or not.
* Take actual commits into account before deciding whether a branch is in FORWARD or BEHIND state.
* Only merge commits can be empty from this time forward. After applying the changes in a StagingArea, double-check if there are any actual changes before adding the commit document and updating the branch document.
* Empty segments are no longer returned from `RevisionBranchRef.difference(RevisionBranchRef)` method.

Unrelated, clean up changes:
* Remove unused, obsolete branch doc REPLACE script (used in 6.x version only)


