### PR TITLE
SO-4422: Add filter for OID in code system search

### DIFF
--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemCreateRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemCreateRequest.java
@@ -157,14 +157,12 @@ final class CodeSystemCreateRequest implements Request<TransactionContext, Strin
 	}
 
 	private Optional<CodeSystemVersionEntry> checkCodeSystem(final TransactionContext context) {
-		
-		//OID must be unique if defined
-		if (!StringUtils.isEmpty(oid)) {
-			if (codeSystemExists(oid, context)) {
-				throw new AlreadyExistsException("Code system", oid);
-			}
+		// OID must be unique if defined
+		if (!StringUtils.isEmpty(oid) && codeSystemExists(oid, context)) {
+			throw new AlreadyExistsException("Code system", oid);
 		}
-		
+
+		// Short name is always checked against existing code systems
 		if (codeSystemExists(shortName, context)) {
 			throw new AlreadyExistsException("Code system", shortName);
 		}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemCreateRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemCreateRequest.java
@@ -157,8 +157,12 @@ final class CodeSystemCreateRequest implements Request<TransactionContext, Strin
 	}
 
 	private Optional<CodeSystemVersionEntry> checkCodeSystem(final TransactionContext context) {
-		if (codeSystemExists(oid, context)) {
-			throw new AlreadyExistsException("Code system", oid);
+		
+		//OID must be unique if defined
+		if (!StringUtils.isEmpty(oid)) {
+			if (codeSystemExists(oid, context)) {
+				throw new AlreadyExistsException("Code system", oid);
+			}
 		}
 		
 		if (codeSystemExists(shortName, context)) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemSearchRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemSearchRequest.java
@@ -50,6 +50,8 @@ final class CodeSystemSearchRequest
 		NAME,
 		/** Exact match for code system name */
 		NAME_EXACT,
+		/** HL7 registry OID **/
+		OID
 	}
 	
 	@Override
@@ -69,6 +71,7 @@ final class CodeSystemSearchRequest
 		addToolingIdFilter(queryBuilder);
 		addNameFilter(queryBuilder);
 		addNameExactFilter(queryBuilder);
+		addOidFilter(queryBuilder);
 		
 		return queryBuilder.build();
 	}
@@ -97,6 +100,12 @@ final class CodeSystemSearchRequest
 		if (containsKey(OptionKey.NAME_EXACT)) {
 			queryBuilder.must(CodeSystemEntry.Expressions.matchNameOriginal(getString(OptionKey.NAME_EXACT)));
 		}		
+	}
+	
+	private void addOidFilter(final ExpressionBuilder queryBuilder) {
+		if (containsKey(OptionKey.OID)) {
+			queryBuilder.filter(CodeSystemEntry.Expressions.oids(getCollection(OptionKey.OID, String.class)));
+		}
 	}
 	
 	@Override

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemSearchRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemSearchRequestBuilder.java
@@ -47,6 +47,14 @@ public final class CodeSystemSearchRequestBuilder
 	public CodeSystemSearchRequestBuilder filterByNameExact(String term) {
 		return addOption(OptionKey.NAME_EXACT, term);
 	}
+	
+	public CodeSystemSearchRequestBuilder filterByOid(String oid) {
+		return addOption(OptionKey.OID, oid);
+	}
+
+	public CodeSystemSearchRequestBuilder filterByOids(Iterable<String> oids) {
+		return addOption(OptionKey.OID, oids);
+	}
 
 	@Override
 	protected SearchResourceRequest<RepositoryContext, CodeSystems> createSearch() {


### PR DESCRIPTION
Also make the OID property optional when creating new code systems. It should still be unique if specified.