### PR TITLE
Fix potential issue when merging revisions with no actual tracked field changes

### DIFF
--- a/commons/com.b2international.index.tests.tools/src/com/b2international/index/revision/BaseRevisionIndexTest.java
+++ b/commons/com.b2international.index.tests.tools/src/com/b2international/index/revision/BaseRevisionIndexTest.java
@@ -44,6 +44,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public abstract class BaseRevisionIndexTest {
 	
+	protected static final String USER_ID = UUID.randomUUID().toString();
 	protected static final String MAIN = RevisionBranch.MAIN_PATH;
 	protected static final String STORAGE_KEY1 = "1";
 	protected static final String STORAGE_KEY2 = "2";
@@ -132,7 +133,7 @@ public abstract class BaseRevisionIndexTest {
 		final long commitTimestamp = currentTime();
 		return index().prepareCommit(branchPath)
 			.stageChange(oldRevision, newRevision)
-			.commit(commitTimestamp, UUID.randomUUID().toString(), "Commit");
+			.commit(commitTimestamp, USER_ID, "Commit");
 	}
 	
 	protected final void indexRemove(final String branchPath, final Revision...removedRevisions) {
@@ -140,21 +141,21 @@ public abstract class BaseRevisionIndexTest {
 		StagingArea staging = index().prepareCommit(branchPath);
 		Arrays.asList(removedRevisions).forEach(staging::stageRemove);
 		staging
-			.commit(commitTimestamp, UUID.randomUUID().toString(), "Commit");
+			.commit(commitTimestamp, USER_ID, "Commit");
 	}
 
 	protected final Commit commit(final String branchPath, final Iterable<? extends Revision> newRevisions) {
 		final long commitTimestamp = currentTime();
 		StagingArea staging = index().prepareCommit(branchPath);
 		newRevisions.forEach(rev -> staging.stageNew(rev.getId(), rev));
-		return staging.commit(commitTimestamp, UUID.randomUUID().toString(), "Commit");
+		return staging.commit(commitTimestamp, USER_ID, "Commit");
 	}
 	
 	protected final void deleteRevision(final String branchPath, final Class<? extends Revision> type, final String key) {
 		final long commitTimestamp = currentTime();
 		StagingArea staging = index().prepareCommit(branchPath);
 		staging.stageRemove(key, getRevision(branchPath, type, key));
-		staging.commit(commitTimestamp, UUID.randomUUID().toString(), "Commit");
+		staging.commit(commitTimestamp, USER_ID, "Commit");
 	}
 	
 	protected final <T> Hits<T> search(final String branchPath, final Query<T> query) {

--- a/commons/com.b2international.index.tests/src/com/b2international/index/revision/NestedDocumentRevisionIndexTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/revision/NestedDocumentRevisionIndexTest.java
@@ -16,7 +16,7 @@
 package com.b2international.index.revision;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Collection;
 
@@ -88,12 +88,13 @@ public class NestedDocumentRevisionIndexTest extends BaseRevisionIndexTest {
 		updatedNestedData.setField1("field1_2");
 		updatedNestedData.setField2("field2_2");
 		final NestedRevisionData updatedDoc = new NestedRevisionData(STORAGE_KEY1, "parent1", updatedNestedData);
-		Commit commit = indexChange(a, doc, updatedDoc);
+		indexChange(a, doc, updatedDoc);
 		
 		RevisionCompare compare = index().compare(MAIN, a);
 		assertThat(compare.getDetails()).containsOnly(
-			RevisionCompareDetail.propertyChange(commit.getAuthor(), commit.getTimestamp(), commit.getComment(), Operation.CHANGE, updatedDoc.getObjectId(), "data/field1", "field1_1", "field1_2"),
-			RevisionCompareDetail.propertyChange(commit.getAuthor(), commit.getTimestamp(), commit.getComment(), Operation.CHANGE, updatedDoc.getObjectId(), "data/field2", "field2_1", "field2_2")
+			RevisionCompareDetail.componentChange(Operation.CHANGE, updatedDoc.getContainerId(), updatedDoc.getObjectId()),
+			RevisionCompareDetail.propertyChange(Operation.CHANGE, updatedDoc.getObjectId(), "data/field1", "field1_1", "field1_2"),
+			RevisionCompareDetail.propertyChange(Operation.CHANGE, updatedDoc.getObjectId(), "data/field2", "field2_1", "field2_2")
 		);
 	}
 	

--- a/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionCompareTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionCompareTest.java
@@ -99,13 +99,10 @@ public class RevisionCompareTest extends BaseRevisionIndexTest {
 		indexChange(MAIN, rev1, rev2);
 		
 		final RevisionCompare compare = index().compare(branch, MAIN);
-		assertThat(compare.getDetails()).hasSize(1);
-		final RevisionCompareDetail detail = compare.getDetails().iterator().next();
-		assertThat(detail.getOp()).isEqualTo(Operation.CHANGE);
-		assertThat(detail.getObject()).isEqualTo(ObjectId.of(DOC_TYPE, STORAGE_KEY1));
-		assertThat(detail.getProperty()).isEqualTo("field1");
-		assertThat(detail.getFromValue()).isEqualTo("field1");
-		assertThat(detail.getValue()).isEqualTo("field1Changed");
+		assertThat(compare.getDetails()).containsOnly(
+			RevisionCompareDetail.componentChange(Operation.CHANGE, rev2.getContainerId(), rev2.getObjectId()),
+			RevisionCompareDetail.propertyChange(Operation.CHANGE, rev2.getObjectId(), "field1", "field1", "field1Changed")
+		);
 	}
 	
 	@Test
@@ -118,13 +115,10 @@ public class RevisionCompareTest extends BaseRevisionIndexTest {
 		
 		final RevisionCompare compare = index().compare(MAIN, branch);
 		
-		assertThat(compare.getDetails()).hasSize(1);
-		final RevisionCompareDetail detail = compare.getDetails().iterator().next();
-		assertThat(detail.getOp()).isEqualTo(Operation.CHANGE);
-		assertThat(detail.getObject()).isEqualTo(ObjectId.of(DOC_TYPE, STORAGE_KEY1));
-		assertThat(detail.getProperty()).isEqualTo("field1");
-		assertThat(detail.getFromValue()).isEqualTo("field1");
-		assertThat(detail.getValue()).isEqualTo("field1Changed");
+		assertThat(compare.getDetails()).containsOnly(
+			RevisionCompareDetail.componentChange(Operation.CHANGE, rev2.getContainerId(), rev2.getObjectId()),
+			RevisionCompareDetail.propertyChange(Operation.CHANGE, rev2.getObjectId(), "field1", "field1", "field1Changed")
+		);
 	}
 	
 	@Test
@@ -191,7 +185,9 @@ public class RevisionCompareTest extends BaseRevisionIndexTest {
 		indexChange(branch, changed, rev1); // this actually reverts the prev. change, via a new revision
 
 		final RevisionCompare compare = index().compare(MAIN, branch);
-		assertThat(compare.getDetails()).isEmpty();
+		assertThat(compare.getDetails()).containsOnly(
+			RevisionCompareDetail.componentChange(Operation.CHANGE, rev1.getContainerId(), rev1.getObjectId())
+		);
 	}
 	
 	@Test

--- a/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionFixtures.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionFixtures.java
@@ -45,12 +45,14 @@ public class RevisionFixtures {
 			private String field1;
 			private String field2;
 			private List<String> terms;
+			private String derivedField;
 			
 			public Builder(RevisionData revisionData) {
 				this.id = revisionData.getId();
 				this.field1 = revisionData.field1;
 				this.field2 = revisionData.field2;
 				this.terms = revisionData.terms;
+				this.derivedField = revisionData.derivedField;
 			}
 
 			public Builder id(String id) {
@@ -73,6 +75,11 @@ public class RevisionFixtures {
 				return getSelf();
 			}
 			
+			public Builder derivedField(String derivedField) {
+				this.derivedField = derivedField;
+				return getSelf();
+			}
+			
 			@Override
 			protected Builder getSelf() {
 				return this;
@@ -80,7 +87,7 @@ public class RevisionFixtures {
 
 			@Override
 			public RevisionData build() {
-				return new RevisionData(id, field1, field2, terms);
+				return new RevisionData(id, field1, field2, terms, derivedField);
 			}
 		}
 		
@@ -88,9 +95,10 @@ public class RevisionFixtures {
 		private final String field1;
 		private final String field2;
 		private final List<String> terms;
+		private final String derivedField;
 
 		public RevisionData(final String id, final String field1, final String field2) {
-			this(id, field1, field2, null);
+			this(id, field1, field2, null, null);
 		}
 		
 		@JsonCreator
@@ -98,11 +106,13 @@ public class RevisionFixtures {
 				@JsonProperty(Revision.Fields.ID) final String id, 
 				@JsonProperty("field1") final String field1, 
 				@JsonProperty("field2") final String field2,
-				@JsonProperty("terms") final List<String> terms) {
+				@JsonProperty("terms") final List<String> terms,
+				@JsonProperty("derivedField") final String derivedField) {
 			super(id);
 			this.field1 = field1;
 			this.field2 = field2;
 			this.terms = terms;
+			this.derivedField = derivedField;
 		}
 		
 		public String getField1() {
@@ -115,6 +125,10 @@ public class RevisionFixtures {
 		
 		public List<String> getTerms() {
 			return terms;
+		}
+		
+		public String getDerivedField() {
+			return derivedField;
 		}
 		
 		@Override
@@ -188,7 +202,7 @@ public class RevisionFixtures {
 				@JsonProperty("field2") final String field2,
 				@JsonProperty("terms") final List<String> terms,
 				@JsonProperty("doi") final float doi) {
-			super(id, field1, field2, terms);
+			super(id, field1, field2, terms, null);
 			this.doi = doi;
 		}
 		
@@ -227,7 +241,7 @@ public class RevisionFixtures {
 				@JsonProperty("field2") final String field2,
 				@JsonProperty("terms") final List<String> terms,
 				@JsonProperty("value") final boolean active) {
-			super(id, field1, field2, terms);
+			super(id, field1, field2, terms, null);
 			this.active = active;
 		}
 		
@@ -251,7 +265,7 @@ public class RevisionFixtures {
 				@JsonProperty("terms") final List<String> terms,
 				@JsonProperty("from") final int from,
 				@JsonProperty("to") final int to) {
-			super(id, field1, field2, terms);
+			super(id, field1, field2, terms, null);
 			this.from = from;
 			this.to = to;
 		}

--- a/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionHistoryTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionHistoryTest.java
@@ -64,9 +64,13 @@ public class RevisionHistoryTest extends BaseRevisionIndexTest {
 		assertThat(commits).hasSize(2);
 		// first element should be the latest commit
 		final Commit commit = Iterables.getFirst(commits, null);
-		assertThat(commit.getDetails()).hasSize(1);
-		final CommitDetail objectChange = CommitDetail.changedProperty("field1", "field1", "field1Changed", DOC_TYPE, Collections.singletonList(STORAGE_KEY1));
-		assertThat(commit.getDetailsByObject(STORAGE_KEY1)).containsOnly(objectChange);
+		assertThat(commit.getDetails()).hasSize(2);
+		final CommitDetail expectedObjectPropertyChange = CommitDetail.changedProperty("field1", "field1", "field1Changed", DOC_TYPE, Collections.singletonList(STORAGE_KEY1));
+		final CommitDetail expectedObjectChange = CommitDetail.changed(DOC_TYPE, DOC_TYPE).putObjects(ObjectId.ROOT, Collections.singleton(STORAGE_KEY1)).build();
+		assertThat(commit.getDetailsByObject(STORAGE_KEY1)).contains(
+			expectedObjectPropertyChange,
+			expectedObjectChange
+		);
 	}
 	
 	@Test

--- a/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranchChangeSet.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranchChangeSet.java
@@ -59,9 +59,16 @@ public final class RevisionBranchChangeSet {
 					}
 				}
 			} else if (detail.isChange()) {
-				Class<?> revType = DocumentMapping.getClass(detail.getObject().type());
-				if (Revision.class.isAssignableFrom(revType)) {
-					changedRevisionIdsByType.put((Class<? extends Revision>) revType, detail.getObject().id());
+				if (detail.isPropertyChange()) {
+					Class<?> revType = DocumentMapping.getClass(detail.getObject().type());
+					if (Revision.class.isAssignableFrom(revType)) {
+						changedRevisionIdsByType.put((Class<? extends Revision>) revType, detail.getObject().id());
+					}
+				} else {
+					Class<?> revType = DocumentMapping.getClass(detail.getComponent().type());
+					if (Revision.class.isAssignableFrom(revType)) {
+						changedRevisionIdsByType.put((Class<? extends Revision>) revType, detail.getComponent().id());
+					}
 				}
 			} else if (detail.isRemove()) {
 				Class<?> revType = DocumentMapping.getClass(detail.getComponent().type());

--- a/commons/com.b2international.index/src/com/b2international/index/revision/RevisionCompare.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/RevisionCompare.java
@@ -66,9 +66,6 @@ public final class RevisionCompare {
 						} else {
 							details = Collections.singletonList(
 									RevisionCompareDetail.propertyChange(
-											commit.getAuthor(), 
-											commit.getTimestamp(), 
-											commit.getComment(), 
 											detail.getOp(), 
 											objectId, 
 											detail.getProp(), 
@@ -78,7 +75,7 @@ public final class RevisionCompare {
 						details = detail.getComponents()
 								.get(i)
 								.stream()
-								.map(component -> RevisionCompareDetail.componentChange(commit.getAuthor(), commit.getTimestamp(), commit.getComment(), detail.getOp(), objectId, ObjectId.of(detail.getComponentType(), component)))
+								.map(component -> RevisionCompareDetail.componentChange(detail.getOp(), objectId, ObjectId.of(detail.getComponentType(), component)))
 								.collect(Collectors.toList());
 					}
 					

--- a/commons/com.b2international.index/src/com/b2international/index/revision/RevisionCompareDetail.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/RevisionCompareDetail.java
@@ -29,10 +29,6 @@ public final class RevisionCompareDetail {
 
 	static final String PROPERTY_CHANGE_KEY_SEPARATOR = "#";
 	
-	// commit details
-	private final String author;
-	private final long timestamp;
-	private final String comment;
 	// change details (hierarchy)
 	private final Operation op;
 	private final ObjectId object;
@@ -45,39 +41,26 @@ public final class RevisionCompareDetail {
 	@JsonIgnore
 	private final String key;
 	
-	public static RevisionCompareDetail propertyChange(String author, 
-			long timestamp, 
-			String comment, 
-			Operation op,
+	public static RevisionCompareDetail propertyChange(Operation op,
 			ObjectId object,
 			String property,
 			String fromValue,
 			String value) {
-		return new RevisionCompareDetail(author, timestamp, comment, op, object, null, property, fromValue, value);
+		return new RevisionCompareDetail(op, object, null, property, fromValue, value);
 	}
 	
-	public static RevisionCompareDetail componentChange(String author, 
-			long timestamp, 
-			String comment, 
-			Operation op,
+	public static RevisionCompareDetail componentChange(Operation op,
 			ObjectId object,
 			ObjectId component) {
-		return new RevisionCompareDetail(author, timestamp, comment, op, object, component, null, null, null);
+		return new RevisionCompareDetail(op, object, component, null, null, null);
 	}
 	
-	private RevisionCompareDetail(
-			String author, 
-			long timestamp, 
-			String comment, 
-			Operation op,
+	private RevisionCompareDetail(Operation op,
 			ObjectId object,
 			ObjectId component,
 			String property,
 			String fromValue,
 			String value) {
-		this.author = author;
-		this.timestamp = timestamp;
-		this.comment = comment;
 		this.op = op;
 		this.object = object;
 		this.component = component;
@@ -89,18 +72,6 @@ public final class RevisionCompareDetail {
 		} else {
 			this.key = String.join(PROPERTY_CHANGE_KEY_SEPARATOR, object.toString(), property);
 		}
-	}
-	
-	public String getAuthor() {
-		return author;
-	}
-	
-	public String getComment() {
-		return comment;
-	}
-	
-	public long getTimestamp() {
-		return timestamp;
 	}
 	
 	public Operation getOp() {
@@ -163,10 +134,7 @@ public final class RevisionCompareDetail {
 		if (this == obj) return true;
 		if (getClass() != obj.getClass()) return false;
 		RevisionCompareDetail other = (RevisionCompareDetail) obj;
-		return Objects.equals(author, other.author)
-				&& Objects.equals(timestamp, other.timestamp)
-				&& Objects.equals(comment, other.comment)
-				&& Objects.equals(op, other.op)
+		return Objects.equals(op, other.op)
 				&& Objects.equals(object, other.object)
 				&& Objects.equals(component, other.component)
 				&& Objects.equals(property, other.property)
@@ -176,7 +144,7 @@ public final class RevisionCompareDetail {
 	
 	@Override
 	public int hashCode() {
-		return Objects.hash(author, timestamp, comment, op, object, component, property, fromValue, value);
+		return Objects.hash(op, object, component, property, fromValue, value);
 	}
 	
 	@Override
@@ -218,7 +186,7 @@ public final class RevisionCompareDetail {
 				return null;
 			} else {
 				// otherwise all new values except the from value, we would like to see the original from value -> latest new value change in the result
-				return propertyChange(other.author, other.timestamp, other.comment, other.op, other.object, other.property, fromValue, other.value);
+				return propertyChange(other.op, other.object, other.property, fromValue, other.value);
 			}
 		}
 	}

--- a/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
@@ -331,9 +331,7 @@ public final class StagingArea {
 					// register component as changed in commit doc
 					ObjectId containerId = checkNotNull(rev.getContainerId(), "Missing containerId for revision: %s", rev);
 					ObjectId objectId = rev.getObjectId();
-					if (!containerId.isRoot()) { // XXX register only sub-components in the changed objects
-						changedComponentsByContainer.put(containerId, objectId);
-					}
+					changedComponentsByContainer.put(containerId, objectId);
 					
 					if (revisionDiff.diff() != null) {
 						// register actual difference between revisions to commit
@@ -740,10 +738,12 @@ public final class StagingArea {
 							}
 						}
 					} else {
-						// this object has changed on both sides probably due to some cascading change, revise the revision on source, since we already have one on this branch
-						revisionsToReviseOnMergeSource.put(type, changedInSourceAndTargetId);
 						fromChangeSet.removeChanged(type, changedInSourceAndTargetId);
 					}
+					
+					// this object has changed on both sides either by tracked field changes or due to some cascading derived field change
+					// revise the revision on source, since we already have one on this branch already
+					revisionsToReviseOnMergeSource.put(type, changedInSourceAndTargetId);
 				}
 			}
 		}


### PR DESCRIPTION
Either no changes or derived field only changes can cause duplicate revisions when merging a branch into another.
Commit documents now contain a change entry for all revision objects
regardless of whether they had a tracked property change or not.