### PR TITLE
SO- 4890: support includeNull and pretty query parameters

### DIFF
--- a/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/tests/FhirTest.java
+++ b/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/tests/FhirTest.java
@@ -39,7 +39,7 @@ public class FhirTest {
 	
 	protected static final String TEST_DATE_STRING = "2018-03-23T07:49:40.000+0000"; //$NON-NLS-N$
 	
-	protected static final ObjectMapper objectMapper = new SnowOwlApiConfig().objectMapper();
+	protected static final ObjectMapper objectMapper = new SnowOwlApiConfig().createObjectMapper();
 	
 	@Rule
 	public ExpectedException exception = ExpectedException.none();

--- a/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/tests/FhirTest.java
+++ b/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/tests/FhirTest.java
@@ -39,7 +39,7 @@ public class FhirTest {
 	
 	protected static final String TEST_DATE_STRING = "2018-03-23T07:49:40.000+0000"; //$NON-NLS-N$
 	
-	protected static final ObjectMapper objectMapper = new SnowOwlApiConfig().createObjectMapper();
+	protected static final ObjectMapper objectMapper = SnowOwlApiConfig.createObjectMapper();
 	
 	@Rule
 	public ExpectedException exception = ExpectedException.none();


### PR DESCRIPTION
Both query parameters work with empty or `true` values. Any other value considered `false` and will not enable the feature.
* `includeNull` - includes all properties of the response model to be
serialized to the JSON representation even if the value is `null`. The
default behavior is to omit `null` values.
* `pretty` - pretty print the output to make it human-readable

Fixes #486.