### PR TITLE
Fix default doc sorting issues

### DIFF
--- a/cis/com.b2international.snowowl.snomed.cis/src/com/b2international/snowowl/snomed/cis/domain/SctId.java
+++ b/cis/com.b2international.snowowl.snomed.cis/src/com/b2international/snowowl/snomed/cis/domain/SctId.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 
 import com.b2international.commons.CompareUtils;
 import com.b2international.index.Doc;
+import com.b2international.index.ID;
 import com.b2international.index.query.Expression;
 import com.b2international.snowowl.core.terminology.ComponentCategory;
 import com.b2international.snowowl.snomed.cis.SnomedIdentifiers;
@@ -62,6 +63,7 @@ public class SctId implements Serializable {
 		}
 	}
 	
+	@ID
 	private String sctid;
 
 	private long sequence;

--- a/commons/com.b2international.index/src/com/b2international/index/ID.java
+++ b/commons/com.b2international.index/src/com/b2international/index/ID.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.index;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Annotated on a field that will be used as the unique ID of the document in the index.
+ * 
+ * @since 7.12
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface ID {
+
+}

--- a/commons/com.b2international.index/src/com/b2international/index/es/EsDocumentSearcher.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/EsDocumentSearcher.java
@@ -396,7 +396,7 @@ public class EsDocumentSearcher implements Searcher {
 					// XXX: default order for scores is *descending*
 					reqSource.sort(SortBuilders.scoreSort().order(sortOrder)); 
 					break;
-				case "_default":
+				case "_default": //$FALL-THROUGH$
 					if (liveScroll) {
 						// for live scrolls use the document ID field as tiebreaker
 						field = mapping.getIdField();

--- a/commons/com.b2international.index/src/com/b2international/index/es/EsDocumentSearcher.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/EsDocumentSearcher.java
@@ -76,7 +76,6 @@ import com.b2international.index.query.Expressions;
 import com.b2international.index.query.Query;
 import com.b2international.index.query.SortBy;
 import com.b2international.index.query.SortBy.MultiSortBy;
-import com.b2international.index.query.SortBy.Order;
 import com.b2international.index.query.SortBy.SortByField;
 import com.b2international.index.query.SortBy.SortByScript;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -123,7 +122,8 @@ public class EsDocumentSearcher implements Searcher {
 	
 	@Override
 	public <T> Iterable<T> get(Class<T> type, Iterable<String> keys) throws IOException {
-		return search(Query.select(type).where(Expressions.matchAny(DocumentMapping._ID, keys)).limit(Iterables.size(keys)).build());
+		final DocumentMapping mapping = admin.mappings().getMapping(type);
+		return search(Query.select(type).where(Expressions.matchAny(mapping.getIdField(), keys)).limit(Iterables.size(keys)).build());
 	}
 
 	@Override
@@ -158,10 +158,7 @@ public class EsDocumentSearcher implements Searcher {
 			reqSource.storedFields(STORED_FIELDS_NONE);
 		}
 		
-		// sorting
-		addSort(mapping, reqSource, query.getSortBy());
-		
-		// scrolling
+		// scroll config
 		final boolean isLocalScroll = limit > resultWindow;
 		final boolean isScrolled = !Strings.isNullOrEmpty(query.getScrollKeepAlive());
 		final boolean isLiveScrolled = !Strings.isNullOrEmpty(query.getSearchAfter());
@@ -179,6 +176,8 @@ public class EsDocumentSearcher implements Searcher {
 			reqSource.searchAfter(fromSearchAfterToken(query.getSearchAfter()));
 		}
 		
+		// sorting config with a default sort field based on scroll config
+		addSort(mapping, reqSource, query.getSortBy(), !isScrolled && !isLocalScroll);
 		// disable explain explicitly, just in case
 		reqSource.explain(false);
 		// disable version field explicitly, just in case
@@ -384,7 +383,7 @@ public class EsDocumentSearcher implements Searcher {
 		}
 	}
 
-	private void addSort(DocumentMapping mapping, SearchSourceBuilder reqSource, SortBy sortBy) {
+	private void addSort(DocumentMapping mapping, SearchSourceBuilder reqSource, SortBy sortBy, boolean liveScroll) {
 		for (final SortBy item : getSortFields(sortBy)) {
 			if (item instanceof SortByField) {
 				SortByField sortByField = (SortByField) item;
@@ -397,8 +396,14 @@ public class EsDocumentSearcher implements Searcher {
 					// XXX: default order for scores is *descending*
 					reqSource.sort(SortBuilders.scoreSort().order(sortOrder)); 
 					break;
-				case DocumentMapping._DOC: //$FALL-THROUGH$
-					field = DocumentMapping._DOC;
+				case "_default":
+					if (liveScroll) {
+						// for live scrolls use the document ID field as tiebreaker
+						field = mapping.getIdField();
+					} else {
+						// for snapshot scrolls use the "_doc" field as tiebreaker
+						field = "_doc";
+					}
 				default:
 					reqSource.sort(SortBuilders.fieldSort(field).order(sortOrder));
 				}
@@ -426,15 +431,15 @@ public class EsDocumentSearcher implements Searcher {
 			items.add(sortBy);
 		}
 
-		Optional<SortByField> existingDocSort = items.stream()
-			.filter(SortByField.class::isInstance)
-			.map(SortByField.class::cast)
-			.filter(field -> DocumentMapping._DOC.equals(field.getField()))
-			.findFirst();
+		Optional<SortByField> existingDefaultSort = items.stream()
+				.filter(SortByField.class::isInstance)
+				.map(SortByField.class::cast)
+				.filter(field -> SortBy.DEFAULT.getField().equals(field.getField()))
+				.findFirst();
 		
-		if (!existingDocSort.isPresent()) {
-			// add _doc field as tiebreaker if not defined in the original SortBy
-			items.add(SortBy.field(DocumentMapping._DOC, Order.DESC));
+		if (!existingDefaultSort.isPresent()) {
+			// add the default field (either _doc or ID field) as tie breaker
+			items.add(SortBy.DEFAULT);
 		}
 		
 		return Iterables.filter(items, SortBy.class);

--- a/commons/com.b2international.index/src/com/b2international/index/mapping/DocumentMapping.java
+++ b/commons/com.b2international.index/src/com/b2international/index/mapping/DocumentMapping.java
@@ -28,6 +28,9 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.b2international.collections.PrimitiveCollection;
 import com.b2international.index.Analyzers;
 import com.b2international.index.Doc;
@@ -58,6 +61,8 @@ import com.google.common.collect.Maps;
  */
 public final class DocumentMapping {
 
+	private static final Logger LOG = LoggerFactory.getLogger(DocumentMapping.class);
+	
 	private static final BiMap<Class<?>, String> DOC_TYPE_CACHE = HashBiMap.create();
 	
 	// type path delimiter to differentiate between same nested types in different contexts
@@ -99,6 +104,7 @@ public final class DocumentMapping {
 		} else if (idFields.size() == 1) {
 			this.idField = Iterables.getOnlyElement(idFields).getName();
 		} else {
+			LOG.warn("'{}' does not define an ID annotated field, falling back to the deprecated '_id', but keep in mind that support will be removed in 8.0", type.getName());
 			this.idField = _ID;
 		}
 		

--- a/commons/com.b2international.index/src/com/b2international/index/query/DefaultQueryBuilder.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/DefaultQueryBuilder.java
@@ -40,7 +40,7 @@ class DefaultQueryBuilder<T> implements QueryBuilder<T>, AfterWhereBuilder<T> {
 	private String searchAfter;
 	private int limit = DEFAULT_LIMIT;
 	private Expression where;
-	private SortBy sortBy = SortBy.DOC;
+	private SortBy sortBy = SortBy.DEFAULT;
 	private boolean withScores = false;
 
 	private List<String> fields = Collections.emptyList();

--- a/commons/com.b2international.index/src/com/b2international/index/query/Query.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ public final class Query<T> {
 	private Class<T> select;
 	private Class<?> from;
 	private Expression where;
-	private SortBy sortBy = SortBy.DOC;
+	private SortBy sortBy = SortBy.DEFAULT;
 	private Class<?> parentType;
 	private boolean withScores;
 	private List<String> fields;
@@ -207,7 +207,7 @@ public final class Query<T> {
 		sb.append("SELECT " + getSelectString());
 		sb.append(" FROM " + DocumentMapping.getType(from));
 		sb.append(" WHERE " + where);
-		if (!SortBy.DOC.equals(sortBy)) {
+		if (!SortBy.DEFAULT.equals(sortBy)) {
 			sb.append(" SORT BY " + sortBy);
 		}
 		sb.append(" LIMIT " + limit);

--- a/commons/com.b2international.index/src/com/b2international/index/query/SortBy.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/SortBy.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import com.b2international.index.ScriptExpression;
-import com.b2international.index.mapping.DocumentMapping;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -44,9 +43,9 @@ public abstract class SortBy {
 	public static final String FIELD_SCORE = "_score";
 	
 	/**
-	 * Singleton representing document sort based on their natural occurrence. 
+	 * Singleton representing document sort based on their default sort field (usually the ID, but in case of scroll we can use _doc to speed things up) in ascending order.
 	 */
-	public static final SortBy DOC = SortBy.field(DocumentMapping._DOC, Order.ASC);
+	public static final SortByField DEFAULT = SortBy.field("_default", Order.ASC);
 	
 	/**
 	 * Singleton representing document sort based on their score in decreasing order (higher score first).
@@ -199,7 +198,7 @@ public abstract class SortBy {
 		
 		public SortBy build() {
 			if (sorts.isEmpty()) {
-				return DOC;
+				return DEFAULT;
 			} else if (sorts.size() == 1) {
 				return Iterables.getOnlyElement(sorts);
 			} else {
@@ -214,7 +213,7 @@ public abstract class SortBy {
 	 * @param order - the order to use when sorting matches
 	 * @return
 	 */
-	public static SortBy field(String field, Order order) {
+	public static SortByField field(String field, Order order) {
 		return new SortByField(field, order);
 	}
 	

--- a/commons/com.b2international.index/src/com/b2international/index/revision/Commit.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/Commit.java
@@ -36,9 +36,9 @@ import java.util.Set;
 import com.b2international.commons.collections.Collections3;
 import com.b2international.index.Analyzers;
 import com.b2international.index.Doc;
+import com.b2international.index.ID;
 import com.b2international.index.Text;
 import com.b2international.index.WithScore;
-import com.b2international.index.mapping.DocumentMapping;
 import com.b2international.index.query.Expression;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -135,11 +135,11 @@ public final class Commit implements WithScore {
 		private Expressions() {}
 		
 		public static final Expression id(String id) {
-			return DocumentMapping.matchId(id);
+			return exactMatch(Fields.ID, id);
 		}
 		
 		public static final Expression ids(Collection<String> ids) {
-			return matchAny(DocumentMapping._ID, ids);
+			return matchAny(Fields.ID, ids);
 		}
 		
 		public static Expression branches(final String...branchPaths) {
@@ -194,6 +194,7 @@ public final class Commit implements WithScore {
 	 * @since 7.0
 	 */
 	public static final class Fields {
+		public static final String ID = "id";
 		public static final String BRANCH = "branch";
 		public static final String AUTHOR = "author";
 		public static final String COMMENT = "comment";
@@ -206,6 +207,7 @@ public final class Commit implements WithScore {
 		public static final Set<String> ALL = ImmutableSet.of(BRANCH, AUTHOR, TIMESTAMP);
 	}
 
+	@ID
 	private final String id;
 	private final String branch;
 	private final String author;

--- a/commons/com.b2international.index/src/com/b2international/index/revision/Revision.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/Revision.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Collections;
 import java.util.List;
 
+import com.b2international.index.ID;
 import com.b2international.index.Script;
 import com.b2international.index.mapping.DocumentMapping;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -56,6 +57,7 @@ public abstract class Revision {
 	// scripts
 	public static final String UPDATE_REVISED = "updateRevised";
 
+	@ID
 	private String id;
 	
 	/**

--- a/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranch.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranch.java
@@ -31,6 +31,7 @@ import com.b2international.commons.exceptions.BadRequestException;
 import com.b2international.commons.options.Metadata;
 import com.b2international.commons.options.MetadataHolderImpl;
 import com.b2international.index.Doc;
+import com.b2international.index.ID;
 import com.b2international.index.Script;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -249,6 +250,8 @@ public final class RevisionBranch extends MetadataHolderImpl {
 	private final long id;
 	private final String name;
     private final String parentPath;
+    
+    @ID
     private final String path;
     private final boolean deleted;
 	private final SortedSet<RevisionSegment> segments;

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/AbstractRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/AbstractRestService.java
@@ -93,7 +93,6 @@ public abstract class AbstractRestService {
 	public AbstractRestService(Set<String> sortFields) {
 		final Set<String> allowedSortFields = ImmutableSet.<String>builder()
 			.addAll(Collections3.toImmutableSet(sortFields))
-			.add(SearchIndexResourceRequest.DOC_ID.getField())
 			.add(SearchIndexResourceRequest.SCORE.getField())
 			.build();
 		this.sortKeyPattern = Pattern.compile("^(" + String.join("|", allowedSortFields) + ")(?:[:](asc|desc))?$");

--- a/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/locks/LockIndexTests.java
+++ b/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/locks/LockIndexTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2019-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import com.b2international.index.mapping.Mappings;
 import com.b2international.index.revision.Revision;
 import com.b2international.index.util.Reflections;
 import com.b2international.snowowl.core.internal.locks.DatastoreLockContextDescriptions;
-import com.b2international.snowowl.core.locks.DatastoreLockIndexEntry;
 import com.b2international.snowowl.core.repository.JsonSupport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/Branch.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/Branch.java
@@ -145,7 +145,7 @@ public final class Branch implements MetadataHolder, Serializable {
 	 */
 	@JsonProperty
 	public String path() {
-		return Strings.isNullOrEmpty(parentPath) ? name : parentPath + Branch.SEPARATOR + name;
+		return Strings.isNullOrEmpty(parentPath) ? name : String.join(Branch.SEPARATOR, parentPath, name);
 	}
 
 	/**

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/review/Review.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/review/Review.java
@@ -19,6 +19,7 @@ import java.util.Date;
 import java.util.Set;
 
 import com.b2international.index.Doc;
+import com.b2international.index.ID;
 import com.b2international.snowowl.core.branch.Branch;
 import com.fasterxml.jackson.databind.util.ISO8601Utils;
 import com.google.common.collect.ImmutableSet;
@@ -38,6 +39,7 @@ public final class Review {
 		public static final Set<String> ALL = ImmutableSet.of(ID, LAST_UPDATED, STATUS);
 	}
 	
+	@ID
 	private final String id;
 	private final String lastUpdated;
 	private final ReviewStatus status;

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemEntry.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemEntry.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.index.Analyzers;
 import com.b2international.index.Doc;
+import com.b2international.index.ID;
 import com.b2international.index.Normalizers;
 import com.b2international.index.Text;
 import com.b2international.index.query.Expression;
@@ -257,6 +258,7 @@ public final class CodeSystemEntry implements Serializable {
 	@com.b2international.index.Text(alias="analyzed") // Analyzed text appears as a field alias
 	private final String name; 
 
+	@ID
 	private final String shortName; 
 	private final String orgLink; 
 	private final String language; 

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemVersionEntry.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemVersionEntry.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import com.b2international.index.Doc;
+import com.b2international.index.ID;
 import com.b2international.index.query.Expression;
 import com.b2international.snowowl.core.api.IBranchPath;
 import com.b2international.snowowl.core.branch.Branch;
@@ -206,6 +207,7 @@ public final class CodeSystemVersionEntry implements Serializable {
 		
 	}
 	
+	@ID
 	private final String id;
 	private final long importDate;
 	private final long effectiveDate;

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/jobs/RemoteJobEntry.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/jobs/RemoteJobEntry.java
@@ -32,10 +32,10 @@ import java.util.Set;
 import com.b2international.commons.CompareUtils;
 import com.b2international.index.Analyzers;
 import com.b2international.index.Doc;
+import com.b2international.index.ID;
 import com.b2international.index.Keyword;
 import com.b2international.index.Script;
 import com.b2international.index.Text;
-import com.b2international.index.mapping.DocumentMapping;
 import com.b2international.index.query.Expression;
 import com.b2international.snowowl.core.api.SnowowlRuntimeException;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -96,15 +96,15 @@ public final class RemoteJobEntry implements Serializable {
 	public static class Expressions {
 
 		public static Expression id(String id) {
-			return DocumentMapping.matchId(id);
+			return exactMatch(Fields.ID, id);
 		}
 
 		public static Expression ids(Collection<String> ids) {
-			return matchAny(DocumentMapping._ID, ids);
+			return matchAny(Fields.ID, ids);
 		}
 		
 		public static Expression idPrefix(String id) {
-			return prefixMatch(DocumentMapping._ID, id);
+			return prefixMatch(Fields.ID, id);
 		}
 		
 		public static Expression key(String key) {
@@ -251,7 +251,7 @@ public final class RemoteJobEntry implements Serializable {
 		
 	}
 	
-
+	@ID
 	private final String id;
 	private final String key;
 	

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DatastoreLockIndexEntry.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DatastoreLockIndexEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2019-2020 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.util.Collection;
 import java.util.Objects;
 
 import com.b2international.index.Doc;
-import com.b2international.index.mapping.DocumentMapping;
+import com.b2international.index.ID;
 import com.b2international.index.query.Expression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -50,12 +50,13 @@ public final class DatastoreLockIndexEntry implements Serializable {
 	}
 	
 	public static class Expressions {
+
 		public static Expression id(final String id) {
-			return DocumentMapping.matchId(id);
+			return exactMatch(Fields.ID, id);
 		}
 		
 		public static Expression ids(final Collection<String> ids) {
-			return matchAny(DocumentMapping._ID, ids);
+			return matchAny(Fields.ID, ids);
 		}
 		
 		public static Expression userId(final String userId) {
@@ -97,6 +98,7 @@ public final class DatastoreLockIndexEntry implements Serializable {
 	@JsonPOJOBuilder(withPrefix="")
 	public static class Builder {
 		
+		@ID
 		private String id;
 		private String userId;
 		private String description;

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DatastoreLockIndexEntry.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DatastoreLockIndexEntry.java
@@ -98,7 +98,6 @@ public final class DatastoreLockIndexEntry implements Serializable {
 	@JsonPOJOBuilder(withPrefix="")
 	public static class Builder {
 		
-		@ID
 		private String id;
 		private String userId;
 		private String description;
@@ -146,6 +145,7 @@ public final class DatastoreLockIndexEntry implements Serializable {
 		}
 	}
 	
+	@ID
 	private final String id;
 	private final String userId;
 	private final String description;

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DatastoreOperationLockManager.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DatastoreOperationLockManager.java
@@ -384,7 +384,7 @@ public final class DatastoreOperationLockManager implements IOperationLockManage
 	}
 	
 	private DatastoreLocks search(Expression query, int limit) {
-		return search(query, ImmutableList.of(), SortBy.DOC, limit); 
+		return search(query, ImmutableList.of(), SortBy.DEFAULT, limit); 
 	}
 	
 	private DatastoreLocks search(Expression query, List<String> fields, SortBy sortBy, int limit) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/SearchIndexResourceRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/SearchIndexResourceRequest.java
@@ -24,8 +24,8 @@ import javax.annotation.OverridingMethodsMustInvokeSuper;
 
 import com.b2international.commons.CompareUtils;
 import com.b2international.index.Hits;
+import com.b2international.index.ID;
 import com.b2international.index.Searcher;
-import com.b2international.index.mapping.DocumentMapping;
 import com.b2international.index.query.Expression;
 import com.b2international.index.query.Expressions;
 import com.b2international.index.query.Expressions.ExpressionBuilder;
@@ -46,11 +46,6 @@ import com.b2international.snowowl.core.domain.CollectionResource;
  */
 public abstract class SearchIndexResourceRequest<C extends ServiceProvider, B, D> extends SearchResourceRequest<C, B> {
 
-	/**
-	 * Special field name for sorting based on the document's natural occurrence (document order). 
-	 */
-	public static final SortField DOC_ID = SortField.ascending(DocumentMapping._ID);
-	
 	/**
 	 * Special field name for sorting based on the document score (relevance).
 	 */
@@ -93,7 +88,7 @@ public abstract class SearchIndexResourceRequest<C extends ServiceProvider, B, D
 	}
 	
 	/**
-	 * @return the currently set {@link SortBy} search option or if sort is not present in the request, the default sort which is by <code>_id</code> document id.
+	 * @return the currently set {@link SortBy} search option or if sort is not present in the request, the default sort which is by the configured {@link ID} document field.
 	 */
 	protected final SortBy querySortBy(C context) {
 		List<Sort> sortBy = sortBy();
@@ -104,7 +99,7 @@ public abstract class SearchIndexResourceRequest<C extends ServiceProvider, B, D
 			}
 			return sortBuilder.build();
 		}		
-		return SortBy.DOC;
+		return SortBy.DEFAULT;
 	}
 	
 	/**

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/SearchResourceRequestIterator.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/SearchResourceRequestIterator.java
@@ -74,7 +74,7 @@ public final class SearchResourceRequestIterator<
 		// Update searchAfter and visited counter
 		searchAfter = hits.getSearchAfter();
 		visited += hits.getItems().size();
-
+		
 		return hits;
 	}
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/validation/issue/ValidationIssue.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/validation/issue/ValidationIssue.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import com.b2international.commons.collections.Collections3;
 import com.b2international.index.Analyzers;
 import com.b2international.index.Doc;
+import com.b2international.index.ID;
 import com.b2international.index.Keyword;
 import com.b2international.index.Script;
 import com.b2international.index.Text;
@@ -77,6 +78,7 @@ public final class ValidationIssue implements Serializable {
 		public static final String WHITELIST = "whitelist";
 	}
 	
+	@ID
 	private final String id;
 	private final String ruleId;
 	private final ComponentURI affectedComponentURI;

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/validation/rule/ValidationRule.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/validation/rule/ValidationRule.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 
 import com.b2international.commons.StringUtils;
 import com.b2international.index.Doc;
+import com.b2international.index.ID;
 import com.b2international.index.Keyword;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -86,6 +87,7 @@ public final class ValidationRule implements Serializable {
 		public static final String TYPE = "type";
 	}
 
+	@ID
 	private final String id;
 	private final String toolingId;
 	private final String messageTemplate;

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/validation/whitelist/ValidationWhiteList.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/validation/whitelist/ValidationWhiteList.java
@@ -21,6 +21,7 @@ import java.util.List;
 import com.b2international.commons.collections.Collections3;
 import com.b2international.index.Analyzers;
 import com.b2international.index.Doc;
+import com.b2international.index.ID;
 import com.b2international.index.Keyword;
 import com.b2international.index.Script;
 import com.b2international.index.Text;
@@ -52,6 +53,7 @@ public final class ValidationWhiteList implements Serializable {
 		public static final String CREATED_AT = "createdAt";
 	}
 	
+	@ID
 	private final String id;
 	private final String ruleId;
 	private final String reporter;

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedConceptRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedConceptRestService.java
@@ -29,7 +29,6 @@ import com.b2international.commons.StringUtils;
 import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.request.SearchIndexResourceRequest;
 import com.b2international.snowowl.core.request.SearchResourceRequest.Sort;
-import com.b2international.snowowl.core.request.SearchResourceRequest.SortField;
 import com.b2international.snowowl.core.rest.AbstractRestService;
 import com.b2international.snowowl.core.rest.RestApiError;
 import com.b2international.snowowl.snomed.core.domain.SnomedConcept;
@@ -90,11 +89,8 @@ public class SnomedConceptRestService extends AbstractSnomedRestService {
 		
 		List<Sort> sorts = extractSortFields(params.getSort());
 		
-		if (sorts.isEmpty()) {
-			final SortField sortField = StringUtils.isEmpty(params.getTerm()) 
-					? SearchIndexResourceRequest.DOC_ID 
-					: SearchIndexResourceRequest.SCORE;
-			sorts = Collections.singletonList(sortField);
+		if (sorts.isEmpty() && !StringUtils.isEmpty(params.getTerm())) {
+			sorts = Collections.singletonList(SearchIndexResourceRequest.SCORE);
 		}
 		
 		return SnomedRequests

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedDescriptionRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedDescriptionRestService.java
@@ -28,7 +28,6 @@ import com.b2international.commons.StringUtils;
 import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.request.SearchIndexResourceRequest;
 import com.b2international.snowowl.core.request.SearchResourceRequest.Sort;
-import com.b2international.snowowl.core.request.SearchResourceRequest.SortField;
 import com.b2international.snowowl.core.rest.AbstractRestService;
 import com.b2international.snowowl.core.rest.RestApiError;
 import com.b2international.snowowl.snomed.core.domain.SnomedDescription;
@@ -81,11 +80,8 @@ public class SnomedDescriptionRestService extends AbstractSnomedRestService {
 		
 		List<Sort> sorts = extractSortFields(params.getSort());
 		
-		if (sorts.isEmpty()) {
-			final SortField sortField = StringUtils.isEmpty(params.getTerm()) 
-					? SearchIndexResourceRequest.DOC_ID 
-					: SearchIndexResourceRequest.SCORE;
-			sorts = Collections.singletonList(sortField);
+		if (sorts.isEmpty() && !StringUtils.isEmpty(params.getTerm())) {
+			sorts = Collections.singletonList(SearchIndexResourceRequest.SCORE);
 		}
 		
 		return SnomedRequests

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/index/ClassificationTaskDocument.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/index/ClassificationTaskDocument.java
@@ -24,6 +24,7 @@ import static com.b2international.index.query.Expressions.matchRange;
 import java.util.Date;
 
 import com.b2international.index.Doc;
+import com.b2international.index.ID;
 import com.b2international.index.Script;
 import com.b2international.index.query.Expression;
 import com.b2international.snowowl.snomed.reasoner.domain.ClassificationStatus;
@@ -237,6 +238,7 @@ public final class ClassificationTaskDocument {
 		}
 	}
 
+	@ID
 	private final String id;
 	private final boolean deleted;
 	private final String userId;


### PR DESCRIPTION
This PR fixes the issues after migrated to `_doc` sorting in commit https://github.com/b2ihealthcare/snow-owl/commit/44d42182359a53732a83c22aeea1ac4c7af7a017
* Revert some of the logic to still use `_id` for searchAfter based paging if no `ID` field (the new ID annotation) is defined for the mapping.
* Use `_doc` as a tiebreaker for localScroll and for and in case of explicit scroll API use.