### PR TITLE
SO-4356: expose squash merge configuration property

### DIFF
--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/branch/MergeRestRequest.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/branch/MergeRestRequest.java
@@ -43,6 +43,10 @@ public class MergeRestRequest {
 	@ApiParam(required = false)
 	@JsonProperty
 	private String reviewId;
+	
+	@ApiParam(required = false)
+	@JsonProperty
+	private boolean squash = true;
 
 	public String getCommitComment() {
 		return commitComment;
@@ -58,6 +62,10 @@ public class MergeRestRequest {
 	
 	public String getTarget() {
 		return target;
+	}
+	
+	public boolean isSquash() {
+		return squash;
 	}
 	
 }

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/branch/RepositoryBranchMergeRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/branch/RepositoryBranchMergeRestService.java
@@ -60,8 +60,7 @@ public abstract class RepositoryBranchMergeRestService extends AbstractRestServi
 	
 	@ApiOperation(
 		value = "Start branch merge or rebase", 
-		notes = "Signals that making changes on the source branch available on the target branch in the SNOMED CT repository " +
-				"should start as soon as possible."
+		notes = "Signals that making changes on the source branch available on the target branch in the repository should start as soon as possible."
 	)
 	@ApiResponses({
 		@ApiResponse(code = 202, message = "Accepted"),
@@ -87,6 +86,7 @@ public abstract class RepositoryBranchMergeRestService extends AbstractRestServi
 				.setReviewId(restRequest.getReviewId())
 				.setUserId(author)
 				.setCommitComment(restRequest.getCommitComment())
+				.setSquash(restRequest.isSquash())
 				.build(repositoryId)
 				.runAsJob(String.format("Merge branch '%s' into '%s'", sourcePath, targetPath))
 				.execute(getBus())

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/BranchMergeRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/BranchMergeRequest.java
@@ -34,9 +34,10 @@ import com.google.common.base.Strings;
  */
 public final class BranchMergeRequest extends AbstractBranchChangeRequest {
 
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 
 	private final Set<String> exclusions;
+	private final boolean squash;
 	
 	private static String commitMessageOrDefault(final String sourcePath, final String targetPath, final String commitMessage) {
 		return !Strings.isNullOrEmpty(commitMessage) 
@@ -44,9 +45,10 @@ public final class BranchMergeRequest extends AbstractBranchChangeRequest {
 				: String.format("Merge branch '%s' into '%s'", sourcePath, targetPath);
 	}
 
-	BranchMergeRequest(final String sourcePath, final String targetPath, Set<String> exclusions, final String userId, final String commitMessage, String reviewId, String parentLockContext) {
+	BranchMergeRequest(final String sourcePath, final String targetPath, Set<String> exclusions, final String userId, final String commitMessage, String reviewId, String parentLockContext, boolean squash) {
 		super(sourcePath, targetPath, userId, commitMessageOrDefault(sourcePath, targetPath, commitMessage), reviewId, parentLockContext);
 		this.exclusions = exclusions;
+		this.squash = squash;
 	}
 	
 	@Override
@@ -63,7 +65,7 @@ public final class BranchMergeRequest extends AbstractBranchChangeRequest {
 				.author(author)
 				.commitMessage(commitMessage)
 				.conflictProcessor(context.service(ComponentRevisionConflictProcessor.class))
-				.squash(true)
+				.squash(squash)
 				.context(context)
 				.merge();
 		} catch (BranchMergeException e) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/CreateMergeRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/CreateMergeRequestBuilder.java
@@ -17,13 +17,13 @@ package com.b2international.snowowl.core.branch;
 
 import java.util.Set;
 
+import com.b2international.commons.collections.Collections3;
 import com.b2international.snowowl.core.api.IBranchPath;
 import com.b2international.snowowl.core.domain.RepositoryContext;
 import com.b2international.snowowl.core.events.BaseRequestBuilder;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.merge.Merge;
 import com.b2international.snowowl.core.request.RepositoryRequestBuilder;
-import com.google.common.collect.Sets;
 
 /**
  * @since 4.5
@@ -34,10 +34,11 @@ public final class CreateMergeRequestBuilder extends BaseRequestBuilder<CreateMe
 	private String target;
 	private String commitComment;
 	private String reviewId;
-	private Set<String> exclusions = Sets.newHashSet();
+	private Set<String> exclusions;
 	
 	private String userId;
 	private String parentLockContext;
+	private boolean squash = true;
 	
 	CreateMergeRequestBuilder() {}
 	
@@ -76,6 +77,11 @@ public final class CreateMergeRequestBuilder extends BaseRequestBuilder<CreateMe
 		return this;
 	}
 	
+	public CreateMergeRequestBuilder setSquash(boolean squash) {
+		this.squash = squash;
+		return this;
+	}
+	
 	@Override
 	protected Request<RepositoryContext, Merge> doBuild() {
 		final IBranchPath sourcePath = BranchPathUtils.createPath(source);
@@ -83,7 +89,7 @@ public final class CreateMergeRequestBuilder extends BaseRequestBuilder<CreateMe
 		if (targetPath.getParent().equals(sourcePath)) {
 			return new BranchRebaseRequest(source, target, userId, commitComment, reviewId, parentLockContext);
 		} else {
-			return new BranchMergeRequest(source, target, exclusions, userId, commitComment, reviewId, parentLockContext);
+			return new BranchMergeRequest(source, target, Collections3.toImmutableSet(exclusions), userId, commitComment, reviewId, parentLockContext, squash);
 		}
 	}
 	


### PR DESCRIPTION
Expose squash property in merge API to make it possible to merge content
between branches without actually moving the content from the source
branch to the target branch.