### PR TITLE
SO-4694: add commit.watermark.low and high configurations

### DIFF
--- a/commons/com.b2international.index/src/com/b2international/index/IndexClientFactory.java
+++ b/commons/com.b2international.index/src/com/b2international/index/IndexClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,6 +117,17 @@ public interface IndexClientFactory {
 	 */
 	String BULK_ACTIONS_SIZE_IN_MB = "bulk_action_size_in_mb";
 
+	// Non-elasticsearch configuration keys
+	
+	/**
+	 * Configuration key to specify the low watermark of commits and raise a log entry with commit properties indicating a minor problem.  
+	 */
+	String COMMIT_WATERMARK_LOW_KEY = "commit.watermark.low";
+	
+	/**
+	 * Configuration key to specify the high watermark of commits and raise a log entry with commit properties indicating a major problem.
+	 */
+	String COMMIT_WATERMARK_HIGH_KEY = "commit.watermark.high";
 	
 	//
 	// Default values
@@ -179,6 +190,17 @@ public interface IndexClientFactory {
 	 * Default size in megabytes to limit all outgoing bulk requests.
 	 */
 	int DEFAULT_BULK_ACTIONS_SIZE_IN_MB = 9;
+	
+	/**
+	 * Default amount of commit details indicating low watermark
+	 */
+	int DEFAULT_COMMIT_WATERMARK_LOW_VALUE = 10_000;
+	
+	/**
+	 * Default amount of commit details indicating high watermark
+	 */
+	int DEFAULT_COMMIT_WATERMARK_HIGH_VALUE = 50_000;
+
 
 	/**
 	 * Create a new {@link IndexClient} with the given name.

--- a/commons/com.b2international.index/src/com/b2international/index/es/admin/EsIndexAdmin.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/admin/EsIndexAdmin.java
@@ -126,6 +126,8 @@ public final class EsIndexAdmin implements IndexAdmin {
 		this.settings.putIfAbsent(IndexClientFactory.TRANSLOG_SYNC_INTERVAL_KEY, IndexClientFactory.DEFAULT_TRANSLOG_SYNC_INTERVAL);
 		this.settings.putIfAbsent(IndexClientFactory.BULK_ACTIONS_SIZE, IndexClientFactory.DEFAULT_BULK_ACTIONS_SIZE);
 		this.settings.putIfAbsent(IndexClientFactory.BULK_ACTIONS_SIZE_IN_MB, IndexClientFactory.DEFAULT_BULK_ACTIONS_SIZE_IN_MB);
+		this.settings.putIfAbsent(IndexClientFactory.COMMIT_WATERMARK_LOW_KEY, IndexClientFactory.DEFAULT_COMMIT_WATERMARK_LOW_VALUE);
+		this.settings.putIfAbsent(IndexClientFactory.COMMIT_WATERMARK_HIGH_KEY, IndexClientFactory.DEFAULT_COMMIT_WATERMARK_HIGH_VALUE);
 		
 		final String prefix = (String) settings.getOrDefault(IndexClientFactory.INDEX_PREFIX, IndexClientFactory.DEFAULT_INDEX_PREFIX);
 		this.prefix = prefix.isEmpty() ? "" : prefix + ".";

--- a/commons/com.b2international.index/src/com/b2international/index/revision/ObjectId.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/ObjectId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,6 +92,14 @@ public final class ObjectId {
 	
 	public static ObjectId rootOf(String type) {
 		return of(type, ROOT);
+	}
+	
+	public static ObjectId toObjectId(Object obj, String id) {
+		if (obj instanceof Revision) {
+			return ((Revision) obj).getObjectId();
+		} else {
+			return ObjectId.of(obj.getClass(), id);
+		}
 	}
 
 }

--- a/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
@@ -83,13 +83,19 @@ public final class StagingArea {
 		this.maxTermsCount = Integer.parseInt((String) index.admin().settings().get(IndexClientFactory.MAX_TERMS_COUNT_KEY));
 		this.commitWatermarkLow = (int) index.admin().settings().get(IndexClientFactory.COMMIT_WATERMARK_LOW_KEY);
 		this.commitWatermarkHigh = (int) index.admin().settings().get(IndexClientFactory.COMMIT_WATERMARK_LOW_KEY);
-		reset();
+		rollback();
 	}
 	
+	/**
+	 * @return the underlying {@link RevisionIndex} instance.
+	 */
 	public RevisionIndex getIndex() {
 		return index;
 	}
 	
+	/**
+	 * @return the branch where this {@link StagingArea} will commit its staged changes during {@link #commit(long, String, String)}
+	 */
 	public String getBranchPath() {
 		return branchPath;
 	}
@@ -139,37 +145,55 @@ public final class StagingArea {
 		return stagedObjects.containsKey(revision.getObjectId());
 	}
 	
+	/**
+	 * @param revision
+	 * @return whether the given {@link Revision} instance is registered as NEW object in this staging area.
+	 */
 	public boolean isNew(Revision revision) {
 		StagedObject so = stagedObjects.get(revision.getObjectId());
 		return so != null && so.isAdded();
 	}
 	
+	/**
+	 * @param revision
+	 * @return whether the given {@link Revision} instance is registered as CHANGED object in this staging area.
+	 */
 	public boolean isChanged(Revision revision) {
 		StagedObject so = stagedObjects.get(revision.getObjectId());
 		return so != null && so.isChanged();
 	}
 	
+	/**
+	 * @param revision
+	 * @return whether the given {@link Revision} instance is registered as REMOVED object in this staging area.
+	 */
 	public boolean isRemoved(Revision revision) {
 		StagedObject so = stagedObjects.get(revision.getObjectId());
 		return so != null && so.isRemoved();
 	}
 	
+	/**
+	 * @return the number of staged objects registered in this staging area
+	 */
 	public int getNumberOfStagedObjects() {
 		return stagedObjects.size();
 	}
 	
+	/**
+	 * @return a {@link Stream} of objects that are registered as NEW in this staging area.
+	 */
 	public Stream<Object> getNewObjects() {
 		return stagedObjects.entrySet()
 				.stream()
 				.filter(entry -> entry.getValue().isAdded())
 				.map(e -> e.getValue().getObject());
 	}
-	
-	public <T> T getNewObject(Class<T> type, String key) {
-		StagedObject stagedObject = stagedObjects.get(ObjectId.of(type, key));
-		return stagedObject == null ? null : type.cast(stagedObject.getObject());
-	}
-	
+
+	/**
+	 * @param <T>
+	 * @param type - the requested object type
+	 * @return a {@link Stream} of objects of type T that are registered as NEW in this staging area.
+	 */
 	public <T> Stream<T> getNewObjects(Class<T> type) {
 		return stagedObjects.entrySet()
 				.stream()
@@ -178,7 +202,21 @@ public final class StagingArea {
 				.filter(type::isInstance)
 				.map(type::cast);
 	}
+
+	/**
+	 * @param <T>
+	 * @param type
+	 * @param key
+	 * @return an Object of T type registered as NEW under the given key identifier, or <code>null</code> if no such object is registered.
+	 */
+	public <T> T getNewObject(Class<T> type, String key) {
+		StagedObject stagedObject = stagedObjects.get(ObjectId.of(type, key));
+		return stagedObject == null ? null : type.cast(stagedObject.getObject());
+	}
 	
+	/**
+	 * @return a {@link Stream} of objects that are registered as CHANGED in this staging area.
+	 */
 	public Stream<Object> getChangedObjects() {
 		return stagedObjects.entrySet()
 				.stream()
@@ -186,6 +224,11 @@ public final class StagingArea {
 				.map(e -> e.getValue().getObject());
 	}
 	
+	/**
+	 * @param <T>
+	 * @param type - the requested object type
+	 * @return a {@link Stream} of objects of type T that are registered as CHANGED in this staging area.
+	 */
 	public <T> Stream<T> getChangedObjects(Class<T> type) {
 		return stagedObjects.entrySet()
 				.stream()
@@ -195,6 +238,9 @@ public final class StagingArea {
 				.map(type::cast);
 	}
 	
+	/**
+	 * @return a {@link Stream} of objects that are registered as REMOVED in this staging area.
+	 */
 	public Stream<Object> getRemovedObjects() {
 		return stagedObjects.entrySet()
 				.stream()
@@ -202,6 +248,11 @@ public final class StagingArea {
 				.map(e -> e.getValue().getObject());
 	}
 	
+	/**
+	 * @param <T>
+	 * @param type - the requested object type
+	 * @return a {@link Stream} of objects of type T that are registered as REMOVED in this staging area.
+	 */
 	public <T> Stream<T> getRemovedObjects(Class<T> type) {
 		return stagedObjects.entrySet()
 				.stream()
@@ -211,6 +262,10 @@ public final class StagingArea {
 				.map(type::cast);
 	}
 	
+	/**
+	 * @return a {@link Map} of changed revision diffs keyed by their {@link ObjectId}.
+	 * @see RevisionDiff
+	 */
 	public Map<ObjectId, RevisionDiff> getChangedRevisions() {
 		return stagedObjects.entrySet()
 				.stream()
@@ -218,6 +273,10 @@ public final class StagingArea {
 				.collect(Collectors.toMap(Entry::getKey, e -> e.getValue().getDiff()));
 	}
 	
+	/**
+	 * @param type - the requested object type
+	 * @return a {@link Stream} of {@link RevisionDiff} objects registered for the given type.
+	 */
 	public Stream<RevisionDiff> getChangedRevisions(Class<? extends Revision> type) {
 		return stagedObjects.entrySet()
 				.stream()
@@ -226,6 +285,12 @@ public final class StagingArea {
 				.filter(diff -> type.isAssignableFrom(diff.newRevision.getClass()));
 	}
 	
+	/**
+	 * 
+	 * @param type - the requested object type
+	 * @param changedPropertyNames - the requested property names
+	 * @return a {@link Stream} of {@link RevisionDiff} objects registered for the given type that have property changes for the given {@link Set} of property names.
+	 */
 	public Stream<RevisionDiff> getChangedRevisions(Class<? extends Revision> type, Set<String> changedPropertyNames) {
 		return stagedObjects.entrySet()
 				.stream()
@@ -460,7 +525,7 @@ public final class StagingArea {
 		}
 		
 		// free up memory before committing 
-		reset();
+		clear();
 		newComponentsByContainer.clear();
 		changedComponentsByContainer.clear();
 		removedComponentsByContainer.clear();
@@ -544,28 +609,64 @@ public final class StagingArea {
 	}
 	
 	/**
-	 * Reset staging area to empty.
+	 * Roll back staging area to an empty state, removing all staged changes, merge states, everything.
 	 */
-	private void reset() {
+	public void rollback() {
+		clear();
+		this.mergeFromBranchRef = null;
+		this.mergeSources = null;
+	}
+	
+	private void clear() {
 		stagedObjects = newHashMap();
 		revisionsToReviseOnMergeSource = HashMultimap.create();
 		externalRevisionsToReviseOnMergeSource = HashMultimap.create();
 	}
 
+	/**
+	 * Stages the given {@link Revision} as NEW in this staging area for commit.
+	 * 
+	 * @param newRevision - the revision to register
+	 * @return - this staging area for chaining
+	 * @see #stageNew(Revision, boolean)
+	 */
 	public StagingArea stageNew(Revision newRevision) {
 		return stageNew(newRevision, true);
 	}
 	
+	/**
+	 * Stages the given {@link Revision} as NEW in this staging area either for commit (commit=true) or for change processing purposes only (commit=false).
+	 *  
+	 * @param newRevision - the revision to register
+	 * @param commit - to register the revision as a NEW object to commit, or as a NEW object to process by commit hooks
+	 * @return - this staging area for chaining
+	 */
 	public StagingArea stageNew(Revision newRevision, boolean commit) {
 		return stageNew(newRevision.getId(), newRevision, commit);
 	}
 	
+	/**
+	 * Stages the given {@link Object} as NEW in this staging area for commit under the given key.
+	 * 
+	 * @param key - the identifier to use when staging the object
+	 * @param newDocument - the new object to register
+	 * @return - this staging area for chaining
+	 * @see #stageNew(String, Object, boolean)
+	 */
 	public StagingArea stageNew(String key, Object newDocument) {
 		return stageNew(key, newDocument, true);
 	}
 	
+	/**
+	 * Stages the given {@link Object} as NEW in this staging area either for commit (commit=true) or for change processing purposes only (commit=false) under the given key.
+	 * 
+	 * @param key - the identifier to use when staging the object
+	 * @param newDocument - the new object to register
+	 * @param commit - to register the object as a NEW object to commit, or as a NEW object to process by commit hooks
+	 * @return - this staging area for chaining
+	 */
 	public StagingArea stageNew(String key, Object newDocument, boolean commit) {
-		ObjectId objectId = toObjectId(newDocument, key);
+		ObjectId objectId = ObjectId.toObjectId(newDocument, key);
 		if (stagedObjects.containsKey(objectId)) {
 			StagedObject currentStagedObject = stagedObjects.get(objectId);
 			if (!currentStagedObject.isCommit() && currentStagedObject.getObject() instanceof Revision && newDocument instanceof Revision) {
@@ -579,13 +680,32 @@ public final class StagingArea {
 		return this;
 	}
 
+	/**
+	 * Stages the given {@link Revision} as CHANGED in this staging area for commit. 
+	 * @param oldRevision - the revision's old state (current state in the index)
+	 * @param changedRevision - the revision's new state with potentially indexable changes
+	 * @return - this staging area for chaining
+	 */
 	public StagingArea stageChange(Revision oldRevision, Revision changedRevision) {
 		return stageChange(oldRevision, changedRevision, true);
 	}
 	
+	/**
+	 * Stages the given {@link Revision} as CHANGED in this staging area either for commit (commit=true) or for change processing purposes only
+	 * (commit=false). In case the object is already registered in this staging area via an early stageX method call this method will use the
+	 * currently staged state as oldRevision instead of the given argument and compute the change compared to that state.
+	 * 
+	 * @param oldRevision
+	 *            - the revision's old state (current state in the index)
+	 * @param changedRevision
+	 *            - the revision's new state with potentially indexable changes
+	 * @param commit
+	 *            - to register the object as a CHANGED object to commit, or as a CHANGED object to process by commit hooks only
+	 * @return - this staging area for chaining
+	 */
 	public StagingArea stageChange(Revision oldRevision, Revision changedRevision, boolean commit) {
 		checkArgument(Objects.equals(oldRevision.getId(), changedRevision.getId()), "IDs of oldRevision and changedRevision must match");
-		ObjectId id = toObjectId(changedRevision, changedRevision.getId());
+		ObjectId id = ObjectId.toObjectId(changedRevision, changedRevision.getId());
 		if (stagedObjects.containsKey(id)) {
 			StagedObject currentObject = stagedObjects.get(id);
 			stagedObjects.put(id, currentObject.withObject(changedRevision, commit));
@@ -595,36 +715,62 @@ public final class StagingArea {
 		return this;
 	}
 	
+	/**
+	 * Stages the given {@link Revision} as REMOVED object in this staging area for commit.
+	 * @param removedRevision - the revision to register
+	 * @return - this staging area for chaining
+	 */
 	public StagingArea stageRemove(Revision removedRevision) {
 		return stageRemove(removedRevision, true);
 	}
 	
+	/**
+	 * Stages the given {@link Revision} as REMOVED object in this staging area for commit.
+	 * @param removedRevision - the revision to register
+	 * @param commit
+	 *            - to register the object as a REMOVED object to commit, or as a REMOVED object to process by commit hooks only
+	 * @return - this staging area for chaining
+	 */
 	public StagingArea stageRemove(Revision removedRevision, boolean commit) {
 		return stageRemove(removedRevision.getId(), removedRevision, commit);
 	}
 	
+	/**
+	 * Stages the given {@link Object} as REMOVED object in this staging area for commit. 
+	 * 
+	 * @param key - the identifier to use when staging the object
+	 * @param removed - the removed object to register
+	 * @return - this staging area for chaining
+	 */
 	public StagingArea stageRemove(String key, Object removed) {
 		return stageRemove(key, removed, true);
 	}
 	
+	/**
+	 * Stages the given {@link Object} as REMOVED in this staging area either for commit (commit=true) or for change processing purposes only (commit=false).
+	 * 
+	 * @param key - the identifier to use when staging the object
+	 * @param removed - the removed object to register
+	 * @param commit
+	 *            - to register the object as a REMOVED object to commit, or as a REMOVED object to process by commit hooks only
+	 * @return - this staging area for chaining
+	 */
 	public StagingArea stageRemove(String key, Object removed, boolean commit) {
-		stagedObjects.put(toObjectId(removed, key), removed(removed, null, commit));
+		stagedObjects.put(ObjectId.toObjectId(removed, key), removed(removed, null, commit));
 		return this;
 	}
 	
+	/**
+	 * Mark the object registered with the given type and ID revised on the current merge source.
+	 * 
+	 * @param type - the type of the object to revise
+	 * @param id - the identifier of the object to revise
+	 */
 	public void reviseOnMergeSource(Class<?> type, String id) {
 		externalRevisionsToReviseOnMergeSource.put(type, id);
 	}
 	
-	private ObjectId toObjectId(Object obj, String id) {
-		if (obj instanceof Revision) {
-			return ((Revision) obj).getObjectId();
-		} else {
-			return ObjectId.of(obj.getClass(), id);
-		}
-	}
-	
-	void merge(RevisionBranchRef fromRef, RevisionBranchRef toRef, boolean squash, RevisionConflictProcessor conflictProcessor, Set<String> exclusions) {
+	/*package*/ void merge(RevisionBranchRef fromRef, RevisionBranchRef toRef, boolean squash, RevisionConflictProcessor conflictProcessor, Set<String> exclusions) {
 		checkArgument(this.mergeSources == null, "Already merged another ref to this StagingArea. Commit staged changes to apply them.");
 		this.mergeFromBranchRef = fromRef.difference(toRef);
 		this.mergeSources = this.mergeFromBranchRef
@@ -1158,15 +1304,15 @@ public final class StagingArea {
 		
 	}
 	
-	public StagedObject added(Object object, RevisionDiff diff, boolean commit) {
+	private StagedObject added(Object object, RevisionDiff diff, boolean commit) {
 		return new StagedObject(StageKind.ADDED, object, diff, commit);
 	}
 	
-	public StagedObject changed(Object object, RevisionDiff diff, boolean commit) {
+	private StagedObject changed(Object object, RevisionDiff diff, boolean commit) {
 		return new StagedObject(StageKind.CHANGED, object, diff, commit);
 	}
 
-	public StagedObject removed(Object object, RevisionDiff diff, boolean commit) {
+	private StagedObject removed(Object object, RevisionDiff diff, boolean commit) {
 		return new StagedObject(StageKind.REMOVED, object, diff, commit);
 	}
 	

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/config/IndexConfiguration.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/config/IndexConfiguration.java
@@ -15,6 +15,7 @@
  */
 package com.b2international.snowowl.core.config;
 
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
 import org.hibernate.validator.constraints.NotEmpty;
@@ -63,6 +64,14 @@ public class IndexConfiguration {
 	@Min(IndexClientFactory.DEFAULT_RESULT_WINDOW)
 	private int resultWindow = DEFAULT_RESULT_WINDOW;
 
+	@Min(5_000)
+	@Max(IndexClientFactory.DEFAULT_COMMIT_WATERMARK_HIGH_VALUE)
+	private int commitWatermarkLow = IndexClientFactory.DEFAULT_COMMIT_WATERMARK_LOW_VALUE;
+	
+	@Min(5_000)
+	@Max(IndexClientFactory.DEFAULT_COMMIT_WATERMARK_HIGH_VALUE)
+	private int commitWatermarkHigh = IndexClientFactory.DEFAULT_COMMIT_WATERMARK_HIGH_VALUE;
+	
 	@JsonProperty
 	public String getCommitInterval() {
 		return commitInterval;
@@ -194,6 +203,22 @@ public class IndexConfiguration {
 	public void setBulkActionSizeInMb(int bulkActionSizeInMb) {
 		this.bulkActionSizeInMb = bulkActionSizeInMb;
 	}
+	
+	public int getCommitWatermarkHigh() {
+		return commitWatermarkHigh;
+	}
+	
+	public int getCommitWatermarkLow() {
+		return commitWatermarkLow;
+	}
+	
+	public void setCommitWatermarkHigh(int commitWatermarkHigh) {
+		this.commitWatermarkHigh = commitWatermarkHigh;
+	}
+	
+	public void setCommitWatermarkLow(int commitWatermarkLow) {
+		this.commitWatermarkLow = commitWatermarkLow;
+	}
 
 	public void configure(Builder<String, Object> settings) {
 		if (getClusterHealthTimeout() <= getSocketTimeout()) {
@@ -222,7 +247,9 @@ public class IndexConfiguration {
 		settings.put(IndexClientFactory.SOCKET_TIMEOUT, getSocketTimeout());
 		settings.put(IndexClientFactory.CLUSTER_HEALTH_TIMEOUT, getClusterHealthTimeout());
 		settings.put(IndexClientFactory.BULK_ACTIONS_SIZE, getBulkActionSize());
-		settings.put(IndexClientFactory.BULK_ACTIONS_SIZE_IN_MB, getBulkActionSizeInMb());		
+		settings.put(IndexClientFactory.BULK_ACTIONS_SIZE_IN_MB, getBulkActionSizeInMb());
+		settings.put(IndexClientFactory.COMMIT_WATERMARK_LOW_KEY, getCommitWatermarkLow());
+		settings.put(IndexClientFactory.COMMIT_WATERMARK_HIGH_KEY, getCommitWatermarkHigh());
 	}
 	
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/CappedTransactionContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/CappedTransactionContext.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.domain;
+
+import com.b2international.index.revision.Revision;
+import com.b2international.index.revision.StagingArea;
+
+/**
+ * @since 7.16
+ */
+public final class CappedTransactionContext extends DelegatingTransactionContext {
+
+	// 0 or less disables this feature, 1 or more allows partial commits for any transaction
+	private final int commitThreshold;
+
+	public CappedTransactionContext(TransactionContext context, int commitThreshold) {
+		super(context);
+		this.commitThreshold = commitThreshold;
+	}
+
+	@Override
+	public String add(Object obj) {
+		String id = super.add(obj);
+		commitIfAboveThreshold();
+		return id;
+	}
+	
+	@Override
+	public void update(Revision oldVersion, Revision newVersion) {
+		// apply update first
+		super.update(oldVersion, newVersion);
+		commitIfAboveThreshold();
+	}
+	
+	@Override
+	public void delete(Object obj) {
+		super.delete(obj);
+		commitIfAboveThreshold();
+	}
+	
+	@Override
+	public void delete(Object obj, boolean force) {
+		super.delete(obj, force);
+		commitIfAboveThreshold();
+	}
+	
+	@Override
+	public void clearContents() {
+		throw new UnsupportedOperationException("clearContents is not supported in capped transaction scenarios");
+	}
+	
+	@Override
+	public void close() throws Exception {
+		// if there is anything left in the staging area on close, then commit it before close (dirty check already included in commit implementation)
+		commit();
+		super.close();
+	}
+	
+	private void commitIfAboveThreshold() {
+		// check if staged objects collection reaches the threshold and commit if it does
+		if (commitThreshold > 0 && service(StagingArea.class).getNumberOfStagedObjects() >= commitThreshold) {
+			commit();
+		}
+	}
+	
+}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/DelegatingTransactionContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/DelegatingTransactionContext.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.domain;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
+import com.b2international.index.revision.Commit;
+import com.b2international.index.revision.Revision;
+import com.b2international.snowowl.core.exceptions.ComponentNotFoundException;
+
+/**
+ * @since 7.16
+ */
+public class DelegatingTransactionContext extends DelegatingBranchContext implements TransactionContext {
+
+	public DelegatingTransactionContext(TransactionContext context) {
+		super(context);
+	}
+
+	@Override
+	protected TransactionContext getDelegate() {
+		return (TransactionContext) super.getDelegate();
+	}
+	
+	@Override
+	public void close() throws Exception {
+		getDelegate().close();
+	}
+
+	@Override
+	public String author() {
+		return getDelegate().author();
+	}
+
+	@Override
+	public String add(Object obj) {
+		return getDelegate().add(obj);
+	}
+
+	@Override
+	public void update(Revision oldVersion, Revision newVersion) {
+		getDelegate().update(oldVersion, newVersion);
+	}
+
+	@Override
+	public void delete(Object obj) {
+		getDelegate().delete(obj);
+	}
+
+	@Override
+	public void delete(Object obj, boolean force) {
+		getDelegate().delete(obj, force);
+	}
+
+	@Override
+	public Optional<Commit> commit() {
+		return getDelegate().commit();
+	}
+
+	@Override
+	public Optional<Commit> commit(String commitComment) {
+		return getDelegate().commit(commitComment);
+	}
+
+	@Override
+	public Optional<Commit> commit(String commitComment, String parentContextDescription) {
+		return getDelegate().commit(commitComment, parentContextDescription);
+	}
+
+	@Override
+	public Optional<Commit> commit(String userId, String commitComment, String parentContextDescription) {
+		return getDelegate().commit(userId, commitComment, parentContextDescription);
+	}
+
+	@Override
+	public boolean isNotificationEnabled() {
+		return getDelegate().isNotificationEnabled();
+	}
+
+	@Override
+	public void setNotificationEnabled(boolean notificationEnabled) {
+		getDelegate().setNotificationEnabled(notificationEnabled);
+	}
+
+	@Override
+	public <T> T lookup(String componentId, Class<T> type) throws ComponentNotFoundException {
+		return getDelegate().lookup(componentId, type);
+	}
+
+	@Override
+	public <T> T lookupIfExists(String componentId, Class<T> type) {
+		return getDelegate().lookupIfExists(componentId, type);
+	}
+
+	@Override
+	public <T> Map<String, T> lookup(Collection<String> componentIds, Class<T> type) {
+		return getDelegate().lookup(componentIds, type);
+	}
+
+	@Override
+	public void clearContents() {
+		getDelegate().clearContents();
+	}
+
+	@Override
+	public boolean isDirty() {
+		return getDelegate().isDirty();
+	}
+
+	@Override
+	public String parentLock() {
+		return getDelegate().parentLock();
+	}
+
+}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/DelegatingTransactionContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/DelegatingTransactionContext.java
@@ -113,6 +113,11 @@ public class DelegatingTransactionContext extends DelegatingBranchContext implem
 	}
 
 	@Override
+	public void rollback() {
+		getDelegate().rollback();
+	}
+	
+	@Override
 	public void clearContents() {
 		getDelegate().clearContents();
 	}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/TransactionContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/TransactionContext.java
@@ -121,6 +121,11 @@ public interface TransactionContext extends BranchContext, AutoCloseable {
 	 * @return - an {@link Optional} {@link Commit} object
 	 */
 	Optional<Commit> commit(String userId, String commitComment, String parentContextDescription);
+
+	/**
+	 * Rolls back the transaction to an empty state, where nothing is staged for commit.
+	 */
+	void rollback();
 	
 	/**
 	 * @return whether the commit will notify interested services, notification services about this transaction's commit or not. It's enabled by default.

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryTransactionContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryTransactionContext.java
@@ -294,6 +294,12 @@ public final class RepositoryTransactionContext extends DelegatingBranchContext 
 			clear();
 		}
 	}
+
+	@Override
+	public void rollback() {
+		staging.rollback();
+		clear();
+	}
 	
 	private void clear() {
 		resolvedObjectsById.clear();

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/version/SnomedVersioningRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/version/SnomedVersioningRequest.java
@@ -15,7 +15,6 @@
  */
 package com.b2international.snowowl.snomed.core.version;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
 
@@ -64,101 +63,47 @@ public final class SnomedVersioningRequest extends VersioningRequest {
 	);
 	
 	private final Set<String> componentIdsToPublish = newHashSet();
+	private final long effectiveTime;
 	
 	public SnomedVersioningRequest(VersioningConfiguration config) {
 		super(config);
+		this.effectiveTime = EffectiveTimes.getEffectiveTime(config().getEffectiveTime());
 	}
 	
 	@Override
 	protected void doVersionComponents(TransactionContext context) throws Exception {
 		final Logger log = context.service(Logger.class);
 		
-		log.info("Collecting unpublished components...");
-		RevisionSearcher searcher = context.service(RevisionSearcher.class);
-			
-		final Collection<SnomedDocument> componentsToVersion = newArrayList();
-		
-		searcher.search(Query.select(SnomedConceptDocument.class)
-				.where(SnomedDocument.Expressions.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME))
-				.limit(Integer.MAX_VALUE)
-				.build())
-				.forEach(componentsToVersion::add);
-		
-		searcher.search(Query.select(SnomedDescriptionIndexEntry.class)
-				.where(SnomedDocument.Expressions.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME))
-				.limit(Integer.MAX_VALUE)
-				.build())
-				.forEach(componentsToVersion::add);
-		
-		searcher.search(Query.select(SnomedRelationshipIndexEntry.class)
-				.where(SnomedDocument.Expressions.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME))
-				.limit(Integer.MAX_VALUE)
-				.build())
-				.forEach(componentsToVersion::add);
-		
-		searcher.search(Query.select(SnomedRefSetMemberIndexEntry.class)
-				.where(SnomedDocument.Expressions.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME))
-				.limit(Integer.MAX_VALUE)
-				.build())
-				.forEach(componentsToVersion::add);
+		log.info("Publishing SNOMED CT components [effectiveTime: {}]...", EffectiveTimes.format(config().getEffectiveTime()));
 		
 		// sourceModuleId to targetModuleId map
 		final Multimap<String, String> componentIdsByReferringModule = HashMultimap.create();
 		
-		log.info("Publishing SNOMED CT components [effectiveTime: {}]...", EffectiveTimes.format(config().getEffectiveTime()));
-		long effectiveTime = EffectiveTimes.getEffectiveTime(config().getEffectiveTime());
+		RevisionSearcher searcher = context.service(RevisionSearcher.class);
+			
+		searcher.scroll(Query.select(SnomedConceptDocument.class)
+				.where(SnomedDocument.Expressions.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME))
+				.limit(getCommitLimit(context))
+				.build())
+				.forEach(componentsToVersion -> versionComponents(context, componentsToVersion, componentIdsByReferringModule));
 		
-		for (SnomedDocument componentToVersion : componentsToVersion) {
-			
-			// register IDs for publication
-			if (componentToVersion instanceof SnomedComponentDocument) {
-				componentIdsToPublish.add(componentToVersion.getId());
-			}
-			
-			// stage update on components based on actual type
-			final SnomedDocument.Builder<?, ?> updatedComponent;
-			if (componentToVersion instanceof SnomedConceptDocument) {
-				final SnomedConceptDocument concept = (SnomedConceptDocument) componentToVersion;
-				componentIdsByReferringModule.put(concept.getModuleId(), concept.isPrimitive() ? Concepts.PRIMITIVE : Concepts.FULLY_DEFINED);
-				updatedComponent = SnomedConceptDocument.builder(concept);
-			} else if (componentToVersion instanceof SnomedDescriptionIndexEntry) {
-				final SnomedDescriptionIndexEntry description = (SnomedDescriptionIndexEntry) componentToVersion;
-				componentIdsByReferringModule.put(description.getModuleId(), description.getConceptId());
-				componentIdsByReferringModule.put(description.getModuleId(), description.getTypeId());
-				componentIdsByReferringModule.put(description.getModuleId(), description.getCaseSignificanceId());
-				updatedComponent = SnomedDescriptionIndexEntry.builder(description);
-			} else if (componentToVersion instanceof SnomedRelationshipIndexEntry) {
-				final SnomedRelationshipIndexEntry relationship = (SnomedRelationshipIndexEntry) componentToVersion;
-				componentIdsByReferringModule.put(relationship.getModuleId(), relationship.getSourceId());
-				componentIdsByReferringModule.put(relationship.getModuleId(), relationship.getTypeId());
-				componentIdsByReferringModule.put(relationship.getModuleId(), relationship.getDestinationId());
-				componentIdsByReferringModule.put(relationship.getModuleId(), relationship.getModifierId());
-				componentIdsByReferringModule.put(relationship.getModuleId(), relationship.getCharacteristicTypeId());
-				updatedComponent = SnomedRelationshipIndexEntry.builder(relationship);
-			} else if (componentToVersion instanceof SnomedRefSetMemberIndexEntry) {
-				final SnomedRefSetMemberIndexEntry member = (SnomedRefSetMemberIndexEntry) componentToVersion;
-				componentIdsByReferringModule.put(member.getModuleId(), member.getReferenceSetId());
-
-				registerIfConcept(componentIdsByReferringModule, member.getModuleId(), member.getReferencedComponentId());
-				
-				final Map<String, Object> additionalFields = member.getAdditionalFields();
-				SnomedRf2Headers.MEMBER_FIELDS_WITH_COMPONENT_ID.forEach(field -> {
-					registerIfConcept(componentIdsByReferringModule, member.getModuleId(), (String) additionalFields.get(field));
-				});
-				
-				updatedComponent = SnomedRefSetMemberIndexEntry.builder(member);
-			} else {
-				throw new UnsupportedOperationException("Not implemented case for: " + componentToVersion);
-			}
-			
-			context.update(
-				componentToVersion, 
-				updatedComponent
-					.effectiveTime(effectiveTime)
-					.released(true)
-					.build()
-			);
-		}
+		searcher.scroll(Query.select(SnomedDescriptionIndexEntry.class)
+				.where(SnomedDocument.Expressions.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME))
+				.limit(getCommitLimit(context))
+				.build())
+				.forEach(componentsToVersion -> versionComponents(context, componentsToVersion, componentIdsByReferringModule));
+		
+		searcher.scroll(Query.select(SnomedRelationshipIndexEntry.class)
+				.where(SnomedDocument.Expressions.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME))
+				.limit(getCommitLimit(context))
+				.build())
+				.forEach(componentsToVersion -> versionComponents(context, componentsToVersion, componentIdsByReferringModule));
+		
+		searcher.scroll(Query.select(SnomedRefSetMemberIndexEntry.class)
+				.where(SnomedDocument.Expressions.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME))
+				.limit(getCommitLimit(context))
+				.build())
+				.forEach(componentsToVersion -> versionComponents(context, componentsToVersion, componentIdsByReferringModule));
 		
 		// iterate over each module and get modules of all components registered to componentsByReferringModule
 		log.info("Collecting module dependencies of changed components...");
@@ -198,6 +143,61 @@ public final class SnomedVersioningRequest extends VersioningRequest {
 		
 	}
 	
+	private void versionComponents(TransactionContext context, Iterable<? extends SnomedDocument> componentsToVersion, Multimap<String, String> componentIdsByReferringModule) {
+		
+		for (SnomedDocument componentToVersion : componentsToVersion) {
+			// register IDs for publication
+			if (componentToVersion instanceof SnomedComponentDocument) {
+				componentIdsToPublish.add(componentToVersion.getId());
+			}
+			
+			// stage update on components based on actual type
+			final SnomedDocument.Builder<?, ?> updatedComponent;
+			if (componentToVersion instanceof SnomedConceptDocument) {
+				final SnomedConceptDocument concept = (SnomedConceptDocument) componentToVersion;
+				componentIdsByReferringModule.put(concept.getModuleId(), concept.isPrimitive() ? Concepts.PRIMITIVE : Concepts.FULLY_DEFINED);
+				updatedComponent = SnomedConceptDocument.builder(concept);
+			} else if (componentToVersion instanceof SnomedDescriptionIndexEntry) {
+				final SnomedDescriptionIndexEntry description = (SnomedDescriptionIndexEntry) componentToVersion;
+				componentIdsByReferringModule.put(description.getModuleId(), description.getConceptId());
+				componentIdsByReferringModule.put(description.getModuleId(), description.getTypeId());
+				componentIdsByReferringModule.put(description.getModuleId(), description.getCaseSignificanceId());
+				updatedComponent = SnomedDescriptionIndexEntry.builder(description);
+			} else if (componentToVersion instanceof SnomedRelationshipIndexEntry) {
+				final SnomedRelationshipIndexEntry relationship = (SnomedRelationshipIndexEntry) componentToVersion;
+				componentIdsByReferringModule.put(relationship.getModuleId(), relationship.getSourceId());
+				componentIdsByReferringModule.put(relationship.getModuleId(), relationship.getTypeId());
+				componentIdsByReferringModule.put(relationship.getModuleId(), relationship.getDestinationId());
+				componentIdsByReferringModule.put(relationship.getModuleId(), relationship.getModifierId());
+				componentIdsByReferringModule.put(relationship.getModuleId(), relationship.getCharacteristicTypeId());
+				updatedComponent = SnomedRelationshipIndexEntry.builder(relationship);
+			} else if (componentToVersion instanceof SnomedRefSetMemberIndexEntry) {
+				final SnomedRefSetMemberIndexEntry member = (SnomedRefSetMemberIndexEntry) componentToVersion;
+				componentIdsByReferringModule.put(member.getModuleId(), member.getReferenceSetId());
+				
+				registerIfConcept(componentIdsByReferringModule, member.getModuleId(), member.getReferencedComponentId());
+				
+				final Map<String, Object> additionalFields = member.getAdditionalFields();
+				SnomedRf2Headers.MEMBER_FIELDS_WITH_COMPONENT_ID.forEach(field -> {
+					registerIfConcept(componentIdsByReferringModule, member.getModuleId(), (String) additionalFields.get(field));
+				});
+				
+				updatedComponent = SnomedRefSetMemberIndexEntry.builder(member);
+			} else {
+				throw new UnsupportedOperationException("Not implemented case for: " + componentToVersion);
+			}
+			
+			context.update(
+				componentToVersion, 
+				updatedComponent
+					.effectiveTime(effectiveTime)
+					.released(true)
+				.build()
+			);
+		}
+		
+	}
+
 	private void adjustDependencyRefSetMembers(TransactionContext context, Multimap<String, String> moduleDependencies, Map<String, Long> moduleToLatestEffectiveTime, long effectiveTime) {
 		// Update existing, add new members to moduleDependencyRefSet
 		if (!CompareUtils.isEmpty(moduleDependencies)) {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/version/SnomedVersioningRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/version/SnomedVersioningRequest.java
@@ -19,11 +19,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import org.slf4j.Logger;
 
@@ -40,12 +36,7 @@ import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
 import com.b2international.snowowl.snomed.common.SnomedRf2Headers;
 import com.b2international.snowowl.snomed.core.domain.refset.SnomedRefSetType;
 import com.b2international.snowowl.snomed.core.domain.refset.SnomedReferenceSetMember;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedComponentDocument;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedDescriptionIndexEntry;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedDocument;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedRefSetMemberIndexEntry;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedRelationshipIndexEntry;
+import com.b2international.snowowl.snomed.datastore.index.entry.*;
 import com.b2international.snowowl.snomed.datastore.request.SnomedRequests;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -72,7 +63,7 @@ public final class SnomedVersioningRequest extends VersioningRequest {
 		SnomedRelationshipIndexEntry.class
 	);
 	
-	private Set<String> componentIdsToPublish = newHashSet();
+	private final Set<String> componentIdsToPublish = newHashSet();
 	
 	public SnomedVersioningRequest(VersioningConfiguration config) {
 		super(config);
@@ -271,23 +262,7 @@ public final class SnomedVersioningRequest extends VersioningRequest {
 			componentIdsByReferringModule.put(moduleId, dependency);
 		}
 	}
-	
-//	@Override
-//	protected void createCodeSystemVersion(final CDOEditingContext editingContext, VersioningConfiguration config) {
-//		if (Branch.MAIN_PATH.equals(editingContext.getBranch())) {
-//			super.createCodeSystemVersion(editingContext, config);
-//		} else {
-//			try (final SnomedEditingContext mainEditingContext = new SnomedEditingContext(BranchPathUtils.createMainPath())) {
-//				super.createCodeSystemVersion(mainEditingContext, config);
-//				final String commitComment = String.format("New Snomed Version %s was added to Snomed Release %s.", config.getVersionId(), config.getCodeSystemShortName());
-//				CDOServerUtils.commit(mainEditingContext, "System", commitComment, null);
-//			} catch (Exception e) {
-//				throw new SnowowlRuntimeException(String.format("An error occurred while adding Snomed Version %s to Snomed Release %s.",
-//						config.getVersionId(), config.getCodeSystemShortName()), e);
-//			}
-//		}
-//	}
-//	
+
 //	@Override
 //	public void postCommit() {
 //		if (!CompareUtils.isEmpty(componentIdsToPublish)) {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/importer/Rf2TransactionContext.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/importer/Rf2TransactionContext.java
@@ -28,11 +28,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.b2international.index.revision.Commit;
-import com.b2international.index.revision.Revision;
 import com.b2international.index.revision.StagingArea;
 import com.b2international.snowowl.core.codesystem.CodeSystemEntry;
 import com.b2international.snowowl.core.date.EffectiveTimes;
-import com.b2international.snowowl.core.domain.DelegatingBranchContext;
+import com.b2international.snowowl.core.domain.DelegatingTransactionContext;
 import com.b2international.snowowl.core.domain.IComponent;
 import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.core.exceptions.ComponentNotFoundException;
@@ -58,7 +57,7 @@ import com.google.common.collect.Multimaps;
 /**
  * @since 6.0
  */
-public final class Rf2TransactionContext extends DelegatingBranchContext implements TransactionContext {
+public final class Rf2TransactionContext extends DelegatingTransactionContext {
 	
 	private static final Logger LOG = LoggerFactory.getLogger("import");
 
@@ -77,33 +76,8 @@ public final class Rf2TransactionContext extends DelegatingBranchContext impleme
 	}
 	
 	@Override
-	public boolean isDirty() {
-		return getDelegate().isDirty();
-	}
-	
-	@Override
-	public String author() {
-		return getDelegate().author();
-	}
-
-	@Override
 	protected RepositoryTransactionContext getDelegate() {
 		return (RepositoryTransactionContext) super.getDelegate();
-	}
-	
-	@Override
-	public String add(Object o) {
-		return getDelegate().add(o);
-	}
-	
-	@Override
-	public void update(Revision oldVersion, Revision newVersion) {
-		getDelegate().update(oldVersion, newVersion);
-	}
-	
-	@Override
-	public void clearContents() {
-		getDelegate().clearContents();
 	}
 	
 	@Override
@@ -134,41 +108,6 @@ public final class Rf2TransactionContext extends DelegatingBranchContext impleme
 	@Override
 	public Optional<Commit> commit(String userId, String commitComment, String parentContextDescription) {
 		throw new UnsupportedOperationException("Use the single supported commit(String) method");
-	}
-	
-	@Override
-	public void delete(Object o) {
-		getDelegate().delete(o);
-	}
-	
-	@Override
-	public void delete(Object o, boolean force) {
-		getDelegate().delete(o, force);
-	}
-	
-	@Override
-	public void close() throws Exception {
-		getDelegate().close();
-	}
-
-	@Override
-	public <T> T lookupIfExists(String componentId, Class<T> type) {
-		return getDelegate().lookupIfExists(componentId, type);
-	}
-	
-	@Override
-	public boolean isNotificationEnabled() {
-		return getDelegate().isNotificationEnabled();
-	}
-	
-	@Override
-	public void setNotificationEnabled(boolean notificationEnabled) {
-		getDelegate().setNotificationEnabled(notificationEnabled);
-	}
-	
-	@Override
-	public String parentLock() {
-		return getDelegate().parentLock();
 	}
 	
 	@Override


### PR DESCRIPTION
This PR introduces new configuration settings in the `snowowl.yml` config file:
* commitWatermarkLow - controls the low watermark of commits based on their size (default value: 10_000)
* commitWatermarkHigh - controls the high watermark of commits based on their size (default value: 50_000)

If a commit reaches either of the configured watermarks, then a warning message will be raised to indicate a commit that is larger than currently allowed. Typically a commit of 50k changes or less is expected. Commits higher than this put too much memory pressure on the system when loading history for components. It is recommended to commit changes in smaller batches than in a few larger ones.