### PR TITLE
Configurable bulk commits

### DIFF
--- a/commons/com.b2international.index/src/com/b2international/index/IndexClientFactory.java
+++ b/commons/com.b2international.index/src/com/b2international/index/IndexClientFactory.java
@@ -106,6 +106,16 @@ public interface IndexClientFactory {
 	 * Configuration key to specify the time to wait until yellow cluster health state is reached in milliseconds.
 	 */
 	String CLUSTER_HEALTH_TIMEOUT = "clusterHealthTimeout";
+	
+	/**
+	 * Configuration key to specify the number of bulk action items to send to the Elasticsearch cluster when performing bulk commit operations
+	 */
+	String BULK_ACTIONS_SIZE = "bulk_action_size";
+	
+	/**
+	 * Configuration key to specify the number of bulk action items in MB to send to the Elasticsearch cluster when performing bulk commit operations
+	 */
+	String BULK_ACTIONS_SIZE_IN_MB = "bulk_action_size_in_mb";
 
 	
 	//
@@ -158,6 +168,10 @@ public interface IndexClientFactory {
 	 * The default cluster.name value for embedded nodes and tcp based clients.
 	 */
 	String DEFAULT_CLUSTER_NAME = "elastic-snowowl";
+	
+	int DEFAULT_BULK_ACTIONS_SIZE = 10_000;
+			
+	int DEFAULT_BULK_ACTIONS_SIZE_IN_MB = 10;
 
 	/**
 	 * Create a new {@link IndexClient} with the given name.

--- a/commons/com.b2international.index/src/com/b2international/index/IndexClientFactory.java
+++ b/commons/com.b2international.index/src/com/b2international/index/IndexClientFactory.java
@@ -169,9 +169,15 @@ public interface IndexClientFactory {
 	 */
 	String DEFAULT_CLUSTER_NAME = "elastic-snowowl";
 	
+	/**
+	 * Default number of bulk action items to send in a single outgoing bulk request.
+	 */
 	int DEFAULT_BULK_ACTIONS_SIZE = 10_000;
-			
-	int DEFAULT_BULK_ACTIONS_SIZE_IN_MB = 10;
+	
+	/**
+	 * Default size in megabytes to limit all outgoing bulk requests.
+	 */
+	int DEFAULT_BULK_ACTIONS_SIZE_IN_MB = 9;
 
 	/**
 	 * Create a new {@link IndexClient} with the given name.

--- a/commons/com.b2international.index/src/com/b2international/index/es/EsDocumentWriter.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/EsDocumentWriter.java
@@ -178,8 +178,8 @@ public class EsDocumentWriter implements Writer {
 				}
 			})
 			.setConcurrentRequests(getConcurrencyLevel())
-			.setBulkActions(10_000)
-			.setBulkSize(new ByteSizeValue(10L, ByteSizeUnit.MB))
+			.setBulkActions((int) admin.settings().get(IndexClientFactory.BULK_ACTIONS_SIZE))
+			.setBulkSize(new ByteSizeValue((int) admin.settings().get(IndexClientFactory.BULK_ACTIONS_SIZE_IN_MB), ByteSizeUnit.MB))
 			.build();
 			
 			for (Class<?> type : ImmutableSet.copyOf(indexOperations.rowKeySet())) {

--- a/commons/com.b2international.index/src/com/b2international/index/es/admin/EsIndexAdmin.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/admin/EsIndexAdmin.java
@@ -89,7 +89,6 @@ public final class EsIndexAdmin implements IndexAdmin {
 
 	private static final EnumSet<DiffFlags> DIFF_FLAGS = EnumSet.of(DiffFlags.ADD_ORIGINAL_VALUE_ON_REPLACE);
 	private static final int DEFAULT_MAX_NUMBER_OF_VERSION_CONFLICT_RETRIES = 5;
-	private static final int BATCH_SIZE = 10_000;
 	
 	private final Random random = new Random();
 	private final EsClient client;
@@ -114,6 +113,8 @@ public final class EsIndexAdmin implements IndexAdmin {
 		this.settings.putIfAbsent(IndexClientFactory.RESULT_WINDOW_KEY, ""+IndexClientFactory.DEFAULT_RESULT_WINDOW);
 		this.settings.putIfAbsent(IndexClientFactory.MAX_TERMS_COUNT_KEY, ""+IndexClientFactory.DEFAULT_MAX_TERMS_COUNT);
 		this.settings.putIfAbsent(IndexClientFactory.TRANSLOG_SYNC_INTERVAL_KEY, IndexClientFactory.DEFAULT_TRANSLOG_SYNC_INTERVAL);
+		this.settings.putIfAbsent(IndexClientFactory.BULK_ACTIONS_SIZE, IndexClientFactory.DEFAULT_BULK_ACTIONS_SIZE);
+		this.settings.putIfAbsent(IndexClientFactory.BULK_ACTIONS_SIZE_IN_MB, IndexClientFactory.DEFAULT_BULK_ACTIONS_SIZE_IN_MB);
 		
 		final String prefix = (String) settings.getOrDefault(IndexClientFactory.INDEX_PREFIX, IndexClientFactory.DEFAULT_INDEX_PREFIX);
 		this.prefix = prefix.isEmpty() ? "" : prefix + ".";
@@ -582,9 +583,9 @@ public final class EsIndexAdmin implements IndexAdmin {
 				
 				final BulkByScrollResponse response; 
 				if ("update".equals(command)) {
-					response = client.updateByQuery(getTypeIndex(mapping), BATCH_SIZE, script, getConcurrencyLevel(), query);
+					response = client.updateByQuery(getTypeIndex(mapping), (int) settings.get(IndexClientFactory.BULK_ACTIONS_SIZE), script, getConcurrencyLevel(), query);
 				} else if ("delete".equals(command)) {
-					response = client.deleteByQuery(getTypeIndex(mapping), BATCH_SIZE, getConcurrencyLevel(), query);
+					response = client.deleteByQuery(getTypeIndex(mapping), (int) settings.get(IndexClientFactory.BULK_ACTIONS_SIZE), getConcurrencyLevel(), query);
 				} else {
 					throw new UnsupportedOperationException("Not implemented command: " + command);
 				}


### PR DESCRIPTION
This PR makes it possible to configure the previously hardcoded `10_000` bulk action items and `10MB` bulk action item size in MB used during commit operations. Configuring the two values are important when working with Elasticsearch clusters with restricted HTTP body sizes (like AWS Elasticsearch service). 