### PR TITLE
[classification] Infer grouped additional properties without participating in redundancy tests

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/ConcreteDomainFragment.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/ConcreteDomainFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,13 +31,15 @@ public class ConcreteDomainFragment implements Serializable {
 	private final String serializedValue;
 	private final long typeId;
 	private final boolean released;
+	private final boolean additional;
 
 	public ConcreteDomainFragment(final String memberId, 
 			final long refSetId, 
 			final int group, 
 			final String serializedValue, 
 			final long typeId, 
-			final boolean released) {
+			final boolean released,
+			final boolean additional) {
 		
 		this.memberId = memberId;
 		this.refSetId = refSetId;
@@ -45,6 +47,7 @@ public class ConcreteDomainFragment implements Serializable {
 		this.serializedValue = serializedValue;
 		this.typeId = typeId;
 		this.released = released;
+		this.additional = additional;
 	}
 
 	public String getMemberId() {
@@ -70,10 +73,14 @@ public class ConcreteDomainFragment implements Serializable {
 	public boolean isReleased() {
 		return released;
 	}
+	
+	public boolean isAdditional() {
+		return additional;
+	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(refSetId, group, serializedValue, typeId);
+		return Objects.hash(refSetId, group, serializedValue, typeId, additional);
 	}
 
 	@Override
@@ -88,7 +95,8 @@ public class ConcreteDomainFragment implements Serializable {
 		if (group != other.group) { return false; }
 		if (!Objects.equals(serializedValue, other.serializedValue)) { return false; }
 		if (typeId != other.typeId) { return false; }
-
+		if (additional != other.additional) { return false; }
+		
 		return true;
 	}
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/StatementFragment.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/StatementFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ public final class StatementFragment implements Serializable {
 	private final int group;
 	private final int unionGroup;
 	private final boolean universal;
+	private final boolean additional;
 
 	// Only stored if the original relationship is known
 	private final long statementId;
@@ -39,8 +40,9 @@ public final class StatementFragment implements Serializable {
 
 	private boolean hasStatedPair;
 
+
 	public StatementFragment(final long typeId, final long destinationId) {
-		this(typeId, destinationId, false, 0, 0, false, -1L, false, false);
+		this(typeId, destinationId, false, 0, 0, false, false, -1L, false, false);
 	}
 
 	public StatementFragment(final long typeId,
@@ -49,6 +51,7 @@ public final class StatementFragment implements Serializable {
 			final int group,
 			final int unionGroup,
 			final boolean universal,
+			final boolean additional,
 			final long statementId,
 			final boolean released,
 			final boolean hasStatedPair) {
@@ -59,6 +62,7 @@ public final class StatementFragment implements Serializable {
 		this.group = group;
 		this.unionGroup = unionGroup;
 		this.universal = universal;
+		this.additional = additional;
 
 		this.statementId = statementId;
 		this.released = released;
@@ -101,6 +105,10 @@ public final class StatementFragment implements Serializable {
 		return hasStatedPair;
 	}
 	
+	public boolean isAdditional() {
+		return additional;
+	}
+
 	@Override
 	public String toString() {
 		final StringBuilder builder = new StringBuilder();

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/entry/SnomedOWLRelationshipDocument.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/entry/SnomedOWLRelationshipDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2019-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,16 @@ public final class SnomedOWLRelationshipDocument implements Serializable {
 			adjustedGroup = group + groupOffset;
 		}
 		
-		return new StatementFragment(Long.parseLong(typeId), Long.parseLong(destinationId), false, adjustedGroup, 0, false, -1L, false, false);
+		return new StatementFragment(Long.parseLong(typeId), // typeId 
+				Long.parseLong(destinationId),               // destinationId
+				false,                                       // destinationNegated
+				adjustedGroup,                               // group
+				0,                                           // unionGroup
+				false,                                       // universal
+				false,                                       // additional: OWL member produces stated relationship fragments 
+				-1L,                                         // statementId
+				false,                                       // released
+				false);                                      // hasStatedPair
 	}
 	
 	@Override

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/taxonomy/ReasonerTaxonomyBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/taxonomy/ReasonerTaxonomyBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -449,7 +449,10 @@ public final class ReasonerTaxonomyBuilder {
 			whereExpressionBuilder.mustNot(modules(excludedModuleIds));
 		}
 		
-		addRelationships(searcher, whereExpressionBuilder, conceptId -> builtDefinedConceptMap.containsKey(conceptId) ? equivalentStatements : subclassOfStatements);
+		addRelationships(searcher, 
+				whereExpressionBuilder, 
+				false, // Stated relationships only
+				conceptId -> builtDefinedConceptMap.containsKey(conceptId) ? equivalentStatements : subclassOfStatements);
 
 		leaving("Registering active stated non-IS A relationships using revision searcher");
 		return this;
@@ -463,7 +466,8 @@ public final class ReasonerTaxonomyBuilder {
 				&& !Concepts.IS_A.equals(relationship.getTypeId())
 				&& !excludedModuleIds.contains(relationship.getModuleId());
 		
-		addRelationships(sortedRelationships.filter(predicate), (sourceId, fragments) -> {
+		// Stated relationships only
+		addRelationships(sortedRelationships.filter(predicate), false, (sourceId, fragments) -> {
 			if (builtDefinedConceptMap.containsKey(sourceId)) {
 				equivalentStatements.putAll(sourceId, fragments);
 			} else {
@@ -487,7 +491,10 @@ public final class ReasonerTaxonomyBuilder {
 			whereExpressionBuilder.mustNot(modules(excludedModuleIds));
 		}
 		
-		addRelationships(searcher, whereExpressionBuilder, conceptId -> additionalGroupedRelationships);
+		addRelationships(searcher, 
+				whereExpressionBuilder, 
+				true, // Additional relationships only
+				conceptId -> additionalGroupedRelationships);
 	
 		leaving("Registering active additional grouped relationships using revision searcher");
 		return this;
@@ -501,7 +508,8 @@ public final class ReasonerTaxonomyBuilder {
 				&& relationship.getGroup() > 0
 				&& !excludedModuleIds.contains(relationship.getModuleId());
 		
-		addRelationships(sortedRelationships.filter(predicate), additionalGroupedRelationships::putAll);
+		// Additional relationships only
+		addRelationships(sortedRelationships.filter(predicate), true, additionalGroupedRelationships::putAll);
 	
 		leaving("Registering active additional grouped relationships using relationship stream");
 		return this;
@@ -596,6 +604,7 @@ public final class ReasonerTaxonomyBuilder {
 						group,
 						unionGroup,
 						universal,
+						false, // Stated and inferred relationships only
 						statementId,
 						released,
 						hasStatedPair);
@@ -626,13 +635,18 @@ public final class ReasonerTaxonomyBuilder {
 				&& CharacteristicType.INFERRED_RELATIONSHIP.equals(relationship.getCharacteristicType())
 				&& !excludedModuleIds.contains(relationship.getModuleId());
 		
-		addRelationships(sortedRelationships.filter(predicate), existingInferredRelationships::putAll);
+		// Inferred relationships only
+		addRelationships(sortedRelationships.filter(predicate), false, existingInferredRelationships::putAll);
 		
 		leaving("Registering active inferred relationships using relationship stream");
 		return this;
 	}
 
-	private void addRelationships(final RevisionSearcher searcher, final ExpressionBuilder whereExpressionBuilder, final Function<String, Builder<StatementFragment>> fragmentBuilder) {
+	private void addRelationships(
+			final RevisionSearcher searcher, 
+			final ExpressionBuilder whereExpressionBuilder, 
+			final boolean additional,
+			final Function<String, Builder<StatementFragment>> fragmentBuilder) {
 		
 		final Query<String[]> query = Query.select(String[].class)
 				.from(SnomedRelationshipIndexEntry.class)
@@ -695,6 +709,7 @@ public final class ReasonerTaxonomyBuilder {
 						group,
 						unionGroup,
 						universal,
+						additional,
 						statementId,
 						released,
 						false); // Relationships added through this method have no stated pair
@@ -719,6 +734,7 @@ public final class ReasonerTaxonomyBuilder {
 	 * XXX: sortedRelationships should be sorted by source ID; we can not verify this in advance
 	 */
 	private void addRelationships(final Stream<SnomedRelationship> sortedRelationships,
+			final boolean additional,
 			final BiConsumer<String, List<StatementFragment>> consumer) {
 		
 		final List<StatementFragment> fragments = newArrayListWithExpectedSize(SCROLL_LIMIT);
@@ -757,6 +773,7 @@ public final class ReasonerTaxonomyBuilder {
 						group,
 						unionGroup,
 						universal,
+						additional,
 						statementId,
 						false,  // XXX: "injected" concepts will not set these flags correctly, but they should
 						false);  // only be used for equivalence checks
@@ -998,17 +1015,19 @@ public final class ReasonerTaxonomyBuilder {
 				final Integer group = member.getRelationshipGroup();
 				final long typeId = Long.parseLong(member.getTypeId());
 				final boolean released = member.isReleased();
+				final boolean additional = Concepts.ADDITIONAL_RELATIONSHIP.equals(member.getCharacteristicTypeId()); 
 
 				final ConcreteDomainFragment fragment = new ConcreteDomainFragment(memberId, 
 						refsetId,
 						group,
 						serializedValue,
 						typeId,
-						released);
+						released,
+						additional);
 
 				if (Concepts.STATED_RELATIONSHIP.equals(member.getCharacteristicTypeId())) {
 					statedFragments.add(fragment);
-				} else if (Concepts.ADDITIONAL_RELATIONSHIP.equals(member.getCharacteristicTypeId()) && member.getRelationshipGroup() > 0) {
+				} else if (additional && member.getRelationshipGroup() > 0) {
 					additionalGroupedFragments.add(fragment);
 				} else if (Concepts.INFERRED_RELATIONSHIP.equals(member.getCharacteristicTypeId())) {
 					inferredFragments.add(fragment);
@@ -1068,17 +1087,19 @@ public final class ReasonerTaxonomyBuilder {
 					final String serializedValue = (String) member.getProperties().get(SnomedRf2Headers.FIELD_VALUE);
 					final Integer group = (Integer) member.getProperties().get(SnomedRf2Headers.FIELD_RELATIONSHIP_GROUP);
 					final long typeId = Long.parseLong((String) member.getProperties().get(SnomedRf2Headers.FIELD_TYPE_ID));
+					final boolean additional = Concepts.ADDITIONAL_RELATIONSHIP.equals(characteristicTypeId);
 
 					final ConcreteDomainFragment fragment = new ConcreteDomainFragment(memberId,
 							refsetId,
 							group,
 							serializedValue,
 							typeId,
-							false); // XXX: "injected" CD members will not set this flag correctly, but they should only be used in equivalence checks
+							false, // XXX: "injected" CD members will not set this flag correctly, but they should only be used in equivalence checks
+							additional); 
 
 					if (Concepts.STATED_RELATIONSHIP.equals(characteristicTypeId)) {
 						statedFragments.add(fragment);
-					} else if (Concepts.ADDITIONAL_RELATIONSHIP.equals(characteristicTypeId) && group > 0) {
+					} else if (additional && group > 0) {
 						additionalGroupedFragments.add(fragment);
 					} else if (Concepts.INFERRED_RELATIONSHIP.equals(characteristicTypeId)) {
 						inferredFragments.add(fragment);

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormGenerator.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormGenerator.java
@@ -450,14 +450,12 @@ public final class NormalFormGenerator implements INormalFormGenerator {
 					}
 					
 					// Existing item should be strictly stronger, same is not good enough
-					if (candidate.isSameOrStrongerThan(comparable) && !comparable.isSameOrStrongerThan(candidate)) {
+					if (comparable.isSameOrStrongerThan(candidate)) {
+						redundant.add(candidate);
+					} else if (candidate.isSameOrStrongerThan(comparable)) {
 						found = true;
 						break;
 					} 
-					
-					if (comparable.isSameOrStrongerThan(candidate)) {
-						redundant.add(candidate);
-					}
 				}
 			}
 			

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormGenerator.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormGenerator.java
@@ -443,14 +443,23 @@ public final class NormalFormGenerator implements INormalFormGenerator {
 			redundant.clear();
 			boolean found = false;
 
+			if (!comparable.isAdditional()) {
 				for (final T candidate : candidates) {
-				if (candidate.isSameOrStrongerThan(comparable)) {
+					if (candidate.isAdditional()) {
+						continue;
+					}
+					
+					// Existing item should be strictly stronger, same is not good enough
+					if (candidate.isSameOrStrongerThan(comparable) && !comparable.isSameOrStrongerThan(candidate)) {
 						found = true;
 						break;
-				} else if (comparable.isSameOrStrongerThan(candidate)) {
+					} 
+					
+					if (comparable.isSameOrStrongerThan(candidate)) {
 						redundant.add(candidate);
 					}
 				}
+			}
 			
 			if (!found) {
 				candidates.removeAll(redundant);

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormGenerator.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormGenerator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2009-2017 International Health Terminology Standards Development Organisation
- * Copyright 2011-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,7 +163,7 @@ public final class NormalFormGenerator implements INormalFormGenerator {
 					currentLayer = PrimitiveSets.newLongOpenHashSet();
 					continue;
 				}
-
+				
 				// Run costly comparison of property chain hierarchies only if there are any
 				precomputeProperties(conceptId, propertyChainsPresent);
 
@@ -285,7 +285,7 @@ public final class NormalFormGenerator implements INormalFormGenerator {
 
 			Iterables.addAll(targetGroupSet, otherGroups);
 		}
-
+		
 		// Finally, add the (stated) information from the concept itself
 		final Iterable<NormalFormGroup> ownGroups = toGroups(false,
 				candidateNonIsAFragments.get(conceptId),
@@ -443,15 +443,15 @@ public final class NormalFormGenerator implements INormalFormGenerator {
 			redundant.clear();
 			boolean found = false;
 
-			for (final T candidate : candidates) {
+				for (final T candidate : candidates) {
 				if (candidate.isSameOrStrongerThan(comparable)) {
-					found = true;
-					break;
+						found = true;
+						break;
 				} else if (comparable.isSameOrStrongerThan(candidate)) {
-					redundant.add(candidate);
+						redundant.add(candidate);
+					}
 				}
-			}
-
+			
 			if (!found) {
 				candidates.removeAll(redundant);
 				candidates.add(comparable);
@@ -487,6 +487,7 @@ public final class NormalFormGenerator implements INormalFormGenerator {
 						groupNumber,
 						unionGroupNumber,
 						property.isUniversal(),
+						property.isAdditional(),
 						property.getStatementId(),
 						property.isReleased(),
 						property.hasStatedPair()));
@@ -514,7 +515,8 @@ public final class NormalFormGenerator implements INormalFormGenerator {
 						groupNumber,
 						property.getSerializedValue(),
 						property.getTypeId(),
-						property.isReleased()));
+						property.isReleased(),
+						property.isAdditional()));
 	}
 
 	private Collection<StatementFragment> getTargetRelationships(final long conceptId) {

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormGroup.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormGroup.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2009 International Health Terminology Standards Development Organisation
- * Copyright 2013-2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2013-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ final class NormalFormGroup implements NormalFormProperty {
 	public NormalFormGroup(final Iterable<NormalFormUnionGroup> unionGroups) {
 		checkNotNull(unionGroups, "unionGroups");
 		this.unionGroups = ImmutableList.copyOf(unionGroups);
-		this.groupNumber = UNKOWN_GROUP;
+		this.groupNumber = UNKNOWN_GROUP;
 	}
 
 	public List<NormalFormUnionGroup> getUnionGroups() {
@@ -78,7 +78,7 @@ final class NormalFormGroup implements NormalFormProperty {
 	}
 
 	public void setGroupNumber(final int groupNumber) {
-		checkState(this.groupNumber == UNKOWN_GROUP, "Group number is already set.");
+		checkState(this.groupNumber == UNKNOWN_GROUP, "Group number is already set.");
 		checkArgument(groupNumber > 0, "Illegal group number '%s'.", groupNumber);
 		this.groupNumber = groupNumber;
 	}
@@ -102,11 +102,20 @@ final class NormalFormGroup implements NormalFormProperty {
 		 */
 		return other.unionGroups
 			.stream()
+			.filter(otherUnionGroup -> !otherUnionGroup.isAdditional())
 			.allMatch(otherUnionGroup -> this.unionGroups
 				.stream()
+				.filter(ourUnionGroup -> !ourUnionGroup.isAdditional())
 				.anyMatch(ourUnionGroup -> ourUnionGroup.isSameOrStrongerThan(otherUnionGroup)));
 	}
 
+	@Override
+	public boolean isAdditional() {
+		// Groups should be considered "additional" if they have no non-additional union groups
+		return unionGroups.stream()
+			.allMatch(NormalFormProperty::isAdditional);
+	}
+	
 	@Override
 	public int hashCode() {
 		return Objects.hash(unionGroups);
@@ -140,7 +149,7 @@ final class NormalFormGroup implements NormalFormProperty {
 			.sorted(Comparator.comparingInt(otherUnionGroup -> otherUnionGroup.getUnionGroupNumber()))
 			.forEachOrdered(otherUnionGroup -> this.unionGroups
 				.stream()
-				.filter(unionGroup -> unionGroup.getUnionGroupNumber() == NormalFormUnionGroup.UNKOWN_GROUP && unionGroup.equals(otherUnionGroup))
+				.filter(unionGroup -> unionGroup.getUnionGroupNumber() == NormalFormUnionGroup.UNKNOWN_GROUP && unionGroup.equals(otherUnionGroup))
 				.findFirst()
 				.ifPresent(unionGroup -> {
 					unionGroup.setUnionGroupNumber(otherUnionGroup.getUnionGroupNumber());
@@ -158,7 +167,7 @@ final class NormalFormGroup implements NormalFormProperty {
 		int unionGroupNumber = 1;
 
 		for (final NormalFormUnionGroup unionGroup : unionGroups) {
-			if (unionGroup.getUnionGroupNumber() == NormalFormUnionGroup.UNKOWN_GROUP) {
+			if (unionGroup.getUnionGroupNumber() == NormalFormUnionGroup.UNKNOWN_GROUP) {
 				while (numbersUsed.contains(unionGroupNumber)) {
 					unionGroupNumber++;
 				}

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormGroupSet.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormGroupSet.java
@@ -47,13 +47,22 @@ final class NormalFormGroupSet extends AbstractSet<NormalFormGroup> {
 	public boolean add(final NormalFormGroup e) {
 		final List<NormalFormGroup> redundant = newArrayList();
 
+		if (!e.isAdditional()) {
 			for (final NormalFormGroup existingGroup : groups) {
-			if (existingGroup.isSameOrStrongerThan(e)) {
+				if (existingGroup.isAdditional()) {
+					continue;
+				}
+				
+				// Existing item should be strictly stronger, same is not good enough
+				if (existingGroup.isSameOrStrongerThan(e) && !e.isSameOrStrongerThan(existingGroup)) {
 					return false;
-				} else if (e.isSameOrStrongerThan(existingGroup)) {
+				}
+				
+				if (e.isSameOrStrongerThan(existingGroup)) {
 					redundant.add(existingGroup);
 				}
 			}
+		}
 
 		groups.removeAll(redundant);
 		groups.add(e);

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormGroupSet.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormGroupSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2013-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,13 +47,13 @@ final class NormalFormGroupSet extends AbstractSet<NormalFormGroup> {
 	public boolean add(final NormalFormGroup e) {
 		final List<NormalFormGroup> redundant = newArrayList();
 
-		for (final NormalFormGroup existingGroup : groups) {
+			for (final NormalFormGroup existingGroup : groups) {
 			if (existingGroup.isSameOrStrongerThan(e)) {
-				return false;
-			} else if (e.isSameOrStrongerThan(existingGroup)) {
-				redundant.add(existingGroup);
+					return false;
+				} else if (e.isSameOrStrongerThan(existingGroup)) {
+					redundant.add(existingGroup);
+				}
 			}
-		}
 
 		groups.removeAll(redundant);
 		groups.add(e);
@@ -96,7 +96,7 @@ final class NormalFormGroupSet extends AbstractSet<NormalFormGroup> {
 			.sorted(Comparator.comparingInt(otherGroup -> otherGroup.getGroupNumber()))
 			.forEachOrdered(otherGroup -> this.groups
 				.stream()
-				.filter(group -> group.getGroupNumber() == NormalFormGroup.UNKOWN_GROUP && group.equals(otherGroup))
+				.filter(group -> group.getGroupNumber() == NormalFormGroup.UNKNOWN_GROUP && group.equals(otherGroup))
 				.findFirst()
 				.ifPresent(group -> {
 					group.adjustOrder(otherGroup);
@@ -115,7 +115,7 @@ final class NormalFormGroupSet extends AbstractSet<NormalFormGroup> {
 		int groupNumber = 1;
 
 		for (final NormalFormGroup group : groups) {
-			if (group.getGroupNumber() == NormalFormGroup.UNKOWN_GROUP) {
+			if (group.getGroupNumber() == NormalFormGroup.UNKNOWN_GROUP) {
 				while (numbersUsed.contains(groupNumber)) {
 					groupNumber++;
 				}

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormGroupSet.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormGroupSet.java
@@ -36,8 +36,8 @@ final class NormalFormGroupSet extends AbstractSet<NormalFormGroup> {
 	 * Adds the specified group to this set if it is not already present.
 	 * <p>
 	 * More formally, adds the specified group e to this set if no group e2 exists
-	 * where e2.isSameOrStrongerThan(e) applies. If this set already contains such
-	 * group, the call leaves the set unchanged and returns <code>false</code>.
+	 * where e2 is "strictly stronger" than e. If this set already contains such 
+	 * a group, the call leaves the set unchanged and returns <code>false</code>.
 	 * <p>
 	 * If no current group can be matched this way to group e, the call removes all
 	 * current e(i) members from the set where e.isSameOrStrongerThan(e(i)) applies,
@@ -54,12 +54,10 @@ final class NormalFormGroupSet extends AbstractSet<NormalFormGroup> {
 				}
 				
 				// Existing item should be strictly stronger, same is not good enough
-				if (existingGroup.isSameOrStrongerThan(e) && !e.isSameOrStrongerThan(existingGroup)) {
-					return false;
-				}
-				
 				if (e.isSameOrStrongerThan(existingGroup)) {
 					redundant.add(existingGroup);
+				} else if (existingGroup.isSameOrStrongerThan(e)) {
+					return false;
 				}
 			}
 		}

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormProperty.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2013-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ interface NormalFormProperty {
 	 * should be used when the fragments in this group/union group are converted into
 	 * relationships.
 	 */
-	static final int UNKOWN_GROUP = -1;
+	static final int UNKNOWN_GROUP = -1;
 	
 	static final int ZERO_GROUP = 0;
 
@@ -41,5 +41,11 @@ interface NormalFormProperty {
 	 *         description when compared to the other item, <code>false</code>
 	 *         otherwise
 	 */
-	public boolean isSameOrStrongerThan (NormalFormProperty property);
+	public boolean isSameOrStrongerThan(NormalFormProperty property);
+	
+	/**
+	 * @return <code>true</code> if this property should not participate in 
+	 *         "is same or stronger" comparisons, <code>false</code> otherwise
+	 */
+	public boolean isAdditional();
 }

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormRelationship.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormRelationship.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2009-2017 International Health Terminology Standards Development Organisation
- * Copyright 2013-2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2013-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ package com.b2international.snowowl.snomed.reasoner.normalform;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.text.MessageFormat;
 import java.util.Map;
 import java.util.Objects;
 
@@ -234,6 +233,11 @@ final class NormalFormRelationship implements NormalFormProperty {
 	private boolean isExhaustive(final long conceptId) {
 		return reasonerTaxonomy.getExhaustiveConcepts().contains(conceptId);
 	}
+	
+	@Override
+	public boolean isAdditional() {
+		return fragment.isAdditional();
+	}
 
 	@Override
 	public boolean equals(final Object obj) {
@@ -242,6 +246,7 @@ final class NormalFormRelationship implements NormalFormProperty {
 
 		final NormalFormRelationship other = (NormalFormRelationship) obj;
 
+		if (isAdditional() != other.isAdditional()) { return false; }
 		if (isUniversal() != other.isUniversal()) { return false; }
 		if (isDestinationNegated() != other.isDestinationNegated()) { return false; }
 		if (getTypeId() != other.getTypeId()) { return false; }
@@ -252,11 +257,21 @@ final class NormalFormRelationship implements NormalFormProperty {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(isUniversal(), isDestinationNegated(), getTypeId(), getDestinationId());
+		return Objects.hash(
+			isAdditional(), 
+			isUniversal(), 
+			isDestinationNegated(), 
+			getTypeId(), 
+			getDestinationId());
 	}
 
 	@Override
 	public String toString() {
-		return MessageFormat.format("{0,number,#} : {1}{2,number,#} ({3})", getTypeId(), (isDestinationNegated() ? "NOT" : ""), getDestinationId(), isUniversal());
+		return String.format("%s: %s%s.%s%s", 
+			getStatementId() > 0L ? getStatementId() : "<?>",
+			isUniversal() ? "\u2200" : "\u2203",
+			getTypeId(),
+			isDestinationNegated() ? "\u00ac" : "",
+			getDestinationId());
 	}
 }

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormRelationship.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormRelationship.java
@@ -267,11 +267,11 @@ final class NormalFormRelationship implements NormalFormProperty {
 
 	@Override
 	public String toString() {
-		return String.format("%s: %s%s.%s%s", 
+		return String.format("%s: %s %s.%s%s", 
 			getStatementId() > 0L ? getStatementId() : "<?>",
-			isUniversal() ? "\u2200" : "\u2203",
+			isUniversal() ? "ALL" : "SOME",
 			getTypeId(),
-			isDestinationNegated() ? "\u00ac" : "",
+			isDestinationNegated() ? "NOT " : "",
 			getDestinationId());
 	}
 }

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormUnionGroup.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormUnionGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2013-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ final class NormalFormUnionGroup implements NormalFormProperty {
 	public NormalFormUnionGroup(final Iterable<NormalFormProperty> properties) {
 		checkNotNull(properties, "properties");
 		this.properties = ImmutableList.copyOf(properties);
-		this.unionGroupNumber = UNKOWN_GROUP;
+		this.unionGroupNumber = UNKNOWN_GROUP;
 	}
 
 	public List<NormalFormProperty> getProperties() {
@@ -71,7 +71,7 @@ final class NormalFormUnionGroup implements NormalFormProperty {
 	}
 
 	public void setUnionGroupNumber(final int unionGroupNumber) {
-		checkState(this.unionGroupNumber == UNKOWN_GROUP, "Union group number is already set.");
+		checkState(this.unionGroupNumber == UNKNOWN_GROUP, "Union group number is already set.");
 		checkArgument(unionGroupNumber > 0, "Illegal union group number '%s'.", unionGroupNumber);
 		this.unionGroupNumber = unionGroupNumber;
 	}
@@ -96,11 +96,20 @@ final class NormalFormUnionGroup implements NormalFormProperty {
 		 */
 		return this.properties
 			.stream()
+			.filter(ourProperty -> !ourProperty.isAdditional())
 			.allMatch(ourProperty -> other.properties
 				.stream()
+				.filter(otherProperty -> !otherProperty.isAdditional())
 				.anyMatch(otherProperty -> ourProperty.isSameOrStrongerThan(otherProperty)));
 	}
 
+	@Override
+	public boolean isAdditional() {
+		// Union groups should be considered "additional" if they have no non-additional properties
+		return properties.stream()
+			.allMatch(NormalFormProperty::isAdditional);
+	}
+	
 	@Override
 	public int hashCode() {
 		return Objects.hash(properties);

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormValue.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package com.b2international.snowowl.snomed.reasoner.normalform;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.text.MessageFormat;
 import java.util.Objects;
 
 import com.b2international.snowowl.snomed.datastore.ConcreteDomainFragment;
@@ -65,6 +64,11 @@ final class NormalFormValue implements NormalFormProperty {
 	public boolean isReleased() {
 		return fragment.isReleased();
 	}
+	
+	@Override
+	public boolean isAdditional() {
+		return fragment.isAdditional();
+	}
 
 	@Override
 	public boolean isSameOrStrongerThan(final NormalFormProperty property) {
@@ -95,6 +99,7 @@ final class NormalFormValue implements NormalFormProperty {
 
 		final NormalFormValue other = (NormalFormValue) obj;
 
+		if (isAdditional() != other.isAdditional()) { return false; }
 		if (getRefSetId() != other.getRefSetId()) { return false; }
 		if (getTypeId() != other.getTypeId()) { return false; }
 		if (!getSerializedValue().equals(other.getSerializedValue())) { return false; }
@@ -104,13 +109,22 @@ final class NormalFormValue implements NormalFormProperty {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(getSerializedValue(), getRefSetId(), getTypeId());
+		return Objects.hash(
+			isAdditional(),
+			getRefSetId(), 
+			getTypeId(),
+			getSerializedValue());
 	}
 
 	@Override
 	public String toString() {
 		final String refSetId = Long.toString(getRefSetId());
 		final DataType dataType = SnomedRefSetUtil.getDataType(refSetId);
-		return MessageFormat.format("{0,number,#} : {1} [{2}]", getTypeId(), getSerializedValue(), dataType);
+		
+		return String.format("%s: %s=%s [%s]", 
+			getMemberId(),
+			getTypeId(),
+			getSerializedValue(),
+			dataType);
 	}
 }


### PR DESCRIPTION
Also favor incoming groups over existing groups on a tie, as this makes the accompanying grouped additional properties more consistent, both for groups inferred "from above" as well as the concept's own (stated) groups.