### PR TITLE
SO-4289: incorrect reuse of indicator member

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/AllSnomedApiTests.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/AllSnomedApiTests.java
@@ -70,6 +70,7 @@ import com.b2international.snowowl.test.commons.SnowOwlAppRule;
 	SnomedConceptInactivationApiTest.class,
 	SnomedDescriptionApiTest.class,
 	SnomedRelationshipApiTest.class,
+	SnomedComponentInactivationApiTest.class,
 	SnomedRefSetApiTest.class,
 	SnomedReferenceSetDeletionPerformanceTest.class,
 	SnomedRefSetParameterizedTest.class,

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/SnomedComponentRestRequests.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/SnomedComponentRestRequests.java
@@ -39,11 +39,11 @@ import io.restassured.response.ValidatableResponse;
  */
 public abstract class SnomedComponentRestRequests {
 
-	public static ValidatableResponse assertInactivation(final IBranchPath branchPath, final String conceptId, InactivationProperties inactivationProperties) {
-		return assertInactivation(branchPath, conceptId, inactivationProperties, null);
+	public static ValidatableResponse assertInactivation(final IBranchPath branchPath, final String componentId, InactivationProperties inactivationProperties) {
+		return assertInactivation(branchPath, componentId, inactivationProperties, null);
 	}
 	
-	public static ValidatableResponse assertInactivation(final IBranchPath branchPath, final String conceptId, InactivationProperties inactivationProperties, final String defaultModuleId) {
+	public static ValidatableResponse assertInactivation(final IBranchPath branchPath, final String componentId, InactivationProperties inactivationProperties, final String defaultModuleId) {
 		ImmutableMap.Builder<String, Object> inactivationRequestBody = ImmutableMap.<String, Object>builder()
 				.put("active", false)
 				.put("inactivationProperties", inactivationProperties)
@@ -53,14 +53,14 @@ public abstract class SnomedComponentRestRequests {
 			inactivationRequestBody.put("defaultModuleId", defaultModuleId);
 		}
 
-		SnomedComponentType type = SnomedComponentType.getByComponentId(conceptId);
-		updateComponent(branchPath, type, conceptId, inactivationRequestBody.build())
+		SnomedComponentType type = SnomedComponentType.getByComponentId(componentId);
+		updateComponent(branchPath, type, componentId, inactivationRequestBody.build())
 			.statusCode(204);
 		
 		final String[] associationReferenceSetIds = inactivationProperties.getAssociationTargets().stream().map(AssociationTarget::getReferenceSetId).toArray(length -> new String[length]);
 		final String[] associationTargets = inactivationProperties.getAssociationTargets().stream().map(AssociationTarget::getTargetComponentId).toArray(length -> new String[length]);
 		
-		return getComponent(branchPath, type, conceptId, "inactivationProperties(),members()")
+		return getComponent(branchPath, type, componentId, "inactivationProperties(),members()")
 			.statusCode(200)
 			.body("active", equalTo(false))
 			.body("inactivationProperties.inactivationIndicatorId", equalTo(inactivationProperties.getInactivationIndicatorId()))

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedComponentInactivationApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedComponentInactivationApiTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.snomed.core.rest.components;
+
+import static com.b2international.snowowl.snomed.core.rest.SnomedComponentRestRequests.updateComponent;
+import static com.b2international.snowowl.snomed.core.rest.SnomedRestFixtures.createNewConcept;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
+import com.b2international.snowowl.snomed.common.SnomedRf2Headers;
+import com.b2international.snowowl.snomed.core.domain.InactivationProperties;
+import com.b2international.snowowl.snomed.core.domain.SnomedConcept;
+import com.b2international.snowowl.snomed.core.domain.SnomedCoreComponent;
+import com.b2international.snowowl.snomed.core.domain.SnomedDescription;
+import com.b2international.snowowl.snomed.core.domain.refset.SnomedReferenceSetMember;
+import com.b2international.snowowl.snomed.core.rest.AbstractSnomedApiTest;
+import com.b2international.snowowl.snomed.core.rest.SnomedComponentType;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+/**
+ * @since 7.9.2
+ */
+public class SnomedComponentInactivationApiTest extends AbstractSnomedApiTest {
+
+	@Test
+	public void reuseConceptAndDescriptionInactivationIndicators() throws Exception {
+		// create a concept
+		String conceptId = createNewConcept(branchPath);
+		SnomedConcept concept = getConcept(conceptId, "descriptions()");
+		
+		// add pending move to concept and descriptions
+		Map<?, ?> pendingMoveUpdate = ImmutableMap.of(
+			"inactivationProperties", new InactivationProperties(Concepts.PENDING_MOVE, null),
+			"commitComment", "Set to Pending Move"
+		);
+
+		updateComponent(branchPath, SnomedComponentType.CONCEPT, conceptId, pendingMoveUpdate)
+			.statusCode(204);
+		
+		for (SnomedDescription description : concept.getDescriptions()) {
+			updateComponent(branchPath, SnomedComponentType.DESCRIPTION, description.getId(), pendingMoveUpdate)
+				.statusCode(204);
+		}
+		
+		SnomedConcept pendingMoveConcept = getConcept(conceptId, "members(),descriptions(expand(members()))"); // XXX intentionally using the members() expand here to check duplication
+		
+		// verify and collect inactivation indicator members
+		SnomedReferenceSetMember conceptInactivationIndicatorMember = getIndicatorMember(pendingMoveConcept, Concepts.REFSET_CONCEPT_INACTIVITY_INDICATOR);
+		SnomedReferenceSetMember fsnInactivationIndicatorMember = null;
+		SnomedReferenceSetMember ptInactivationIndicatorMember = null;
+		
+		for (SnomedDescription description : pendingMoveConcept.getDescriptions()) {
+			if (Concepts.FULLY_SPECIFIED_NAME.equals(description.getTypeId())) {
+				fsnInactivationIndicatorMember = getIndicatorMember(description, Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR);
+			} else if (Concepts.SYNONYM.equals(description.getTypeId())) {
+				ptInactivationIndicatorMember = getIndicatorMember(description, Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR);
+			} else {
+				throw new UnsupportedOperationException();
+			}
+		}
+		
+		Map<?, ?> inactivationConceptRequest = ImmutableMap.builder()
+				.put("active", false)
+				.put("inactivationProperties", new InactivationProperties(Concepts.DUPLICATE, null))
+				.put("commitComment", "Inactivated concept")
+				.build();
+
+		updateComponent(branchPath, SnomedComponentType.CONCEPT, conceptId, inactivationConceptRequest).statusCode(204);
+		
+		SnomedConcept inactivatedConcept = getConcept(conceptId, "members(),descriptions(expand(members()))"); // XXX intentionally using the members() expand here to check duplication/member issues
+		
+		SnomedReferenceSetMember afterInactivationConceptInactivationIndicatorMember = getIndicatorMember(inactivatedConcept, Concepts.REFSET_CONCEPT_INACTIVITY_INDICATOR);
+		SnomedReferenceSetMember afterInactivationFsnInactivationIndicatorMember = null;
+		SnomedReferenceSetMember afterInactivationPtInactivationIndicatorMember = null;
+		
+		for (SnomedDescription description : inactivatedConcept.getDescriptions()) {
+			if (Concepts.FULLY_SPECIFIED_NAME.equals(description.getTypeId())) {
+				afterInactivationFsnInactivationIndicatorMember = getIndicatorMember(description, Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR);
+			} else if (Concepts.SYNONYM.equals(description.getTypeId())) {
+				afterInactivationPtInactivationIndicatorMember = getIndicatorMember(description, Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR);
+			} else {
+				throw new UnsupportedOperationException();
+			}
+		}
+		
+		assertEquals(conceptInactivationIndicatorMember.getId(), afterInactivationConceptInactivationIndicatorMember.getId());
+		assertEquals(null, afterInactivationConceptInactivationIndicatorMember.getEffectiveTime());
+		assertEquals(false, afterInactivationConceptInactivationIndicatorMember.isReleased());
+		assertEquals(Concepts.DUPLICATE, afterInactivationConceptInactivationIndicatorMember.getProperties().get(SnomedRf2Headers.FIELD_VALUE_ID));
+		
+		assertEquals(fsnInactivationIndicatorMember.getId(), afterInactivationFsnInactivationIndicatorMember.getId());
+		assertEquals(null, afterInactivationFsnInactivationIndicatorMember.getEffectiveTime());
+		assertEquals(false, afterInactivationFsnInactivationIndicatorMember.isReleased());
+		assertEquals(Concepts.CONCEPT_NON_CURRENT, afterInactivationFsnInactivationIndicatorMember.getProperties().get(SnomedRf2Headers.FIELD_VALUE_ID));
+		
+		assertEquals(ptInactivationIndicatorMember.getId(), afterInactivationPtInactivationIndicatorMember.getId());
+		assertEquals(null, afterInactivationPtInactivationIndicatorMember.getEffectiveTime());
+		assertEquals(false, afterInactivationPtInactivationIndicatorMember.isReleased());
+		assertEquals(Concepts.CONCEPT_NON_CURRENT, afterInactivationPtInactivationIndicatorMember.getProperties().get(SnomedRf2Headers.FIELD_VALUE_ID));
+		
+	}
+
+	private SnomedReferenceSetMember getIndicatorMember(SnomedCoreComponent component, String inactivationIndicatorRefSetId) {
+		List<SnomedReferenceSetMember> members = component.getMembers()
+			.stream()
+			.filter(member -> inactivationIndicatorRefSetId.equals(member.getReferenceSetId()))
+			.collect(Collectors.toList());
+		if (members.size() != 1) {
+			fail("Missing or duplicate inactivation member detected for component: " + component.getId() + ", " + members);
+		}
+		return Iterables.getOnlyElement(members);
+	}
+	
+}

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedDescriptionApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedDescriptionApiTest.java
@@ -42,14 +42,13 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
 
@@ -362,10 +361,11 @@ public class SnomedDescriptionApiTest extends AbstractSnomedApiTest {
 			new InactivationProperties(Concepts.CONCEPT_NON_CURRENT, Collections.emptyList())
 		).extract().as(SnomedDescription.class);
 		
-		SnomedReferenceSetMember inactivationIndicator = description.getMembers().stream()
+		List<SnomedReferenceSetMember> inactivationIndicators = description.getMembers().stream()
 			.filter(member -> Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR.equals(member.getReferenceSetId()))
-			.findFirst()
-			.get();
+			.collect(Collectors.toList());
+		
+		final SnomedReferenceSetMember inactivationIndicator = Iterables.getOnlyElement(inactivationIndicators); 
 		
 		assertEquals(Concepts.CONCEPT_NON_CURRENT, inactivationIndicator.getProperties().get(SnomedRf2Headers.FIELD_VALUE_ID));
 		assertNull(inactivationIndicator.getEffectiveTime());

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/domain/refset/SnomedReferenceSetMember.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/domain/refset/SnomedReferenceSetMember.java
@@ -253,5 +253,14 @@ public final class SnomedReferenceSetMember extends SnomedComponent {
 				.setSource(changes)
 				.build();
 	}
+
+	@Override
+	public String toString() {
+		return String.format(
+				"SnomedReferenceSetMember [type=%s, referencedComponent=%s, referenceSetId=%s, properties=%s, equivalentOWLRelationships=%s, classOWLRelationships=%s, gciOWLRelationships=%s]",
+				type, referencedComponent, referenceSetId, properties, equivalentOWLRelationships, classOWLRelationships, gciOWLRelationships);
+	}
+	
+	
 	
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/ComponentInactivationChangeProcessor.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/ComponentInactivationChangeProcessor.java
@@ -18,6 +18,7 @@ package com.b2international.snowowl.snomed.datastore.index.change;
 import static com.google.common.collect.Sets.newHashSet;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -36,6 +37,7 @@ import com.b2international.snowowl.core.repository.ChangeSetProcessorBase;
 import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
 import com.b2international.snowowl.snomed.common.SnomedRf2Headers;
 import com.b2international.snowowl.snomed.core.domain.refset.SnomedRefSetType;
+import com.b2international.snowowl.snomed.datastore.SnomedRefSetUtil;
 import com.b2international.snowowl.snomed.datastore.index.entry.SnomedComponentDocument;
 import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument;
 import com.b2international.snowowl.snomed.datastore.index.entry.SnomedDescriptionIndexEntry;
@@ -89,7 +91,7 @@ final class ComponentInactivationChangeProcessor extends ChangeSetProcessorBase 
 		processReactivations(staging, searcher, reactivatedConceptIds, reactivatedComponentIds);
 	}
 
-	private void processInactivations(StagingArea staging, RevisionSearcher searcher, Set<String> inactivatedConceptIds, Set<String> inactivatedComponentIds) {
+	private void processInactivations(StagingArea staging, RevisionSearcher searcher, Set<String> inactivatedConceptIds, Set<String> inactivatedComponentIds) throws IOException {
 		// inactivate descriptions of inactivated concepts, take current description changes into account
 		if (!inactivatedConceptIds.isEmpty()) {
 			
@@ -107,35 +109,70 @@ final class ComponentInactivationChangeProcessor extends ChangeSetProcessorBase 
 							.build())
 					.limit(PAGE_SIZE)
 					.build())) {
-				// TODO exclude descriptions that are already present in the tx or apply 
-				hits.forEach(description -> {
-					final String descriptionId = description[0];
-					SnomedRefSetMemberIndexEntry existingInactivationMember = changedMembersByReferencedComponentId.get(descriptionId).stream()
-								.map(diff -> diff.newRevision)
-								.map(SnomedRefSetMemberIndexEntry.class::cast)
-								.filter(member -> Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR.equals(member.getReferenceSetId()))
-								.findFirst()
-								.orElse(null);
-					
-					SnomedRefSetMemberIndexEntry.Builder inactivationMember;
-					if (existingInactivationMember == null) {
-						inactivationMember = SnomedRefSetMemberIndexEntry.builder()
-							.id(UUID.randomUUID().toString())
-							.active(true)
-							.released(false)
-							.referenceSetId(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR)
-							.referenceSetType(SnomedRefSetType.ATTRIBUTE_VALUE)
-							.referencedComponentId(descriptionId)
-							.moduleId(description[1]);
-					} else {
-						inactivationMember = SnomedRefSetMemberIndexEntry.builder(existingInactivationMember);
+				final Set<String> descriptionIds = hits.stream().map(description -> description[0]).collect(Collectors.toSet());
+				
+				// load existing indicator reference set members from index
+				final Multimap<String, SnomedRefSetMemberIndexEntry> existingIndicatorReferenceSetMembers = HashMultimap.create();
+				searcher.search(Query.select(SnomedRefSetMemberIndexEntry.class)
+						.where(Expressions.builder()
+								.filter(SnomedRefSetMemberIndexEntry.Expressions.referenceSetId(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR))
+								.filter(SnomedRefSetMemberIndexEntry.Expressions.referencedComponentIds(descriptionIds))
+								.build())
+						.limit(Integer.MAX_VALUE)
+						.build())
+						.forEach(existingIndicatorMember -> {
+							existingIndicatorReferenceSetMembers.put(existingIndicatorMember.getReferencedComponentId(), existingIndicatorMember);
+						});
+				
+				// override members with the ones that present in the staging area
+				for (String[] descriptionToCheck : hits) {
+					final String descriptionId = descriptionToCheck[0];
+					// get the persisted, existing members
+					// get the current members from the tx
+					final Collection<SnomedRefSetMemberIndexEntry> transactionMembers = changedMembersByReferencedComponentId.get(descriptionId).stream()
+							.map(diff -> diff.newRevision)
+							.map(SnomedRefSetMemberIndexEntry.class::cast)
+							.filter(member -> Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR.equals(member.getReferenceSetId()))
+							.collect(Collectors.toList());
+					// if there were no registered member changes to this description
+					if (transactionMembers.isEmpty()) {
+						// apply CONCEPT_NON_CURRENT to all existing members or generate a new one 
+						final Collection<SnomedRefSetMemberIndexEntry> existingMembers = existingIndicatorReferenceSetMembers.get(descriptionId)
+								.stream()
+								.filter(member -> {
+									// reusable member, if it was inactivated earlier
+									// was active and used one of the active description attribute values
+									return !member.isActive() 
+											|| SnomedRefSetUtil.ATTRIBUTE_VALUES_FOR_ACTIVE_DESCRIPTIONS.contains(member.getValueId());
+								})
+								.collect(Collectors.toList());
+						if (existingMembers.isEmpty()) {
+							SnomedRefSetMemberIndexEntry inactivationMember = SnomedRefSetMemberIndexEntry.builder()
+								.id(UUID.randomUUID().toString())
+								.active(true)
+								.released(false)
+								.referenceSetId(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR)
+								.referenceSetType(SnomedRefSetType.ATTRIBUTE_VALUE)
+								.referencedComponentId(descriptionId)
+								.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME)
+								.moduleId(descriptionToCheck[1])
+								.field(SnomedRf2Headers.FIELD_VALUE_ID, Concepts.CONCEPT_NON_CURRENT)
+								.build();
+							stageNew(inactivationMember);
+						} else {
+							for (SnomedRefSetMemberIndexEntry existingMember : existingMembers) {
+								// update the existing member only, if it was active, registered as PENDING_MOVE
+								final SnomedRefSetMemberIndexEntry updated = SnomedRefSetMemberIndexEntry.builder(existingMember)
+										.active(true) // ensure active
+										.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME) // ensure unpublished
+										.field(SnomedRf2Headers.FIELD_VALUE_ID, Concepts.CONCEPT_NON_CURRENT) // ensure non-current
+										.build();
+								stageChange(existingMember, updated);
+							}
+						}
+						
 					}
-					
-					// set to concept non current
-					inactivationMember.field(SnomedRf2Headers.FIELD_VALUE_ID, Concepts.CONCEPT_NON_CURRENT);
-					
-					stageNew(inactivationMember.build());
-				});
+				}
 			}
 			
 			// inactivate relationships of inactivated concepts

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/SnomedRf2ExportRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/SnomedRf2ExportRequest.java
@@ -975,7 +975,7 @@ final class SnomedRf2ExportRequest extends ResourceRequest<BranchContext, Attach
 	}
 
 	private static long getCutoffBaseTimestamp(final RepositoryContext context, final Branch cutoffBranch, final String versionParentPath) {
-		System.err.println("SnomedRf2ExportRequest.getCutoffBaseTimestamp(): branch[" + cutoffBranch.path() + "], branchParentPath: [" + cutoffBranch.parentPath() +  "], versionParentPath: [" + versionParentPath + "]");
+//		System.err.println("SnomedRf2ExportRequest.getCutoffBaseTimestamp(): branch[" + cutoffBranch.path() + "], branchParentPath: [" + cutoffBranch.parentPath() +  "], versionParentPath: [" + versionParentPath + "]");
 		if (cutoffBranch.path().equals(versionParentPath) || Branch.MAIN_PATH.equals(cutoffBranch.path())) {
 			// We are on the working branch of the code system, all versions are visible for export
 			return Long.MAX_VALUE;	
@@ -999,7 +999,7 @@ final class SnomedRf2ExportRequest extends ResourceRequest<BranchContext, Attach
 	}
 
 	private static Branch getBranch(final RepositoryContext context, final String path) {
-		System.err.println("SnomedRf2ExportRequest.getBranch(): " + path);
+//		System.err.println("SnomedRf2ExportRequest.getBranch(): " + path);
 		return RepositoryRequests.branching()
 				.prepareGet(path)
 				.build()
@@ -1007,7 +1007,7 @@ final class SnomedRf2ExportRequest extends ResourceRequest<BranchContext, Attach
 	}
 
 	private static Branches getBranches(final RepositoryContext context, final String parent, final Collection<String> paths) {
-		System.err.println("SnomedRf2ExportRequest.getBranches(): " + parent + ", paths: " + paths + "");
+//		System.err.println("SnomedRf2ExportRequest.getBranches(): " + parent + ", paths: " + paths + "");
 		return RepositoryRequests.branching()
 				.prepareSearch()
 				.all()


### PR DESCRIPTION
This PR addresses an issue with the automatic generation of concept non-current members during concept inactivation.
In cases when the concept and its descriptions were released earlier with active pending move indicator members, during inactivation, the descriptions got indicator members with incorrect effective dates due to a bug in the inactivation process.