### PR TITLE
SO-4891: multi-value expand parameter support

### DIFF
--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/bundle/BundleRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/bundle/BundleRestService.java
@@ -28,6 +28,7 @@ import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.internal.ResourceDocument;
 import com.b2international.snowowl.core.request.ResourceRequests;
 import com.b2international.snowowl.core.rest.AbstractRestService;
+import com.b2international.snowowl.core.rest.domain.ResourceSelectors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -103,11 +104,10 @@ public class BundleRestService extends AbstractRestService {
 			@PathVariable(value="bundleId", required = true) 
 			final String bundleId,
 			
-			@Parameter(description="expand") 
-			@RequestParam(value = "expand", required = false)
-			String expand) {
+			@ParameterObject
+			final ResourceSelectors params) {
 		return ResourceRequests.bundles().prepareGet(bundleId)
-				.setExpand(expand)
+				.setExpand(params.getExpand())
 				.buildAsync()
 				.execute(getBus());
 	}

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/commit/CommitInfoRestSearch.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/commit/CommitInfoRestSearch.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.rest.commit;
+
+import java.util.List;
+
+import com.b2international.snowowl.core.rest.domain.ObjectRestSearch;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+/**
+ * @since 8.0
+ */
+public class CommitInfoRestSearch extends ObjectRestSearch {
+
+	@Parameter(description = "The author of the commit to match")
+	private String author;
+	
+	@Parameter(description = "Affected component identifier to match")
+	private String affectedComponentId;
+	
+	@Parameter(description = "Commit comment term to match")
+	private String comment;
+	
+	@Parameter(description = "One or more branch paths to match")
+	private List<String> branch;
+	
+	@Parameter(description = "Commit timestamp to match")
+	private Long timestamp;
+	
+	@Parameter(description = "Minimum commit timestamp to search matches from")
+	private Long timestampFrom;
+	
+	@Parameter(description = "Maximum commit timestamp to search matches to")
+	private Long timestampTo;
+
+	public String getAuthor() {
+		return author;
+	}
+
+	public void setAuthor(String author) {
+		this.author = author;
+	}
+
+	public String getAffectedComponentId() {
+		return affectedComponentId;
+	}
+
+	public void setAffectedComponentId(String affectedComponentId) {
+		this.affectedComponentId = affectedComponentId;
+	}
+
+	public String getComment() {
+		return comment;
+	}
+
+	public void setComment(String comment) {
+		this.comment = comment;
+	}
+
+	public List<String> getBranch() {
+		return branch;
+	}
+
+	public void setBranch(List<String> branch) {
+		this.branch = branch;
+	}
+
+	public Long getTimestamp() {
+		return timestamp;
+	}
+
+	public void setTimestamp(Long timestamp) {
+		this.timestamp = timestamp;
+	}
+
+	public Long getTimestampFrom() {
+		return timestampFrom;
+	}
+
+	public void setTimestampFrom(Long timestampFrom) {
+		this.timestampFrom = timestampFrom;
+	}
+
+	public Long getTimestampTo() {
+		return timestampTo;
+	}
+
+	public void setTimestampTo(Long timestampTo) {
+		this.timestampTo = timestampTo;
+	}
+	
+	
+	
+}

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/commit/RepositoryCommitRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/commit/RepositoryCommitRestService.java
@@ -16,20 +16,20 @@
 package com.b2international.snowowl.core.rest.commit;
 
 import java.util.List;
-import java.util.Set;
 
+import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
+import com.b2international.commons.CompareUtils;
 import com.b2international.index.revision.Commit;
 import com.b2international.snowowl.core.commit.CommitInfo;
 import com.b2international.snowowl.core.commit.CommitInfos;
 import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.repository.RepositoryRequests;
 import com.b2international.snowowl.core.rest.AbstractRestService;
-import com.google.common.base.Strings;
+import com.b2international.snowowl.core.rest.domain.ResourceSelectors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -59,69 +59,22 @@ public abstract class RepositoryCommitRestService extends AbstractRestService {
 		@ApiResponse(responseCode = "200", description = "OK")
 	})
 	@GetMapping(produces = { AbstractRestService.JSON_MEDIA_TYPE })
-	public Promise<CommitInfos> search(
-			@Parameter(description = "The author of the commit to match")
-			@RequestParam(value="author", required=false)
-			final String author,
-			
-			@Parameter(description = "The identifier(s) to match")
-			@RequestParam(value="id", required=false)
-			final Set<String> id,
-			
-			@Parameter(description = "Affected component identifier to match")
-			@RequestParam(value="affectedComponentId", required=false)
-			final String affectedComponentId,
-			
-			@Parameter(description = "Commit comment term to match")
-			@RequestParam(value="comment", required=false)
-			final String comment,
-			
-			@Parameter(description = "One or more branch paths to match")
-			@RequestParam(value="branch", required=false)
-			final List<String> branch,
-			
-			@Parameter(description = "Commit timestamp to match")
-			@RequestParam(value="timestamp", required=false)
-			final Long timestamp,
-			
-			@Parameter(description = "Minimum commit timestamp to search matches from")
-			@RequestParam(value="timestampFrom", required=false)
-			final Long timestampFrom,
-			
-			@Parameter(description = "Maximum commit timestamp to search matches to")
-			@RequestParam(value="timestampTo", required=false)
-			final Long timestampTo,
-			
-			@Parameter(description = "Expansion parameters")
-			@RequestParam(value="expand", required=false)
-			final String expand,
-			
-			@Parameter(description = "The search key to use for retrieving the next page of results")
-			@RequestParam(value="searchAfter", required=false)
-			final String searchAfter,
-			
-			@Parameter(description = "Sort keys")
-			@RequestParam(value="sort", required=false)
-			final List<String> sort,
-			
-			@Parameter(description = "The maximum number of items to return")
-			@RequestParam(value="limit", defaultValue="50", required=false) 
-			final int limit) {
+	public Promise<CommitInfos> search(CommitInfoRestSearch params) {
 		return RepositoryRequests
 					.commitInfos()
 					.prepareSearchCommitInfo()
-					.filterByIds(id)
-					.filterByAuthor(author)
-					.filterByAffectedComponent(affectedComponentId)
-					.filterByComment(comment)
-					.filterByBranches(branch)
-					.filterByTimestamp(timestamp)
-					.filterByTimestamp(timestampFrom, timestampTo)
-					.setFields(Strings.isNullOrEmpty(expand) ? List.of(Commit.Fields.ID, Commit.Fields.AUTHOR, Commit.Fields.BRANCH, Commit.Fields.COMMENT, Commit.Fields.TIMESTAMP, Commit.Fields.GROUP_ID) : null)
-					.setExpand(expand)
-					.setSearchAfter(searchAfter)
-					.setLimit(limit)
-					.sortBy(extractSortFields(sort))
+					.filterByIds(params.getId())
+					.filterByAuthor(params.getAuthor())
+					.filterByAffectedComponent(params.getAffectedComponentId())
+					.filterByComment(params.getComment())
+					.filterByBranches(params.getBranch())
+					.filterByTimestamp(params.getTimestamp())
+					.filterByTimestamp(params.getTimestampFrom(), params.getTimestampTo())
+					.setFields(CompareUtils.isEmpty(params.getExpand()) ? List.of(Commit.Fields.ID, Commit.Fields.AUTHOR, Commit.Fields.BRANCH, Commit.Fields.COMMENT, Commit.Fields.TIMESTAMP, Commit.Fields.GROUP_ID) : null)
+					.setExpand(params.getExpand())
+					.setSearchAfter(params.getSearchAfter())
+					.setLimit(params.getLimit())
+					.sortBy(extractSortFields(params.getSort()))
 					.build(repositoryId)
 					.execute(getBus());
 	}
@@ -139,13 +92,12 @@ public abstract class RepositoryCommitRestService extends AbstractRestService {
 			@PathVariable(value="commitId")
 			final String commitId, 
 			
-			@Parameter(description = "Expansion parameters")
-			@RequestParam(value="expand", required=false)
-			final String expand) {
+			@ParameterObject
+			final ResourceSelectors selectors) {
 		return RepositoryRequests
 					.commitInfos()
 					.prepareGetCommitInfo(commitId)
-					.setExpand(expand)
+					.setExpand(selectors.getExpand())
 					.build(repositoryId)
 					.execute(getBus());
 	}

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/domain/ObjectRestSearch.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/domain/ObjectRestSearch.java
@@ -23,18 +23,18 @@ import io.swagger.v3.oas.annotations.Parameter;
 /**
  * @since 7.3
  */
-public abstract class ObjectRestSearch {
+public class ObjectRestSearch extends ResourceSelectors {
 
 	@Parameter(description = "The identifier(s) to match")
 	private Set<String> id;
 	
 	// scrolling/paging/expansion/sorting
-	@Parameter(description = "Expansion parameters")
-	private String expand;
 	@Parameter(description = "The search key to use for retrieving the next page of results")
 	private String searchAfter;
+	
 	@Parameter(description = "Sort keys")
 	private List<String> sort;
+	
 	@Parameter(description = "The maximum number of items to return")
 	private int limit = 50;
 
@@ -44,14 +44,6 @@ public abstract class ObjectRestSearch {
 
 	public final void setId(Set<String> id) {
 		this.id = id;
-	}
-	
-	public final String getExpand() {
-		return expand;
-	}
-
-	public final void setExpand(String expand) {
-		this.expand = expand;
 	}
 
 	public final String getSearchAfter() {

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/domain/ResourceSelectors.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/domain/ResourceSelectors.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.rest.domain;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+/**
+ * @since 8.0
+ */
+public class ResourceSelectors {
+
+	@Parameter(description = "Expansion parameters")
+	private List<String> expand;
+	
+	public final List<String> getExpand() {
+		return expand;
+	}
+
+	public final void setExpand(List<String> expand) {
+		this.expand = expand;
+	}
+
+}

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/resource/ResourceRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/resource/ResourceRestService.java
@@ -16,11 +16,14 @@
 package com.b2international.snowowl.core.rest.resource;
 
 import java.util.List;
-import java.util.Set;
 
 import org.springdoc.api.annotations.ParameterObject;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+import com.b2international.commons.CompareUtils;
 import com.b2international.index.revision.Commit;
 import com.b2international.snowowl.core.Resource;
 import com.b2international.snowowl.core.Resources;
@@ -32,7 +35,7 @@ import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.repository.RepositoryRequests;
 import com.b2international.snowowl.core.request.ResourceRequests;
 import com.b2international.snowowl.core.rest.AbstractRestService;
-import com.google.common.base.Strings;
+import com.b2international.snowowl.core.rest.commit.CommitInfoRestSearch;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -105,68 +108,23 @@ public class ResourceRestService extends AbstractRestService {
 	})
 	@GetMapping(value = "/commits", produces = { AbstractRestService.JSON_MEDIA_TYPE })
 	public Promise<CommitInfos> searchCommits(
-			@Parameter(description = "The author of the commit to match")
-			@RequestParam(value="author", required=false)
-			final String author,
-	
-			@Parameter(description = "The identifier(s) to match")
-			@RequestParam(value="id", required=false)
-			final Set<String> id,
-	
-			@Parameter(description = "Affected component identifier to match")
-			@RequestParam(value="affectedComponentId", required=false)
-			final String affectedComponentId,
-			
-			@Parameter(description = "Commit comment term to match")
-			@RequestParam(value="comment", required=false)
-			final String comment,
-			
-			@Parameter(description = "One or more branch paths to match")
-			@RequestParam(value="branch", required=false)
-			final List<String> branch,
-			
-			@Parameter(description = "Commit timestamp to match")
-			@RequestParam(value="timestamp", required=false)
-			final Long timestamp,
-			
-			@Parameter(description = "Minimum commit timestamp to search matches from")
-			@RequestParam(value="timestampFrom", required=false)
-			final Long timestampFrom,
-			
-			@Parameter(description = "Maximum commit timestamp to search matches to")
-			@RequestParam(value="timestampTo", required=false)
-			final Long timestampTo,
-	
-			@Parameter(description = "Expansion parameters")
-			@RequestParam(value="expand", required=false)
-			final String expand,
-			
-			@Parameter(description = "The search key to use for retrieving the next page of results")
-			@RequestParam(value="searchAfter", required=false)
-			final String searchAfter,
-			
-			@Parameter(description = "Sort keys")
-			@RequestParam(value="sort", required=false)
-			final List<String> sort,
-	
-			@Parameter(description = "The maximum number of items to return")
-			@RequestParam(value="limit", defaultValue="50", required=false) 
-			final int limit) {
+			@ParameterObject
+			final CommitInfoRestSearch params) {
 		 Request<RepositoryContext, CommitInfos> req = RepositoryRequests
 				.commitInfos()
 				.prepareSearchCommitInfo()
-				.filterByIds(id)
-				.filterByAuthor(author)
-				.filterByAffectedComponent(affectedComponentId)
-				.filterByComment(comment)
-				.filterByBranches(branch)
-				.filterByTimestamp(timestamp)
-				.filterByTimestamp(timestampFrom, timestampTo)
-				.setFields(Strings.isNullOrEmpty(expand) ? List.of(Commit.Fields.ID, Commit.Fields.AUTHOR, Commit.Fields.BRANCH, Commit.Fields.COMMENT, Commit.Fields.TIMESTAMP, Commit.Fields.GROUP_ID) : null)
-				.setExpand(expand)
-				.setSearchAfter(searchAfter)
-				.setLimit(limit)
-				.sortBy(extractSortFields(sort))
+				.filterByIds(params.getId())
+				.filterByAuthor(params.getAuthor())
+				.filterByAffectedComponent(params.getAffectedComponentId())
+				.filterByComment(params.getComment())
+				.filterByBranches(params.getBranch())
+				.filterByTimestamp(params.getTimestamp())
+				.filterByTimestamp(params.getTimestampFrom(), params.getTimestampTo())
+				.setFields(CompareUtils.isEmpty(params.getExpand()) ? List.of(Commit.Fields.ID, Commit.Fields.AUTHOR, Commit.Fields.BRANCH, Commit.Fields.COMMENT, Commit.Fields.TIMESTAMP, Commit.Fields.GROUP_ID) : null)
+				.setExpand(params.getExpand())
+				.setSearchAfter(params.getSearchAfter())
+				.setLimit(params.getLimit())
+				.sortBy(extractSortFields(params.getSort()))
 				.build();
 		 return new ResourceRepositoryRequestBuilder<CommitInfos>() {
 

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/IndexResourceRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/IndexResourceRequestBuilder.java
@@ -35,11 +35,17 @@ public abstract class IndexResourceRequestBuilder<B extends IndexResourceRequest
 	protected IndexResourceRequestBuilder() {}
 	
 	public final B setExpand(String...expand) {
-		return setExpand(String.join(",", expand));
+		if (!CompareUtils.isEmpty(expand)) {
+			return setExpand(String.join(",", expand));
+		}
+		return getSelf();
 	}
 	
 	public final B setExpand(List<String> expand) {
-		return setExpand(String.join(",", expand));
+		if (!CompareUtils.isEmpty(expand)) {
+			return setExpand(String.join(",", expand));
+		}
+		return getSelf();
 	}
 	
 	public final B setExpand(String expand) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/IndexResourceRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/IndexResourceRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2020-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import com.b2international.commons.CompareUtils;
 import com.b2international.commons.options.Options;
 import com.b2international.commons.options.OptionsBuilder;
 import com.b2international.snowowl.core.ServiceProvider;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 /**
@@ -34,6 +33,14 @@ public abstract class IndexResourceRequestBuilder<B extends IndexResourceRequest
 	private List<String> fields = Collections.emptyList();
 
 	protected IndexResourceRequestBuilder() {}
+	
+	public final B setExpand(String...expand) {
+		return setExpand(String.join(",", expand));
+	}
+	
+	public final B setExpand(List<String> expand) {
+		return setExpand(String.join(",", expand));
+	}
 	
 	public final B setExpand(String expand) {
 		if (!CompareUtils.isEmpty(expand)) {
@@ -55,7 +62,7 @@ public abstract class IndexResourceRequestBuilder<B extends IndexResourceRequest
 	
 	public final B setFields(List<String> fields) {
 		if (!CompareUtils.isEmpty(fields)) {
-			this.fields = ImmutableList.copyOf(fields);
+			this.fields = List.copyOf(fields);
 		}
 		return getSelf();
 	}

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedClassificationRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedClassificationRestService.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -26,15 +27,16 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import com.b2international.commons.CompareUtils;
 import com.b2international.commons.validation.ApiValidation;
 import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.rest.AbstractRestService;
 import com.b2international.snowowl.core.rest.SnomedApiConfig;
+import com.b2international.snowowl.core.rest.domain.ObjectRestSearch;
 import com.b2international.snowowl.snomed.core.rest.domain.ClassificationRunRestInput;
 import com.b2international.snowowl.snomed.core.rest.domain.ClassificationRunRestUpdate;
 import com.b2international.snowowl.snomed.reasoner.domain.*;
 import com.b2international.snowowl.snomed.reasoner.request.ClassificationRequests;
-import com.google.common.base.Strings;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -206,30 +208,21 @@ public class SnomedClassificationRestService extends AbstractRestService {
 			@PathVariable(value="classificationId") 
 			final String classificationId,
 			
-			@Parameter(description ="Expansion parameters")
-			@RequestParam(value="expand", required=false)
-			final String expand,
-
-			@Parameter(description = "The search key to use for retrieving the next page of results")
-			@RequestParam(value="searchAfter", required=false)
-			final String searchAfter,
-			
-			@Parameter(description ="The maximum number of items to return")
-			@RequestParam(value="limit", defaultValue="50", required=false) 
-			final int limit) {
+			@ParameterObject
+			final ObjectRestSearch params) {
 		
 		final String expandWithRelationship;
-		if (Strings.isNullOrEmpty(expand)) {
+		if (CompareUtils.isEmpty(params.getExpand())) {
 			expandWithRelationship = "relationship()";
 		} else {
-			expandWithRelationship = String.format("relationship(expand(%s))", expand);
+			expandWithRelationship = String.format("relationship(expand(%s))", String.join(",", params.getExpand()));
 		}
 		
 		return ClassificationRequests.prepareSearchRelationshipChange()
 				.filterByClassificationId(classificationId)
 				.setExpand(expandWithRelationship)
-				.setSearchAfter(searchAfter)
-				.setLimit(limit)
+				.setSearchAfter(params.getSearchAfter())
+				.setLimit(params.getLimit())
 				.build(SnomedApiConfig.REPOSITORY_ID)
 				.execute(getBus());
 	}

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedConceptRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedConceptRestService.java
@@ -31,6 +31,7 @@ import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.request.SearchIndexResourceRequest;
 import com.b2international.snowowl.core.request.SearchResourceRequest.Sort;
 import com.b2international.snowowl.core.rest.AbstractRestService;
+import com.b2international.snowowl.core.rest.domain.ResourceSelectors;
 import com.b2international.snowowl.snomed.core.domain.SnomedConcept;
 import com.b2international.snowowl.snomed.core.domain.SnomedConcepts;
 import com.b2international.snowowl.snomed.core.rest.domain.SnomedConceptRestInput;
@@ -177,16 +178,15 @@ public class SnomedConceptRestService extends AbstractRestService {
 			@PathVariable(value="conceptId")
 			final String conceptId,
 			
-			@Parameter(description = "Expansion parameters")
-			@RequestParam(value="expand", required=false)
-			final String expand,
+			@ParameterObject
+			final ResourceSelectors selectors,
 			
 			@Parameter(description = "Accepted language tags, in order of preference")
 			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
 			final String acceptLanguage) {
 		return SnomedRequests
 					.prepareGetConcept(conceptId)
-					.setExpand(expand)
+					.setExpand(selectors.getExpand())
 					.setLocales(acceptLanguage)
 					.build(path)
 					.execute(getBus());

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedDescriptionRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedDescriptionRestService.java
@@ -30,6 +30,7 @@ import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.request.SearchIndexResourceRequest;
 import com.b2international.snowowl.core.request.SearchResourceRequest.Sort;
 import com.b2international.snowowl.core.rest.AbstractRestService;
+import com.b2international.snowowl.core.rest.domain.ResourceSelectors;
 import com.b2international.snowowl.snomed.core.domain.SnomedDescription;
 import com.b2international.snowowl.snomed.core.domain.SnomedDescriptions;
 import com.b2international.snowowl.snomed.core.rest.domain.SnomedDescriptionRestInput;
@@ -192,12 +193,11 @@ public class SnomedDescriptionRestService extends AbstractRestService {
 			@PathVariable(value="descriptionId")
 			final String descriptionId,
 			
-			@Parameter(description = "Expansion parameters")
-			@RequestParam(value="expand", required=false)
-			final String expand) {
+			@ParameterObject
+			final ResourceSelectors selectors) {
 		
 		return SnomedRequests.prepareGetDescription(descriptionId)
-					.setExpand(expand)
+					.setExpand(selectors.getExpand())
 					.build(path)
 					.execute(getBus());
 	}

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedReferenceSetMemberRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedReferenceSetMemberRestService.java
@@ -28,6 +28,7 @@ import com.b2international.commons.options.Options;
 import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.rest.AbstractRestService;
+import com.b2international.snowowl.core.rest.domain.ResourceSelectors;
 import com.b2international.snowowl.snomed.core.domain.refset.SnomedReferenceSetMember;
 import com.b2international.snowowl.snomed.core.domain.refset.SnomedReferenceSetMembers;
 import com.b2international.snowowl.snomed.core.rest.domain.SnomedMemberRestUpdate;
@@ -149,16 +150,15 @@ public class SnomedReferenceSetMemberRestService extends AbstractRestService {
 			@PathVariable(value="id")
 			final String memberId,
 			
-			@Parameter(description = "Expansion parameters")
-			@RequestParam(value="expand", required=false)
-			final String expand,
+			@ParameterObject
+			final ResourceSelectors selectors,
 
 			@Parameter(description = "Accepted language tags, in order of preference")
 			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
 			final String acceptLanguage) {
 		return SnomedRequests
 				.prepareGetMember(memberId)
-				.setExpand(expand)
+				.setExpand(selectors.getExpand())
 				.setLocales(acceptLanguage)
 				.build(path)
 				.execute(getBus());

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedReferenceSetRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedReferenceSetRestService.java
@@ -36,6 +36,7 @@ import com.b2international.snowowl.core.events.bulk.BulkRequestBuilder;
 import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.request.SearchResourceRequest.Sort;
 import com.b2international.snowowl.core.rest.AbstractRestService;
+import com.b2international.snowowl.core.rest.domain.ResourceSelectors;
 import com.b2international.snowowl.snomed.core.domain.refset.SnomedRefSetType;
 import com.b2international.snowowl.snomed.core.domain.refset.SnomedReferenceSet;
 import com.b2international.snowowl.snomed.core.domain.refset.SnomedReferenceSets;
@@ -177,9 +178,8 @@ public class SnomedReferenceSetRestService extends AbstractRestService {
 			@PathVariable(value="id")
 			final String referenceSetId,
 			
-			@Parameter(description = "Expansion parameters")
-			@RequestParam(value="expand", required=false)
-			final String expand,
+			@ParameterObject
+			final ResourceSelectors selectors,
 
 			@Parameter(description = "Accepted language tags, in order of preference")
 			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
@@ -187,7 +187,7 @@ public class SnomedReferenceSetRestService extends AbstractRestService {
 
 		return SnomedRequests
 				.prepareGetReferenceSet(referenceSetId)
-				.setExpand(expand)
+				.setExpand(selectors.getExpand())
 				.setLocales(acceptLanguage)
 				.build(path)
 				.execute(getBus());


### PR DESCRIPTION
Update documentation to use `array<string>` collection format.
Update all uses of `expand` parameter by extracting it into a ResourceSelectors class.

Fixes #659.