### PR TITLE
Deprecate SNOMEDCT code system shortname and repositoryId constants

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.common/src/com/b2international/snowowl/snomed/common/SnomedTerminologyComponentConstants.java
+++ b/snomed/com.b2international.snowowl.snomed.common/src/com/b2international/snowowl/snomed/common/SnomedTerminologyComponentConstants.java
@@ -52,6 +52,9 @@ public abstract class SnomedTerminologyComponentConstants {
 	public static final String TEMPLATE = "com.b2international.snowowl.terminology.snomed.template";
 	public static final short TEMPLATE_NUMBER = 106;
 	
+	/**
+	 * @deprecated - will be moved to test API in Snow Owl 8.0, using it in business logic might yield incorrect results
+	 */
 	public static final String SNOMED_SHORT_NAME = "SNOMEDCT";
 	public static final String SNOMED_NAME = "SNOMED CT";
 	
@@ -65,6 +68,9 @@ public abstract class SnomedTerminologyComponentConstants {
 			"Patients benefit from the use of SNOMED CT because it improves the recording of EHR information and facilitates better communication, " +
 			"leading to improvements in the quality of care.";
 	
+	/**
+	 * @deprecated - will be moved to test API in Snow Owl 8.0, using it in business logic might yield incorrect results
+	 */
 	public static final String SNOMED_B2I_SHORT_NAME = SNOMED_SHORT_NAME + "-B2I";
 	public static final String SNOMED_B2I_NAME = SNOMED_NAME + ", B2i extension";
 	public static final String SNOMED_B2I_OID = SNOMED_INT_OID + ".1000154";

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDatastoreActivator.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDatastoreActivator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package com.b2international.snowowl.snomed.datastore;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
+import com.b2international.snowowl.core.uri.CodeSystemURI;
+
 public class SnomedDatastoreActivator implements BundleActivator {
 
 	/**
@@ -25,7 +27,10 @@ public class SnomedDatastoreActivator implements BundleActivator {
 	 */
 	public static final String PLUGIN_ID = "com.b2international.snowowl.snomed.datastore"; //$NON-NLS-1$
 	
-	/** The repository identifier for this tooling */
+	/** 
+	 * The repository identifier for this tooling
+	 * @deprecated - will be removed in Snow Owl 8.0, should not be used when accessing Snow Owl APIs, instead always refer to {@link CodeSystemURI}s.
+	 */
 	public static final String REPOSITORY_UUID = "snomedStore";
 	
 	// Resource names


### PR DESCRIPTION
They will be removed in Snow Owl 8.0.
Clients should create their own SNOMED CT CodeSystem with their desired short name to designate the content they would like to create in Snow Owl.