### PR TITLE
Support List values in search options

### DIFF
--- a/commons/com.b2international.commons/src/com/b2international/commons/options/HashMapOptions.java
+++ b/commons/com.b2international.commons/src/com/b2international/commons/options/HashMapOptions.java
@@ -161,11 +161,11 @@ public class HashMapOptions extends HashMap<String, Object> implements Options {
 		if (type.isInstance(value)) {
 			return Collections.singleton(type.cast(value));
 		} else {
-			final Set<Object> list = get(key, Set.class);
-			final Object first = list != null ? Iterables.getFirst(list, null) : null;
+			final Set<Object> set = get(key, Set.class);
+			final Object first = set != null ? Iterables.getFirst(set, null) : null;
 			if (first != null) {
 				if (type.isInstance(first)) {
-					return (Set<T>) list;
+					return (Set<T>) set;
 				}
 				throw new IllegalArgumentException(String.format("The elements (%s) in the List are not the instance of the given type (%s)", first.getClass(), type));
 			}

--- a/commons/com.b2international.commons/src/com/b2international/commons/options/HashMapOptions.java
+++ b/commons/com.b2international.commons/src/com/b2international/commons/options/HashMapOptions.java
@@ -15,14 +15,15 @@
  */
 package com.b2international.commons.options;
 
-import static java.util.Collections.emptySet;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -151,6 +152,30 @@ public class HashMapOptions extends HashMap<String, Object> implements Options {
 	@Override
 	public <T> Collection<T> getCollection(Enum<?> key, Class<T> type) {
 		return getCollection(key.name(), type);
+	}
+	
+	@Override
+	@SuppressWarnings("unchecked")
+	public final <T> Set<T> getSet(String key, Class<T> type) {
+		final Object value = get(key);
+		if (type.isInstance(value)) {
+			return Collections.singleton(type.cast(value));
+		} else {
+			final Set<Object> list = get(key, Set.class);
+			final Object first = list != null ? Iterables.getFirst(list, null) : null;
+			if (first != null) {
+				if (type.isInstance(first)) {
+					return (Set<T>) list;
+				}
+				throw new IllegalArgumentException(String.format("The elements (%s) in the List are not the instance of the given type (%s)", first.getClass(), type));
+			}
+			return emptySet();
+		}
+	}
+	
+	@Override
+	public <T> Set<T> getSet(Enum<?> key, Class<T> type) {
+		return getSet(key.name(), type);
 	}
 	
 	@Override

--- a/commons/com.b2international.commons/src/com/b2international/commons/options/Options.java
+++ b/commons/com.b2international.commons/src/com/b2international/commons/options/Options.java
@@ -196,7 +196,7 @@ public interface Options {
 	<T> Collection<T> getCollection(Enum<?> key, Class<T> type);
 
 	/**
-	 * Returns a set of values conform to the given class type found on the given key. If a single value (not a {@link List}) is mapped to the given
+	 * Returns a set of values conform to the given class type found on the given key. If a single value (not a {@link Set}) is mapped to the given
 	 * key, then it wraps the value in a {@link Collections#singleton(Object) singleton set} and returns it. Otherwise it tries to get the value
 	 * as an immutable {@link Set} and return it.
 	 * 

--- a/commons/com.b2international.commons/src/com/b2international/commons/options/Options.java
+++ b/commons/com.b2international.commons/src/com/b2international/commons/options/Options.java
@@ -183,7 +183,7 @@ public interface Options {
 	/**
 	 * Returns a collection of values conform to the given class type found on the given Enum key's name. If a single value (not a {@link Collection}) is mapped
 	 * to the given key, then it wraps the value in a {@link Collections#singleton(Object) singleton set} and returns it. Otherwise it tries to get
-	 * the value as a {@link Collection} and return it.
+	 * the value as an immutable {@link Collection} and return it.
 	 * 
 	 * @param key
 	 *            - the key whose associated value is to be returned
@@ -196,9 +196,39 @@ public interface Options {
 	<T> Collection<T> getCollection(Enum<?> key, Class<T> type);
 
 	/**
+	 * Returns a set of values conform to the given class type found on the given key. If a single value (not a {@link List}) is mapped to the given
+	 * key, then it wraps the value in a {@link Collections#singleton(Object) singleton set} and returns it. Otherwise it tries to get the value
+	 * as an immutable {@link Set} and return it.
+	 * 
+	 * @param key
+	 *            - the key whose associated value is to be returned
+	 * @param type
+	 *            - the type of the items if a set is mapped to the given key in this map
+	 * @return a {@link Set} mapped to the given key, or an empty set if there was no mapping for the key, never <code>null</code>.
+	 * @throws IllegalArgumentException
+	 *             - if the elements in the set is not applicable to the given type.
+	 */
+	<T> Set<T> getSet(String key, Class<T> type);
+	
+	/**
+	 * Returns a set of values conform to the given class type found on the given Enum key's name. If a single value (not a {@link Set}) is mapped to the given
+	 * key, then it wraps the value in a {@link Collections#singleton(Object) singleton set} and returns it. Otherwise it tries to get the value
+	 * as an immutable {@link Set} and return it.
+	 * 
+	 * @param key
+	 *            - the key whose associated value is to be returned
+	 * @param type
+	 *            - the type of the items if a set is mapped to the given key in this map
+	 * @return a {@link Set} mapped to the given key, or an empty set if there was no mapping for the key, never <code>null</code>.
+	 * @throws IllegalArgumentException
+	 *             - if the elements in the set is not applicable to the given type.
+	 */
+	<T> Set<T> getSet(Enum<?> key, Class<T> type);
+	
+	/**
 	 * Returns a list of values conform to the given class type found on the given key. If a single value (not a {@link List}) is mapped to the given
 	 * key, then it wraps the value in a {@link Collections#singletonList(Object) singleton list} and returns it. Otherwise it tries to get the value
-	 * as a {@link List} and return it.
+	 * as an immutable {@link List} and return it.
 	 * 
 	 * @param key
 	 *            - the key whose associated value is to be returned
@@ -213,7 +243,7 @@ public interface Options {
 	/**
 	 * Returns a list of values conform to the given class type found on the given Enum key's name. If a single value (not a {@link List}) is mapped to the given
 	 * key, then it wraps the value in a {@link Collections#singletonList(Object) singleton list} and returns it. Otherwise it tries to get the value
-	 * as a {@link List} and return it.
+	 * as an immutable {@link List} and return it.
 	 * 
 	 * @param key
 	 *            - the key whose associated value is to be returned

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/SearchResourceRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/SearchResourceRequestBuilder.java
@@ -144,12 +144,17 @@ public abstract class SearchResourceRequestBuilder<B extends SearchResourceReque
 	// XXX: Does not allow null values or collections with null values
 	protected final B addOption(String key, Object value) {
 		if (value instanceof Iterable<?>) {
-			for (final Object val : (Iterable<?>)value) {
+			for (final Object val : (Iterable<?>) value) {
 				if (val == null) {
 					throw new BadRequestException("%s filter cannot contain null values", key);
 				}
 			}
-			optionsBuilder.put(key, Collections3.toImmutableSet((Iterable<?>) value));
+			if (value instanceof List) {
+				optionsBuilder.put(key, Collections3.toImmutableList((Iterable<?>) value));
+			} else {
+				// handle any other Iterable subtype as Set
+				optionsBuilder.put(key, Collections3.toImmutableSet((Iterable<?>) value));
+			}
 		} else if (value != null) {
 			optionsBuilder.put(key, value);
 		}


### PR DESCRIPTION
This PR improves the API to store List search option values as Lists instead of converting them to distinct values in a Set.