### PR TITLE
SO-4136: Validate LDAP identity settings at server startup

### DIFF
--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/AdminPartyIdentityProvider.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/AdminPartyIdentityProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,4 +67,8 @@ class AdminPartyIdentityProvider implements IdentityProvider, IdentityWriter {
 		return String.format("adminParty[%s]", delegate.getInfo());
 	}
 
+	@Override
+	public void validateSettings() {
+		// Nothing to do
+	}
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/IdentityPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/IdentityPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,8 @@ public final class IdentityPlugin extends Plugin {
 		if (conf.isAdminParty()) {
 			identityProvider = new AdminPartyIdentityProvider(identityProvider);
 		}
+		
+		identityProvider.validateSettings();
 		IdentityProvider.LOG.info("Configured identity providers [{}]", identityProvider.getInfo());
 		env.services().registerService(IdentityProvider.class, identityProvider);
 		

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/IdentityProvider.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/IdentityProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,11 @@ public interface IdentityProvider {
 		public String getInfo() {
 			return "unprotected";
 		}
-		
+
+		@Override
+		public void validateSettings() {
+			// Nothing to do
+		}
 	};
 	
 	
@@ -157,4 +161,10 @@ public interface IdentityProvider {
 	 */
 	String getInfo();
 	
+	/**
+	 * Performs startup-time checks to ensure that the provided parameters are correct.
+	 * @throws Exception if a configuration value is invalid, or the
+	 *         identity provider can not work correctly under the currently given conditions
+	 */
+	void validateSettings() throws Exception;
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/MultiIdentityProvider.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/MultiIdentityProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,4 +74,11 @@ final class MultiIdentityProvider implements IdentityProvider, IdentityWriter {
 		return String.format("multi[%s]", providers.stream().map(IdentityProvider::getInfo).collect(Collectors.joining(",")));
 	}
 
+	@Override
+	public void validateSettings() throws Exception {
+		// Throws exception at the first failing provider
+		for (final IdentityProvider provider : providers) {
+			provider.validateSettings();
+		}
+	}
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/file/FileIdentityProvider.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/file/FileIdentityProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,6 +108,11 @@ final class FileIdentityProvider implements IdentityProvider, IdentityWriter {
 	@Override
 	public String getInfo() {
 		return String.join("@", TYPE, usersFile.toString());
+	}
+	
+	@Override
+	public void validateSettings() {
+		// File access/creation had to be done earlier in the constructor, so nothing to check here
 	}
 	
 	private FileUser getFileUser(String username) {

--- a/core/com.b2international.snowowl.identity.ldap/src/com/b2international/snowowl/identity/ldap/LdapIdentityPlugin.java
+++ b/core/com.b2international.snowowl.identity.ldap/src/com/b2international/snowowl/identity/ldap/LdapIdentityPlugin.java
@@ -29,9 +29,7 @@ public final class LdapIdentityPlugin extends Plugin implements IdentityProvider
 
 	@Override
 	public IdentityProvider create(Environment env, LdapIdentityProviderConfig configuration) throws Exception {
-		final LdapIdentityProvider identityProvider = new LdapIdentityProvider(configuration);
-		identityProvider.testLdapSettings();
-		return identityProvider;
+		return new LdapIdentityProvider(configuration);
 	}
 
 	@Override

--- a/core/com.b2international.snowowl.identity.ldap/src/com/b2international/snowowl/identity/ldap/LdapIdentityPlugin.java
+++ b/core/com.b2international.snowowl.identity.ldap/src/com/b2international/snowowl/identity/ldap/LdapIdentityPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2020-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,12 +29,13 @@ public final class LdapIdentityPlugin extends Plugin implements IdentityProvider
 
 	@Override
 	public IdentityProvider create(Environment env, LdapIdentityProviderConfig configuration) throws Exception {
-		return new LdapIdentityProvider(configuration);
+		final LdapIdentityProvider identityProvider = new LdapIdentityProvider(configuration);
+		identityProvider.testLdapSettings();
+		return identityProvider;
 	}
 
 	@Override
 	public Class<LdapIdentityProviderConfig> getConfigType() {
 		return LdapIdentityProviderConfig.class;
 	}
-
 }

--- a/core/com.b2international.snowowl.identity.ldap/src/com/b2international/snowowl/identity/ldap/LdapIdentityProvider.java
+++ b/core/com.b2international.snowowl.identity.ldap/src/com/b2international/snowowl/identity/ldap/LdapIdentityProvider.java
@@ -129,7 +129,8 @@ final class LdapIdentityProvider implements IdentityProvider {
 		LOG.info("Configured LDAP identity provider with the following options: {}", options);
 	}
 	
-	public void testLdapSettings() throws Exception {
+	@Override
+	public void validateSettings() throws Exception {
 		InitialLdapContext systemContext = null;
 		try {
 			systemContext = createLdapContext();


### PR DESCRIPTION
- Test connection settings given in the LDAP identity provider configuration
- Make sure role objects can be read properly if the connection attempt succeeds
- Report error on failure; do not let the server continue