### PR TITLE
fix(index): use segment diff to compute accurate base/head timestamps...

### DIFF
--- a/commons/com.b2international.index/src/com/b2international/index/revision/BaseRevisionBranching.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/BaseRevisionBranching.java
@@ -365,8 +365,10 @@ public abstract class BaseRevisionBranching {
 	 * @return
 	 */
 	public final BranchState getBranchState(RevisionBranch left, RevisionBranch right) {
-    	long leftBaseTimestamp = left.getBaseTimestamp();
-    	long leftHeadTimestamp = left.getHeadTimestamp();
+		final RevisionBranchRef diff = left.ref().difference(right.ref());
+		
+    	long leftBaseTimestamp = diff.segments().isEmpty() ? left.getBaseTimestamp() : diff.segments().first().start();
+    	long leftHeadTimestamp = diff.segments().isEmpty() ? left.getHeadTimestamp() : diff.segments().last().end();
     	long rightBaseTimestamp = leftBaseTimestamp;
     	long rightHeadTimestamp = right.getHeadTimestamp();
     	


### PR DESCRIPTION
...when merging empty branch (with non-empty parent branch segments) to
another branch. Related use case: use CodeSystem version branch to
create a Code System upgrade instead of using the HEAD of the
CodeSystem's working branch.