### PR TITLE
feat: support synonym filter in tokenized analyzer configurations

### DIFF
--- a/commons/com.b2international.index.tests.tools/src/com/b2international/index/SynonymsRule.java
+++ b/commons/com.b2international.index.tests.tools/src/com/b2international/index/SynonymsRule.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.index;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.rules.ExternalResource;
+
+import com.b2international.index.es.EsIndexClientFactory;
+import com.b2international.index.es.EsNode;
+
+/**
+ * @since 8.0
+ */
+public final class SynonymsRule extends ExternalResource {
+
+	private final Path synonymsFile;
+	private final List<String> synonyms;
+
+	private List<String> linesToRestore;
+	
+	public SynonymsRule(String...synonyms) {
+		this(List.of(synonyms));
+	}
+	
+	public SynonymsRule(List<String> synonyms) {
+		this(EsIndexClientFactory.DEFAULT_PATH.resolve(IndexClientFactory.DEFAULT_CLUSTER_NAME).resolve(EsNode.CONFIG_DIR).resolve(EsNode.SYNONYMS_FILE), synonyms);
+	}
+	
+	public SynonymsRule(Path synonymsFile, List<String> synonyms) {
+		this.synonymsFile = synonymsFile;
+		this.synonyms = synonyms;
+	}
+	
+	@Override
+	protected void before() throws Throwable {
+		linesToRestore = Files.exists(synonymsFile) ? Files.readAllLines(synonymsFile) : Collections.emptyList();
+		Files.createDirectories(synonymsFile.getParent());
+		Files.write(synonymsFile, synonyms);
+	}
+	
+	@Override
+	protected void after() {
+		try {
+			Files.write(synonymsFile, linesToRestore);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+	
+}

--- a/commons/com.b2international.index/src/com/b2international/index/Analyzers.java
+++ b/commons/com.b2international.index/src/com/b2international/index/Analyzers.java
@@ -69,6 +69,29 @@ public enum Analyzers {
 	TOKENIZED,
 	
 	/**
+	 * "tokenized_synonyms": {
+	       "tokenizer": "whitespace",
+	       "filter": [
+	          "asciifolding",
+	          "lowercase",
+	          "possessive",
+	          "synonyms",
+	          "word_splitter",
+	          "unique_token"
+	       ]
+	    }
+	    "word_splitter": {
+            "type": "word_delimiter",
+            "split_on_case_change": "false",
+            "split_on_numerics": "false",
+            "preserve_original": "true",
+            "stem_english_possessive": "false",
+            "type_table": [", => DIGIT", ". => DIGIT"]
+        }
+	 */
+	TOKENIZED_SYNONYMS,
+	
+	/**
 	 * "tokenized_ignore_stopwords": {
 			"tokenizer": "whitespace",
 			"filter": [
@@ -82,6 +105,22 @@ public enum Analyzers {
 		}
 	 */
 	TOKENIZED_IGNORE_STOPWORDS,
+	
+	/**
+	 * "tokenized_synonyms_ignore_stopwords": {
+			"tokenizer": "whitespace",
+			"filter": [
+				"asciifolding",
+				"lowercase",
+				"stop_words",
+				"possessive",
+				"synonyms",
+				"word_splitter",
+				"unique_token"				
+			]
+		}
+	 */
+	TOKENIZED_SYNONYMS_IGNORE_STOPWORDS,
 	
 	/**
 	 * "stemming": {
@@ -191,7 +230,9 @@ public enum Analyzers {
 		case KEYWORD: return "keyword";
 		case EXACT: return "exact";
 		case TOKENIZED: return "tokenized";
+		case TOKENIZED_SYNONYMS: return "tokenized_synonyms";
 		case TOKENIZED_IGNORE_STOPWORDS: return "tokenized_ignore_stopwords";
+		case TOKENIZED_SYNONYMS_IGNORE_STOPWORDS: return "tokenized_synonyms_ignore_stopwords";
 		case STEMMING: return "stemming";
 		case SEARCH_STEMMING: return "search_stemming";
 		case CASE_SENSITIVE: return "case_sensitive";

--- a/commons/com.b2international.index/src/com/b2international/index/es/EsIndexClientFactory.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/EsIndexClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public final class EsIndexClientFactory implements IndexClientFactory {
 
-	private static final Path DEFAULT_PATH = Paths.get("target", "resources", "indexes");
+	public static final Path DEFAULT_PATH = Paths.get("target", "resources", "indexes");
 
 	@Override
 	public IndexClient createClient(String name, ObjectMapper mapper, Mappings mappings, Map<String, Object> settings) {

--- a/commons/com.b2international.index/src/com/b2international/index/es/admin/analysis.json
+++ b/commons/com.b2international.index/src/com/b2international/index/es/admin/analysis.json
@@ -10,6 +10,40 @@
 				"unique_token"
 			]
 		},
+		"tokenized_synonyms": {
+			"tokenizer": "whitespace",
+			"filter": [
+				"asciifolding",
+				"lowercase",
+				"possessive",
+				"synonyms",
+				"word_splitter",
+				"unique_token"
+			]
+		},
+		"tokenized_ignore_stopwords": {
+			"tokenizer": "whitespace",
+			"filter": [
+				"asciifolding",
+				"lowercase",
+				"stop_words",
+				"possessive",
+				"word_splitter",
+				"unique_token"				
+			]
+		},
+		"tokenized_synonyms_ignore_stopwords": {
+			"tokenizer": "whitespace",
+			"filter": [
+				"asciifolding",
+				"lowercase",
+				"stop_words",
+				"possessive",
+				"synonyms",
+				"word_splitter",
+				"unique_token"				
+			]
+		},
 		"exact": {
 			"tokenizer": "keyword",
 			"filter": [
@@ -81,17 +115,6 @@
 				"unique_token",
 				"edge_ngram"
 			]
-		},
-		"tokenized_ignore_stopwords": {
-			"tokenizer": "whitespace",
-			"filter": [
-				"asciifolding",
-				"lowercase",
-				"stop_words",
-				"possessive",
-				"word_splitter",
-				"unique_token"				
-			]
 		}
 	},
 	"normalizer": {
@@ -136,6 +159,11 @@
 		"stop_words": {
 			"type": "stop",
 			"stopwords": ["a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into", "is", "it", "of", "on", "or", "such", "that", "the", "their", "then", "there", "these", "they", "this", "to", "was", "will", "with"]
+		},
+		"synonyms": {
+			"type": "synonym",
+			"synonyms_path": "analysis/synonym.txt",
+			"lenient": true
 		}
 	}
 }

--- a/commons/com.b2international.index/src/com/b2international/index/query/TextPredicate.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/TextPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public final class TextPredicate extends Predicate {
 		if (ignoreStopwords) {
 			return withAnalyzer((analyzer == Analyzers.TOKENIZED_SYNONYMS || analyzer == Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS) ? Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS : Analyzers.TOKENIZED_IGNORE_STOPWORDS);
 		} else {
-			return withAnalyzer(null);
+			return withAnalyzer(analyzer == Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS ? Analyzers.TOKENIZED_SYNONYMS : null);
 		}
 	}
 	
@@ -82,7 +82,7 @@ public final class TextPredicate extends Predicate {
 		if (enableSynonyms) {
 			return withAnalyzer((analyzer == Analyzers.TOKENIZED_IGNORE_STOPWORDS || analyzer == Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS) ? Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS : Analyzers.TOKENIZED_SYNONYMS);
 		} else {
-			return withAnalyzer(null);
+			return withAnalyzer(analyzer == Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS ? Analyzers.TOKENIZED_IGNORE_STOPWORDS : null);
 		}
 	}
 

--- a/commons/com.b2international.index/src/com/b2international/index/query/TextPredicate.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/TextPredicate.java
@@ -31,7 +31,7 @@ public final class TextPredicate extends Predicate {
 	private final MatchType type;
 	private final int minShouldMatch;
 	
-	private String analyzer;
+	private Analyzers analyzer;
 	
 	TextPredicate(String field, String term, MatchType type) {
 		this(field, term, type, 1);
@@ -57,11 +57,11 @@ public final class TextPredicate extends Predicate {
 	}
 	
 	public String analyzer() {
-		return analyzer;
+		return analyzer == null ? null : analyzer.getAnalyzer();
 	}
 	
 	public TextPredicate withAnalyzer(Analyzers analyzer) {
-		this.analyzer = analyzer == null ? null : analyzer.getAnalyzer();
+		this.analyzer = analyzer;
 		return this;
 	}
 	
@@ -72,11 +72,18 @@ public final class TextPredicate extends Predicate {
 
 	public TextPredicate withIgnoreStopwords(boolean ignoreStopwords) {
 		if (ignoreStopwords) {
-			analyzer = Analyzers.TOKENIZED_IGNORE_STOPWORDS.getAnalyzer();
+			return withAnalyzer((analyzer == Analyzers.TOKENIZED_SYNONYMS || analyzer == Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS) ? Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS : Analyzers.TOKENIZED_IGNORE_STOPWORDS);
 		} else {
-			analyzer = null;
+			return withAnalyzer(null);
 		}
-		return this;
+	}
+	
+	public TextPredicate withSynonyms(boolean enableSynonyms) {
+		if (enableSynonyms) {
+			return withAnalyzer((analyzer == Analyzers.TOKENIZED_IGNORE_STOPWORDS || analyzer == Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS) ? Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS : Analyzers.TOKENIZED_SYNONYMS);
+		} else {
+			return withAnalyzer(null);
+		}
 	}
 
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/ResourceDocument.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/ResourceDocument.java
@@ -425,7 +425,7 @@ public final class ResourceDocument extends RevisionDocument {
 	@Field(
 		aliases = {
 			@FieldAlias(name = "prefix", type = FieldAliasType.TEXT, analyzer=Analyzers.PREFIX, searchAnalyzer=Analyzers.TOKENIZED),
-			@FieldAlias(name = "text", type = FieldAliasType.TEXT, analyzer=Analyzers.TOKENIZED),
+			@FieldAlias(name = "text", type = FieldAliasType.TEXT, analyzer=Analyzers.TOKENIZED, searchAnalyzer = Analyzers.TOKENIZED_SYNONYMS),
 			@FieldAlias(name = "exact", type = FieldAliasType.KEYWORD, normalizer = Normalizers.LOWER_ASCII)
 		}
 	)

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/jobs/RemoteJobEntry.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/jobs/RemoteJobEntry.java
@@ -252,7 +252,7 @@ public final class RemoteJobEntry implements Serializable {
 	private final String key;
 	
 	@Field(aliases = {
-		@FieldAlias(name = "text", type = FieldAliasType.TEXT, analyzer = Analyzers.TOKENIZED),
+		@FieldAlias(name = "text", type = FieldAliasType.TEXT, analyzer = Analyzers.TOKENIZED, searchAnalyzer = Analyzers.TOKENIZED_SYNONYMS),
 		@FieldAlias(name = "prefix", type = FieldAliasType.TEXT, analyzer = Analyzers.PREFIX, searchAnalyzer = Analyzers.TOKENIZED)
 	})
 	private final String description;	

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/validation/issue/ValidationIssue.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/validation/issue/ValidationIssue.java
@@ -78,7 +78,7 @@ public final class ValidationIssue implements Serializable {
 	private final boolean whitelisted;
 
 	@Field(aliases = {
-		@FieldAlias(name = "text", type = FieldAliasType.TEXT, analyzer = Analyzers.TOKENIZED),
+		@FieldAlias(name = "text", type = FieldAliasType.TEXT, analyzer = Analyzers.TOKENIZED, searchAnalyzer = Analyzers.TOKENIZED_SYNONYMS),
 		@FieldAlias(name = "prefix", type = FieldAliasType.TEXT, analyzer = Analyzers.PREFIX, searchAnalyzer = Analyzers.TOKENIZED)
 	})
 	private List<String> affectedComponentLabels = Collections.emptyList();

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/validation/whitelist/ValidationWhiteList.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/validation/whitelist/ValidationWhiteList.java
@@ -63,7 +63,7 @@ public final class ValidationWhiteList implements Serializable {
 	private final String componentType;
 	
 	@Field(aliases = {
-		@FieldAlias(name = "text", type = FieldAliasType.TEXT, analyzer = Analyzers.TOKENIZED),
+		@FieldAlias(name = "text", type = FieldAliasType.TEXT, analyzer = Analyzers.TOKENIZED, searchAnalyzer = Analyzers.TOKENIZED_SYNONYMS),
 		@FieldAlias(name = "prefix", type = FieldAliasType.TEXT, analyzer = Analyzers.PREFIX, searchAnalyzer = Analyzers.TOKENIZED)
 	})
 	private final List<String> affectedComponentLabels;

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.13.3
     container_name: elasticsearch
     environment:
       cluster.name: "elastic-snowowl"
@@ -12,7 +12,6 @@ services:
       bootstrap.memory_lock: "true"
       ES_JAVA_OPTS: "-Xms6g -Xmx6g"
       TAKE_FILE_OWNERSHIP: "true"
-      node.master: "true"
       http.type: "netty4"
       http.cors.enabled: "true"
       http.cors.allow-origin: "/https?:\\/\\/localhost(:[0-9]+)?/"
@@ -25,14 +24,16 @@ services:
         hard: 65536
     volumes:
       - /path/to/indexes:/usr/share/elasticsearch/data
+      - ./config/analysis/synonym.txt:/usr/share/elasticsearch/config/analysis/synonym.txt
     healthcheck:
       test: ["CMD", "curl", "-f", "http://elasticsearch:9200"]
       interval: 1s
       timeout: 1s
       retries: 60
     ports:
-     - "9200:9200"
-     - "9300:9300"
+     - "127.0.0.1:9200:9200"
+     - "127.0.0.1:9300:9300"
+    restart: unless-stopped
   snowowl:
     image: b2ihealthcare/snow-owl-oss:latest
     container_name: snowowl
@@ -47,4 +48,5 @@ services:
       - /path/to/resources:/var/lib/snowowl             # Snow Owl's resources folder
       - /path/to/logs:/var/log/snowowl                  # Snow Owl's log folder
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
+    restart: unless-stopped

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/entry/SnomedDescriptionIndexEntry.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/entry/SnomedDescriptionIndexEntry.java
@@ -369,7 +369,7 @@ public final class SnomedDescriptionIndexEntry extends SnomedComponentDocument {
 	private final String languageCode;
 	
 	@Field(aliases = {
-		@FieldAlias(name = "text", type = FieldAliasType.TEXT, analyzer = Analyzers.TOKENIZED),
+		@FieldAlias(name = "text", type = FieldAliasType.TEXT, analyzer = Analyzers.TOKENIZED, searchAnalyzer = Analyzers.TOKENIZED_SYNONYMS),
 		@FieldAlias(name = "prefix", type = FieldAliasType.TEXT, analyzer = Analyzers.PREFIX, searchAnalyzer = Analyzers.TOKENIZED),
 		@FieldAlias(name = "exact", type = FieldAliasType.KEYWORD, normalizer = Normalizers.LOWER_ASCII),
 	})


### PR DESCRIPTION
New `SO_HOME/configuration/analysis/synonym.txt` file can be configured
to allow Snow Owl use the defined set of synonym rules when performing
full-text searches.
Update docker configuration as well to include an empty synonyms.txt
file (required by all Elasticsearch nodes now).

SO-4895 #resolve