### PR TITLE
[taxonomy] Update OWL ontology building process

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/taxonomy/InternalIdMap.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/taxonomy/InternalIdMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import com.b2international.collections.longs.LongList;
 import com.b2international.collections.longs.LongSet;
 
 /**
- * Bidirectionally maps component SCTIDs to an integer internal identifier. 
+ * Bi-directionally maps component SCTIDs to an integer internal identifier. 
  * 
  * @since 7.0
  */
@@ -132,6 +132,10 @@ public final class InternalIdMap {
 	}
 
 	public LongIterator getSctIds() {
-		return sctIdToInternal.keySet().iterator();
+		return keySet().iterator();
+	}
+
+	public LongSet keySet() {
+		return sctIdToInternal.keySet();
 	}
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/taxonomy/InternalIdMultimap.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/taxonomy/InternalIdMultimap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import com.b2international.collections.PrimitiveMaps;
 import com.b2international.collections.ints.IntIterator;
 import com.b2international.collections.ints.IntKeyMap;
 import com.b2international.collections.ints.IntSet;
+import com.b2international.collections.longs.LongSet;
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -122,5 +123,9 @@ public final class InternalIdMultimap<T> {
 				.flatMap(obj -> {
 					return ((ImmutableList<T>) obj).stream();
 				});
+	}
+
+	public LongSet keySet() {
+		return internalIdMap.keySet();
 	}
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/taxonomy/ReasonerTaxonomy.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/taxonomy/ReasonerTaxonomy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,12 +43,12 @@ public final class ReasonerTaxonomy implements IReasonerTaxonomy {
 
 	private final InternalSctIdSet exhaustiveConcepts;
 
-	private final InternalIdMultimap<StatementFragment> subclassOfStatements;
-	private final InternalIdMultimap<StatementFragment> equivalentStatements;
+	private final InternalIdMultimap<StatementFragment> statedRelationships;
+	private final InternalIdMultimap<StatementFragment> statedAxiomRelationships;
 	private final InternalIdMultimap<StatementFragment> existingInferredRelationships;
 	private final InternalIdMultimap<StatementFragment> additionalGroupedRelationships;
 	
-	private final InternalIdMultimap<String> statedAdditionalAxioms;
+	private final InternalIdMultimap<String> statedAxioms;
 	private final LongSet neverGroupedTypeIds;
 	private Set<PropertyChain> propertyChains;
 	
@@ -71,12 +71,12 @@ public final class ReasonerTaxonomy implements IReasonerTaxonomy {
 			
 			final InternalSctIdSet exhaustiveConcepts, 
 			
-			final InternalIdMultimap<StatementFragment> subclassOfStatements,
-			final InternalIdMultimap<StatementFragment> equivalentStatements,
+			final InternalIdMultimap<StatementFragment> statedRelationships,
+			final InternalIdMultimap<StatementFragment> statedAxiomRelationships,
 			final InternalIdMultimap<StatementFragment> existingInferredRelationships,
 			final InternalIdMultimap<StatementFragment> additionalGroupedRelationships, 
 			
-			final InternalIdMultimap<String> statedAdditionalAxioms,
+			final InternalIdMultimap<String> statedAxioms,
 			final LongSet neverGroupedTypeIds,
 			final Set<PropertyChain> propertyChains, 
 			
@@ -98,12 +98,12 @@ public final class ReasonerTaxonomy implements IReasonerTaxonomy {
 		
 		this.exhaustiveConcepts = exhaustiveConcepts;
 		
-		this.subclassOfStatements = subclassOfStatements;
-		this.equivalentStatements = equivalentStatements;
+		this.statedRelationships = statedRelationships;
+		this.statedAxiomRelationships = statedAxiomRelationships;
 		this.existingInferredRelationships = existingInferredRelationships;
 		this.additionalGroupedRelationships = additionalGroupedRelationships;
 		
-		this.statedAdditionalAxioms = statedAdditionalAxioms;
+		this.statedAxioms = statedAxioms;
 		this.neverGroupedTypeIds = neverGroupedTypeIds;
 		this.propertyChains = propertyChains;
 		
@@ -155,12 +155,12 @@ public final class ReasonerTaxonomy implements IReasonerTaxonomy {
 		return exhaustiveConcepts;
 	}
 
-	public InternalIdMultimap<StatementFragment> getSubclassOfStatements() {
-		return subclassOfStatements;
+	public InternalIdMultimap<StatementFragment> getStatedRelationships() {
+		return statedRelationships;
 	}
 	
-	public InternalIdMultimap<StatementFragment> getEquivalentStatements() {
-		return equivalentStatements;
+	public InternalIdMultimap<StatementFragment> getStatedAxiomRelationships() {
+		return statedAxiomRelationships;
 	}
 	
 	public InternalIdMultimap<StatementFragment> getExistingInferredRelationships() {
@@ -171,8 +171,8 @@ public final class ReasonerTaxonomy implements IReasonerTaxonomy {
 		return additionalGroupedRelationships;
 	}
 
-	public InternalIdMultimap<String> getStatedAdditionalAxioms() {
-		return statedAdditionalAxioms;
+	public InternalIdMultimap<String> getStatedAxioms() {
+		return statedAxioms;
 	}
 	
 	public LongSet getNeverGroupedTypeIds() {
@@ -223,12 +223,12 @@ public final class ReasonerTaxonomy implements IReasonerTaxonomy {
 				
 				exhaustiveConcepts,
 				
-				subclassOfStatements,
-				equivalentStatements,
+				statedRelationships,
+				statedAxiomRelationships,
 				existingInferredRelationships,
 				additionalGroupedRelationships,
 				
-				statedAdditionalAxioms,
+				statedAxioms,
 				neverGroupedTypeIds,
 				propertyChains,
 				

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormGenerator.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/normalform/NormalFormGenerator.java
@@ -209,9 +209,15 @@ public final class NormalFormGenerator implements INormalFormGenerator {
 			candidateNonIsARelationships.put(parentId, statementCache.get(parentId));
 		}
 
+		// Stated axiom fragments are non-IS A, but any stated relationships need to be filtered (if they are still present)
+		final Collection<StatementFragment> ownStatedRelationships = reasonerTaxonomy.getStatedRelationships().get(conceptId);
+		final Collection<StatementFragment> ownStatedNonIsaRelationships = ownStatedRelationships.stream()
+				.filter(r -> r.getTypeId() != IS_A)
+				.collect(Collectors.toList());
+
 		candidateNonIsARelationships.put(conceptId, ImmutableList.<StatementFragment>builder()
-				.addAll(reasonerTaxonomy.getSubclassOfStatements().get(conceptId))
-				.addAll(reasonerTaxonomy.getEquivalentStatements().get(conceptId))
+				.addAll(ownStatedNonIsaRelationships)
+				.addAll(reasonerTaxonomy.getStatedAxiomRelationships().get(conceptId))
 				.addAll(reasonerTaxonomy.getAdditionalGroupedRelationships().get(conceptId))
 				.build());
 

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/ClassificationJobRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/ClassificationJobRequest.java
@@ -161,7 +161,7 @@ final class ClassificationJobRequest implements Request<BranchContext, Boolean>,
 		
 		taxonomyBuilder.addConceptFlags(revisionSearcher);
 		taxonomyBuilder.addActiveStatedEdges(revisionSearcher);
-		taxonomyBuilder.addActiveStatedNonIsARelationships(revisionSearcher);
+		taxonomyBuilder.addActiveStatedRelationships(revisionSearcher);
 		taxonomyBuilder.addActiveInferredRelationships(revisionSearcher);
 		taxonomyBuilder.addActiveAdditionalGroupedRelationships(revisionSearcher);
 		
@@ -179,7 +179,7 @@ final class ClassificationJobRequest implements Request<BranchContext, Boolean>,
 				.flatMap(c -> c.getRelationships().stream());
 		
 		taxonomyBuilder.addActiveStatedEdges(relationshipSupplier.get());
-		taxonomyBuilder.addActiveStatedNonIsARelationships(relationshipSupplier.get());
+		taxonomyBuilder.addActiveStatedRelationships(relationshipSupplier.get());
 		taxonomyBuilder.addActiveInferredRelationships(relationshipSupplier.get());
 		taxonomyBuilder.addActiveAdditionalGroupedRelationships(relationshipSupplier.get());
 

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/OntologyExportRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/OntologyExportRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ final class OntologyExportRequest implements Request<BranchContext, String>, Bra
 		taxonomyBuilder.addFullySpecifiedNames(revisionSearcher);
 		taxonomyBuilder.addConceptFlags(revisionSearcher);
 		taxonomyBuilder.addActiveStatedEdges(revisionSearcher);
-		taxonomyBuilder.addActiveStatedNonIsARelationships(revisionSearcher);
+		taxonomyBuilder.addActiveStatedRelationships(revisionSearcher);
 		
 		taxonomyBuilder.addNeverGroupedTypeIds(revisionSearcher);
 		taxonomyBuilder.addActiveAxioms(revisionSearcher);


### PR DESCRIPTION
This PR changes `DelegateOntology` so that the `expression` content of each OWL axiom reference set member is loaded directly, without splitting them into stated relationship fragments.