### PR TITLE
SO-4198: LCS replace type import fails with NPE

### DIFF
--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/TransactionContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/TransactionContext.java
@@ -22,6 +22,8 @@ import com.b2international.index.Doc;
 import com.b2international.index.revision.Revision;
 import com.b2international.index.revision.RevisionIndex;
 import com.b2international.index.revision.StagingArea;
+import com.b2international.snowowl.core.codesystem.CodeSystemEntry;
+import com.b2international.snowowl.core.codesystem.CodeSystemVersionEntry;
 import com.b2international.snowowl.core.domain.DelegatingContext.Builder;
 import com.b2international.snowowl.core.exceptions.ComponentNotFoundException;
 
@@ -77,7 +79,7 @@ public interface TransactionContext extends BranchContext, AutoCloseable {
 	 * 
 	 * @return - the timestamp of the successful commit
 	 */
-	long commit();
+	Long commit();
 	
 	/**
 	 * Commits all changes made so far using the current userId, the given commit comment and no lock context.
@@ -85,7 +87,7 @@ public interface TransactionContext extends BranchContext, AutoCloseable {
 	 * @param commitComment - the commit comment to use for the commit
 	 * @return - the timestamp of the successful commit
 	 */
-	long commit(String commitComment);
+	Long commit(String commitComment);
 	
 	/**
 	 * Commits all changes made so far using the current userId and the given commitComment and lock context.
@@ -94,7 +96,7 @@ public interface TransactionContext extends BranchContext, AutoCloseable {
 	 * @param parentContextDescription - the parent lock context to use for the commit
 	 * @return - the timestamp of the successful commit
 	 */
-	long commit(String commitComment, String parentContextDescription);
+	Long commit(String commitComment, String parentContextDescription);
 	
 	/**
 	 * Commits all changes made so far.
@@ -109,7 +111,7 @@ public interface TransactionContext extends BranchContext, AutoCloseable {
 	 * 
 	 * @return - the timestamp of the successful commit
 	 */
-	long commit(String userId, String commitComment, String parentContextDescription);
+	Long commit(String userId, String commitComment, String parentContextDescription);
 	
 	/**
 	 * @return whether the commit will notify interested services, notification services about this transaction's commit or not. It's enabled by default.

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryTransactionContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryTransactionContext.java
@@ -276,7 +276,7 @@ public final class RepositoryTransactionContext extends DelegatingBranchContext 
 		Commit commit = null;
 		try {
 			acquireLock(locks, lockContext, lockTarget);
-			final Long timestamp = service(TimestampProvider.class).getTimestamp();
+			final long timestamp = service(TimestampProvider.class).getTimestamp();
 			log().info("Persisting changes to {}@{}", path(), timestamp);
 			commit = staging.commit(null, timestamp, author, commitComment);
 			log().info("Changes have been successfully persisted to {}@{}.", path(), timestamp);

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryTransactionContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryTransactionContext.java
@@ -251,22 +251,22 @@ public final class RepositoryTransactionContext extends DelegatingBranchContext 
 	}
 
 	@Override
-	public long commit() {
+	public Long commit() {
 		return commit(author(), commitComment, parentLockContext);
 	}
 	
 	@Override
-	public long commit(String commitComment) {
+	public Long commit(String commitComment) {
 		return commit(author(), commitComment, parentLockContext);
 	}
 	
 	@Override
-	public long commit(String commitComment, String parentLockContext) {
+	public Long commit(String commitComment, String parentLockContext) {
 		return commit(author(), commitComment, parentLockContext);
 	}
 	
 	@Override
-	public long commit(String author, String commitComment, String parentLockContext) {
+	public Long commit(String author, String commitComment, String parentLockContext) {
 		if (!isDirty()) {
 			return -1L;
 		}
@@ -276,11 +276,11 @@ public final class RepositoryTransactionContext extends DelegatingBranchContext 
 		Commit commit = null;
 		try {
 			acquireLock(locks, lockContext, lockTarget);
-			final long timestamp = service(TimestampProvider.class).getTimestamp();
+			final Long timestamp = service(TimestampProvider.class).getTimestamp();
 			log().info("Persisting changes to {}@{}", path(), timestamp);
 			commit = staging.commit(null, timestamp, author, commitComment);
 			log().info("Changes have been successfully persisted to {}@{}.", path(), timestamp);
-			return commit.getTimestamp();
+			return commit == null ? null : commit.getTimestamp();
 		} catch (final IndexException e) {
 			Throwable rootCause = Throwables.getRootCause(e);
 			if (rootCause instanceof CycleDetectedException) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/CommitResult.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/CommitResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,15 +26,15 @@ public final class CommitResult implements Serializable {
 
 	private static final long serialVersionUID = -7479022976959306232L;
 	
-	private final long commitTimestamp;
+	private final Long commitTimestamp;
 	private final Object result;
 
-	CommitResult(long commitTimestamp, Object result) {
+	CommitResult(Long commitTimestamp, Object result) {
 		this.commitTimestamp = commitTimestamp;
 		this.result = result;
 	}
 	
-	public long getCommitTimestamp() {
+	public Long getCommitTimestamp() {
 		return commitTimestamp;
 	}
 	

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/TransactionalRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/TransactionalRequest.java
@@ -75,7 +75,7 @@ public final class TransactionalRequest implements Request<BranchContext, Commit
 		 * FIXME: at this point, the component identifier might have changed even though the input 
 		 * required an exact ID to be assigned. What to do?
 		 */
-		final long commitTimestamp = context.commit(context.author(), commitComment, parentLockContext);
+		final Long commitTimestamp = context.commit(context.author(), commitComment, parentLockContext);
 		return new CommitResult(commitTimestamp, body);
 	}
 	

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/importer/Rf2TransactionContext.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/importer/Rf2TransactionContext.java
@@ -118,17 +118,17 @@ public final class Rf2TransactionContext extends DelegatingBranchContext impleme
 	}
 	
 	@Override
-	public long commit() {
+	public Long commit() {
 		throw new UnsupportedOperationException("Use the single supported commit(String) method");
 	}
 	
 	@Override
-	public long commit(String commitComment) {
+	public Long commit(String commitComment) {
 		final Set<String> idsToRegister = ImmutableSet.copyOf(newComponents.keySet().stream().filter(SnomedIdentifiers::isValid).iterator());
 		// clear local cache before executing commit
 		newComponents = newHashMap();
 		LOG.info("Pushing changes: {}", commitComment);
-		long timestamp = getDelegate().commit(commitComment);
+		Long timestamp = getDelegate().commit(commitComment);
 		// after successful commit register all commited IDs to CIS
 		final ISnomedIdentifierService cis = service(ISnomedIdentifierService.class);
 		if (cis.importSupported()) {
@@ -138,12 +138,12 @@ public final class Rf2TransactionContext extends DelegatingBranchContext impleme
 	}
 	
 	@Override
-	public long commit(String commitComment, String parentContextDescription) {
+	public Long commit(String commitComment, String parentContextDescription) {
 		throw new UnsupportedOperationException("Use the single supported commit(String) method");
 	}
 	
 	@Override
-	public long commit(String userId, String commitComment, String parentContextDescription) {
+	public Long commit(String userId, String commitComment, String parentContextDescription) {
 		throw new UnsupportedOperationException("Use the single supported commit(String) method");
 	}
 	


### PR DESCRIPTION
The return type of commit() was changed to Long to be able to return null.