### PR TITLE
SO-4737 reindex on alias field changes

### DIFF
--- a/cis/com.b2international.snowowl.snomed.cis/src/com/b2international/snowowl/snomed/cis/memory/DefaultSnomedIdentifierService.java
+++ b/cis/com.b2international.snowowl.snomed.cis/src/com/b2international/snowowl/snomed/cis/memory/DefaultSnomedIdentifierService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import static com.google.common.collect.Sets.newLinkedHashSet;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -38,7 +37,6 @@ import com.b2international.index.Index;
 import com.b2international.index.mapping.DocumentMapping;
 import com.b2international.index.query.Expressions;
 import com.b2international.index.query.Query;
-import com.b2international.snowowl.core.IDisposableService;
 import com.b2international.snowowl.core.terminology.ComponentCategory;
 import com.b2international.snowowl.snomed.cis.AbstractSnomedIdentifierService;
 import com.b2international.snowowl.snomed.cis.SnomedIdentifierConfiguration;
@@ -51,11 +49,7 @@ import com.b2international.snowowl.snomed.cis.reservations.ISnomedIdentifierRese
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;
 import com.google.common.base.Strings;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
+import com.google.common.collect.*;
 import com.google.inject.Provider;
 
 /**
@@ -63,13 +57,12 @@ import com.google.inject.Provider;
  * 
  * @since 4.5
  */
-public class DefaultSnomedIdentifierService extends AbstractSnomedIdentifierService implements IDisposableService {
+public class DefaultSnomedIdentifierService extends AbstractSnomedIdentifierService {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSnomedIdentifierService.class);
 
 	private final Index store;
 	private final ItemIdGenerationStrategy generationStrategy;
-	private final AtomicBoolean disposed = new AtomicBoolean(false);
 
 	/*
 	 * Tests only
@@ -349,18 +342,6 @@ public class DefaultSnomedIdentifierService extends AbstractSnomedIdentifierServ
 			index.commit();
 			return null;
 		});
-	}
-	
-	@Override
-	public void dispose() {
-		if (disposed.compareAndSet(false, true)) {
-			store.admin().close();
-		}
-	}
-	
-	@Override
-	public boolean isDisposed() {
-		return disposed.get();
 	}
 	
 }

--- a/commons/com.b2international.index.tests/src/com/b2international/index/mapping/MappingMigrationTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/mapping/MappingMigrationTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.index.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.elasticsearch.common.collect.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.b2international.index.*;
+import com.b2international.index.admin.IndexAdmin;
+import com.b2international.index.query.Expressions;
+import com.b2international.index.query.Query;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @since 7.16.1
+ */
+public class MappingMigrationTest extends BaseIndexTest {
+
+	@Doc(type = "schema") // this will ensure the same index name will be used for all subclasses and versions
+	static class Schema {
+		
+		@ID
+		private String id;
+		private String field;
+		
+		@JsonCreator
+		public Schema(@JsonProperty("id") String id, @JsonProperty("field") String field) {
+			this.id = id;
+			this.field = field;
+		}
+		
+		public String getId() {
+			return id;
+		}
+		
+		public String getField() {
+			return field;
+		}
+		
+	}
+	
+	@Doc(type = "schema")
+	static class SchemaWithNewField extends Schema {
+
+		private String newField;
+		
+		@JsonCreator
+		public SchemaWithNewField(@JsonProperty("id") String id, @JsonProperty("field") String field, @JsonProperty("newField") String newField) {
+			super(id, field);
+			this.newField = newField;
+		}
+		
+		public String getNewField() {
+			return newField;
+		}
+		
+	}
+	
+	@Doc(type = "schema")
+	static class SchemaWithNewFieldAlias {
+
+		@ID
+		private String id;
+		
+		@Keyword
+		@Text(alias = "text", analyzer = Analyzers.TOKENIZED)
+		private String field;
+		
+		@JsonCreator
+		public SchemaWithNewFieldAlias(@JsonProperty("id") String id, @JsonProperty("field") String field) {
+			this.id = id;
+			this.field = field;
+		}
+		
+		public String getId() {
+			return id;
+		}
+		
+		public String getField() {
+			return field;
+		}
+		
+	}
+
+	private Schema existingDoc1;
+	private Schema existingDoc2;
+	
+	@Override
+	protected Collection<Class<?>> getTypes() {
+		return List.of(); // no types at the beginning
+	}
+	
+	@Before
+	public void setup() {
+		// enable class overrides for test(s) in this class
+		DocumentMappingRegistry.INSTANCE.enableRuntimeMappingOverrides = true;
+		// make sure we always start with the basic Schema
+		admin().updateMappings(new Mappings(Schema.class));
+		admin().create();
+		// index two documents with the existing schema
+		existingDoc1 = new Schema(KEY1, "existing field one");
+		existingDoc2 = new Schema(KEY2, "existing field two");
+		indexDocuments(Map.of(
+			KEY1, existingDoc1,
+			KEY2, existingDoc2
+		));
+	}
+
+	@Test
+	public void migrateNewField() throws Exception {
+		// update Mappings to new schema
+		admin().updateMappings(new Mappings(SchemaWithNewField.class));
+		// then recreate indices using the new mappings (and to perform potential migration as well)
+		admin().create();
+		// TODO assert log messages about successfully applying new compatible mapping change
+		assertDocEquals(existingDoc1, getDocument(SchemaWithNewField.class, KEY1));
+		assertDocEquals(existingDoc2, getDocument(SchemaWithNewField.class, KEY2));
+	}
+	
+	@Test
+	public void migrateNewFieldAlias() throws Exception {
+		// update Mappings to new schema
+		admin().updateMappings(new Mappings(SchemaWithNewFieldAlias.class));
+		// then recreate indices using the new mappings (and to perform potential migration as well)
+		admin().create();
+		// TODO assert log messages about successfully applying new compatible mapping change
+		assertDocEquals(existingDoc1, getDocument(SchemaWithNewFieldAlias.class, KEY1));
+		assertDocEquals(existingDoc2, getDocument(SchemaWithNewFieldAlias.class, KEY2));
+		
+		// TODO perform full text search to verify successful migration
+		Hits<SchemaWithNewFieldAlias> hits = search(Query.select(SchemaWithNewFieldAlias.class)
+				.where(Expressions.matchTextAll("field", "one"))
+				.build());
+		assertThat(hits).hasSize(1);
+	}
+	
+	@After
+	public void teardown() {
+		// clear the custom indices
+		admin().updateMappings(new Mappings(Schema.class));
+		admin().clear(List.of(Schema.class));
+		// disable class overrides after running the test(s)
+		DocumentMappingRegistry.INSTANCE.enableRuntimeMappingOverrides = false;
+	}
+	
+	/*
+	 * Helper method to access the IndexAdmin for the revision index and not for the underlying raw index.
+	 */
+	private IndexAdmin admin() {
+		return index.getRevisionIndex().admin();
+	}
+	
+}

--- a/commons/com.b2international.index/src/com/b2international/index/admin/IndexAdmin.java
+++ b/commons/com.b2international.index/src/com/b2international/index/admin/IndexAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,11 +101,6 @@ public interface IndexAdmin {
 	 * @return
 	 */
 	String getTypeIndex(DocumentMapping mapping);
-
-	/**
-	 * Closes the underlying index.
-	 */
-	void close();
 
 	/**
 	 * Optimizes the underlying index until it has less than or equal segments than the supplied maxSegments number.

--- a/commons/com.b2international.index/src/com/b2international/index/es/admin/EsIndexAdmin.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/admin/EsIndexAdmin.java
@@ -409,11 +409,10 @@ public final class EsIndexAdmin implements IndexAdmin {
 							prop.put("normalizer", normalizer);
 						}
 						// XXX index: true is the default, ES won't store it in the mapping and will default to true even if explicitly set, which would cause unnecessary mapping update during boot
+						// XXX doc_values: true is the default, ES won't store it in the mapping and will default to true even if explicitly set, which would cause unnecessary mapping update during boot
 						if (!keywordMapping.index()) {
 							prop.put("index", false);
-						}
-						if (!keywordMapping.index()) {
-							prop.put("doc_values", keywordMapping.index());
+							prop.put("doc_values", false);
 						}
 					}
 					

--- a/commons/com.b2international.index/src/com/b2international/index/es/admin/EsIndexAdmin.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/admin/EsIndexAdmin.java
@@ -574,9 +574,6 @@ public final class EsIndexAdmin implements IndexAdmin {
 	}
 
 	@Override
-	public void close() {}
-
-	@Override
 	public void optimize(int maxSegments) {
 //		client().admin().indices().prepareForceMerge(name).setMaxNumSegments(maxSegments).get();
 //		waitForYellowHealth();

--- a/commons/com.b2international.index/src/com/b2international/index/es/admin/EsIndexAdmin.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/admin/EsIndexAdmin.java
@@ -18,7 +18,6 @@ package com.b2international.index.es.admin;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Maps.newHashMapWithExpectedSize;
-import static com.google.common.collect.Sets.newHashSet;
 import static com.google.common.collect.Sets.newHashSetWithExpectedSize;
 
 import java.io.IOException;
@@ -28,6 +27,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
@@ -63,6 +63,7 @@ import com.b2international.index.es.client.EsClient;
 import com.b2international.index.es.query.EsQueryBuilder;
 import com.b2international.index.mapping.DocumentMapping;
 import com.b2international.index.mapping.Mappings;
+import com.b2international.index.query.Expression;
 import com.b2international.index.query.Expressions;
 import com.b2international.index.util.NumericClassUtils;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -82,6 +83,8 @@ import com.google.common.primitives.Primitives;
  */
 public final class EsIndexAdmin implements IndexAdmin {
 
+	private static final Pattern FIELD_ALIAS_CHANGE_PROPERTY_PATTERN = Pattern.compile("properties/[a-zA-Z0-9_]*/fields(/[a-zA-Z0-9_]*)?");
+	
 	/**
 	 * List of Elasticsearch supported dynamic settings.
 	 */
@@ -163,6 +166,9 @@ public final class EsIndexAdmin implements IndexAdmin {
 	@Override
 	public void create() {
 		log.info("Preparing '{}' indexes...", name);
+		// register any type that requires a refresh at the end of the index create/open
+		Set<DocumentMapping> mappingsToRefresh = Sets.newHashSet();
+		
 		// create number of indexes based on number of types
 		for (DocumentMapping mapping : mappings.getMappings()) {
 			final String index = getTypeIndex(mapping);
@@ -188,8 +194,8 @@ public final class EsIndexAdmin implements IndexAdmin {
 					final ObjectNode currentTypeMapping = mapper.valueToTree(currentIndexMapping.get(type).getSourceAsMap());
 					final JsonNode diff = JsonDiff.asJson(currentTypeMapping, newTypeMapping, DIFF_FLAGS);
 					final ArrayNode diffNode = ClassUtils.checkAndCast(diff, ArrayNode.class);
-					Set<String> compatibleChanges = newHashSet();
-					Set<String> uncompatibleChanges = newHashSet();
+					SortedSet<String> compatibleChanges = Sets.newTreeSet();
+					SortedSet<String> uncompatibleChanges = Sets.newTreeSet();
 					for (ObjectNode change : Iterables.filter(diffNode, ObjectNode.class)) {
 						String prop = change.get("path").asText().substring(1);
 						switch (change.get("op").asText()) {
@@ -207,11 +213,17 @@ public final class EsIndexAdmin implements IndexAdmin {
 					if (!uncompatibleChanges.isEmpty()) {
 						log.warn("Cannot migrate index '{}' to new mapping with breaking changes on properties '{}'. Run repository reindex to migrate to new mapping schema or drop that index manually using the Elasticsearch API.", index, uncompatibleChanges);
 					} else if (!compatibleChanges.isEmpty()) {
-						compatibleChanges.forEach(prop -> {
-							log.info("Applying mapping changes on property {} in index {}", prop, index);
-						});
+						log.info("Applying mapping changes {} in index {}", compatibleChanges, index);
 						AcknowledgedResponse response = client.indices().updateMapping(new PutMappingRequest(index).type(type).source(typeMapping));
 						checkState(response.isAcknowledged(), "Failed to update mapping '%s' for type '%s'", name, mapping.typeAsString());
+						// if there are field alias changes, then run update_by_query on all documents to simply reindex them
+						// new fields do not require reindex, they will be added to new documents, existing documents don't have any data that needs reindex 
+						if (hasFieldAliasChange(compatibleChanges)) {
+							if (bulkIndexByScroll(client, mapping, Expressions.matchAll(), "update", null /*no script, in place update of docs to pick up mapping changes*/, "mapping migration")) {
+								mappingsToRefresh.add(mapping);
+							}
+							log.info("Migrated documents to new mapping in index '{}'", index);
+						}
 					}
 				} catch (IOException e) {
 					throw new IndexException(String.format("Failed to update mapping '%s' for type '%s'", name, mapping.typeAsString()), e);
@@ -240,9 +252,18 @@ public final class EsIndexAdmin implements IndexAdmin {
 		}
 		// wait until the cluster processes each index create request
 		waitForYellowHealth(indices());
+		if (!mappingsToRefresh.isEmpty()) {
+			refresh(mappingsToRefresh);
+		}
 		log.info("'{}' indexes are ready.", name);
 	}
 
+	private boolean hasFieldAliasChange(SortedSet<String> compatibleChanges) {
+		return compatibleChanges.stream()
+				.map(FIELD_ALIAS_CHANGE_PROPERTY_PATTERN::matcher)
+				.anyMatch(Matcher::matches);
+	}
+	
 	private Map<String, Object> stringsAsKeywords() {
 		return Map.of(
 			"strings_as_keywords", Map.of(
@@ -391,7 +412,9 @@ public final class EsIndexAdmin implements IndexAdmin {
 						if (!keywordMapping.index()) {
 							prop.put("index", false);
 						}
-						prop.put("doc_values", keywordMapping.index());
+						if (!keywordMapping.index()) {
+							prop.put("doc_values", keywordMapping.index());
+						}
 					}
 					
 					// put extra text fields into fields object
@@ -500,7 +523,9 @@ public final class EsIndexAdmin implements IndexAdmin {
 		final Set<DocumentMapping> typesToRefresh = Collections.synchronizedSet(newHashSetWithExpectedSize(types.size()));
 		
 		for (Class<?> type : types) {
-			bulkDelete(new BulkDelete<>(type, Expressions.matchAll()), typesToRefresh);
+			if (bulkDelete(new BulkDelete<>(type, Expressions.matchAll()))) {
+				typesToRefresh.add(mappings.getMapping(type));
+			}
 		}
 		
 		refresh(typesToRefresh);
@@ -624,26 +649,28 @@ public final class EsIndexAdmin implements IndexAdmin {
 		}
 	}
 	
-	public void bulkUpdate(final BulkUpdate<?> update, Set<DocumentMapping> mappingsToRefresh) {
+	public boolean bulkUpdate(final BulkUpdate<?> update) {
 		final DocumentMapping mapping = mappings().getMapping(update.getType());
 		final String rawScript = mapping.getScript(update.getScript()).script();
-		org.elasticsearch.script.Script script = new org.elasticsearch.script.Script(ScriptType.INLINE, "painless", rawScript, ImmutableMap.copyOf(update.getParams()));
-		bulkIndexByScroll(client, update, "update", script, mappingsToRefresh);
+		org.elasticsearch.script.Script script = new org.elasticsearch.script.Script(ScriptType.INLINE, "painless", rawScript, Map.copyOf(update.getParams()));
+		return bulkIndexByScroll(client, mapping, update.getFilter(), "update", script, update.toString());
 	}
 
-	public void bulkDelete(final BulkDelete<?> delete, Set<DocumentMapping> mappingsToRefresh) {
-		bulkIndexByScroll(client, delete, "delete", null, mappingsToRefresh);
+	public boolean bulkDelete(final BulkDelete<?> delete) {
+		final DocumentMapping mapping = mappings().getMapping(delete.getType());
+		return bulkIndexByScroll(client, mapping, delete.getFilter(), "delete", null, delete.toString());
 	}
 
-	private void bulkIndexByScroll(final EsClient client,
-			final BulkOperation<?> op, 
+	private boolean bulkIndexByScroll(final EsClient client,
+			final DocumentMapping mapping,
+			final Expression filter,
 			final String command, 
-			final org.elasticsearch.script.Script script, 
-			final Set<DocumentMapping> mappingsToRefresh) {
+			final org.elasticsearch.script.Script script,
+			final String operationDescription) {
 		
-		final DocumentMapping mapping = mappings().getMapping(op.getType());
-		final QueryBuilder query = new EsQueryBuilder(mapping, settings, log).build(op.getFilter());
+		final QueryBuilder query = new EsQueryBuilder(mapping, settings, log).build(filter);
 		
+		boolean needsRefresh = false;
 		long versionConflicts = 0;
 		int attempts = DEFAULT_MAX_NUMBER_OF_VERSION_CONFLICT_RETRIES;
 		
@@ -670,19 +697,19 @@ public final class EsIndexAdmin implements IndexAdmin {
 				
 				boolean updated = updateCount > 0;
 				if (updated) {
-					mappingsToRefresh.add(mapping);
-					log().info("Updated {} {} documents with bulk {}", updateCount, mapping.typeAsString(), op);
+					log().info("Updated {} {} documents with bulk {}", updateCount, mapping.typeAsString(), operationDescription);
+					needsRefresh = true;
 				}
 				
 				boolean deleted = deleteCount > 0;
 				if (deleted) {
-					mappingsToRefresh.add(mapping);
-					log().info("Deleted {} {} documents with bulk {}", deleteCount, mapping.typeAsString(), op);
+					log().info("Deleted {} {} documents with bulk {}", deleteCount, mapping.typeAsString(), operationDescription);
+					needsRefresh = true;
 				}
 				
 				if (!updated && !deleted) {
 					log().warn("Bulk {} could not be applied to {} documents, no-ops ({}), conflicts ({})",
-							op,
+							operationDescription,
 							mapping.typeAsString(), 
 							noops, 
 							versionConflicts);
@@ -724,6 +751,8 @@ public final class EsIndexAdmin implements IndexAdmin {
 				throw new IndexException("Could not execute bulk update.", e);
 			}
 		} while (versionConflicts > 0);
+		
+		return needsRefresh;
 	}
 	
 	public int getConcurrencyLevel() {

--- a/commons/com.b2international.index/src/com/b2international/index/mapping/DocumentMappingRegistry.java
+++ b/commons/com.b2international.index/src/com/b2international/index/mapping/DocumentMappingRegistry.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.index.mapping;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Collection;
+import java.util.Set;
+
+import com.b2international.index.Doc;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+
+/**
+ * @since 
+ */
+public enum DocumentMappingRegistry {
+
+	INSTANCE;
+	
+	private final BiMap<Class<?>, String> docTypeCache = HashBiMap.create();
+	
+	/**
+	 * For testing purposes only.
+	 */
+	@VisibleForTesting
+	/*package*/ boolean enableRuntimeMappingOverrides = false; 
+
+	public String getType(Class<?> type) {
+		if (!docTypeCache.containsKey(type)) {
+			final Doc annotation = getDocAnnotation(type);
+			checkArgument(annotation != null, "Doc annotation must be present on type '%s' or on its class hierarchy", type);
+			final String docType = Strings.isNullOrEmpty(annotation.type()) ? type.getSimpleName().toLowerCase() : annotation.type();
+			checkArgument(!Strings.isNullOrEmpty(docType), "Document type should not be null or empty on class %s", type.getName());
+			// let other classes override
+			if (docTypeCache.containsValue(docType)) {
+				if (enableRuntimeMappingOverrides) {
+					docTypeCache.inverse().remove(docType);
+				} else {
+					Class<?> existingClassMapping = docTypeCache.inverse().get(docType);
+					throw new IllegalArgumentException(String.format("Another class '%s' already uses the same index name '%s' as this class '%s'.", existingClassMapping.getName(), docType, type.getName()));
+				}
+			}
+			docTypeCache.put(type, docType);
+		}
+		return docTypeCache.get(type);
+	}
+
+	public Collection<Class<?>> getTypes() {
+		return Set.copyOf(docTypeCache.keySet());
+	}
+
+	public Class<?> getClass(String type) {
+		return checkNotNull(docTypeCache.inverse().get(type), "Missing doc class for key '%s'. Populate the doc type cache via #getType(Class<?>) method before using this method.", type);
+	}
+	
+	public static Doc getDocAnnotation(Class<?> type) {
+		if (type.isAnnotationPresent(Doc.class)) {
+			return type.getAnnotation(Doc.class);
+		} else {
+			if (type.getSuperclass() != null) {
+				final Doc doc = getDocAnnotation(type.getSuperclass());
+				if (doc != null) {
+					return doc;
+				}
+			}
+			
+			for (Class<?> iface : type.getInterfaces()) {
+				final Doc doc = getDocAnnotation(iface);
+				if (doc != null) {
+					return doc;
+				}
+			}
+			return null;
+		}
+	}
+	
+}

--- a/commons/com.b2international.index/src/com/b2international/index/revision/RevisionIndexAdmin.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/RevisionIndexAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,11 +102,6 @@ public final class RevisionIndexAdmin implements IndexAdmin {
 	@Override
 	public String getTypeIndex(DocumentMapping mapping) {
 		return rawIndexAdmin.getTypeIndex(mapping);
-	}
-
-	@Override
-	public void close() {
-		rawIndexAdmin.close();
 	}
 
 	@Override

--- a/commons/com.b2international.index/src/com/b2international/index/util/Reflections.java
+++ b/commons/com.b2international.index/src/com/b2international/index/util/Reflections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,15 @@ public class Reflections {
 			return field.get(object);
 		} catch (IllegalArgumentException | IllegalAccessException e) {
 			throw new IndexException("Couldn't get value from field " + field, e);
+		}
+	}
+	
+	public static Object getValueOrNull(Object object, Field field) {
+		try {
+			return field.get(object);
+		} catch (IllegalArgumentException | IllegalAccessException e) {
+			// in case of any error treat the field as non-existent and return null
+			return null;
 		}
 	}
 	

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/validation/ValidationRepository.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/validation/ValidationRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,43 +16,23 @@
 package com.b2international.snowowl.core.internal.validation;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.b2international.index.Hits;
-import com.b2international.index.Index;
-import com.b2international.index.IndexRead;
-import com.b2international.index.IndexWrite;
-import com.b2international.index.Scroll;
-import com.b2international.index.Searcher;
+import com.b2international.index.*;
 import com.b2international.index.admin.IndexAdmin;
 import com.b2international.index.aggregations.Aggregation;
 import com.b2international.index.aggregations.AggregationBuilder;
 import com.b2international.index.query.Query;
-import com.b2international.snowowl.core.IDisposableService;
 
 /**
  * @since 6.0
  */
-public final class ValidationRepository implements Index, IDisposableService {
+public final class ValidationRepository implements Index {
 
 	private final Index index;
-	private final AtomicBoolean disposed = new AtomicBoolean(false);
 
 	public ValidationRepository(Index index) {
 		this.index = index;
 		this.index.admin().create();
-	}
-	
-	@Override
-	public boolean isDisposed() {
-		return disposed.get();
-	}
-
-	@Override
-	public void dispose() {
-		if (disposed.compareAndSet(false, true)) {
-			admin().close();
-		}
 	}
 	
 	@Override

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/jobs/RemoteJobTracker.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/jobs/RemoteJobTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,7 @@
 package com.b2international.snowowl.core.jobs;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -33,11 +27,7 @@ import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.b2international.index.BulkUpdate;
-import com.b2international.index.Hits;
-import com.b2international.index.Index;
-import com.b2international.index.Scroll;
-import com.b2international.index.Searcher;
+import com.b2international.index.*;
 import com.b2international.index.aggregations.Aggregation;
 import com.b2international.index.aggregations.AggregationBuilder;
 import com.b2international.index.query.Expression;
@@ -219,7 +209,6 @@ public final class RemoteJobTracker implements IDisposableService {
 		if (disposed.compareAndSet(false, true)) {
 			this.cleanUp.cancel();
 			Job.getJobManager().removeJobChangeListener(listener);
-			this.index.admin().close();
 		}
 	}
 

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/TerminologyRepository.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/TerminologyRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,11 +25,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 
 import com.b2international.commons.exceptions.RequestTimeoutException;
-import com.b2international.index.DefaultIndex;
-import com.b2international.index.Index;
-import com.b2international.index.IndexClient;
-import com.b2international.index.IndexClientFactory;
-import com.b2international.index.Indexes;
+import com.b2international.index.*;
 import com.b2international.index.es.client.EsClient;
 import com.b2international.index.es.client.EsClusterStatus;
 import com.b2international.index.mapping.Mappings;
@@ -137,11 +133,6 @@ public final class TerminologyRepository extends DelegatingContext implements Re
 		return revisionIndex;
 	}
 
-	@Override
-	public void doDispose() {
-		service(RevisionIndex.class).admin().close();
-	}
-	
 	@Override
 	protected Environment getDelegate() {
 		return (Environment) super.getDelegate();

--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/validation/SnomedValidationIssueDetailTest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/validation/SnomedValidationIssueDetailTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import org.eclipse.xtext.parser.IParser;
 import org.eclipse.xtext.serializer.ISerializer;
 import org.eclipse.xtext.validation.IResourceValidator;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -127,11 +126,6 @@ public class SnomedValidationIssueDetailTest extends BaseRevisionIndexTest {
 		}
 		
 		context.service(ValidationIssueDetailExtensionProvider.class).addExtension(new SnomedValidationIssueDetailExtension());
-	}
-	
-	@After
-	public void teardown() {
-		repository.dispose();
 	}
 	
 	@Test


### PR DESCRIPTION
This PR adds the capability to migrate existing indices to a new mapping schema when the new schema has field alias changes (and additionally extra new fields). 

The following schema changes are still considered as breaking and require a major Snow Owl version bump:
- deleting a field from a mapping
- renaming a field on a mapping