### PR TITLE
feat: support `dialectId` and `dialect` filters in ECL evaluation

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/BaseSnomedEclEvaluationRequestTest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/BaseSnomedEclEvaluationRequestTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.snomed.core.ecl;
+
+import java.util.*;
+
+import org.eclipse.xtext.parser.IParser;
+import org.eclipse.xtext.serializer.ISerializer;
+import org.eclipse.xtext.validation.IResourceValidator;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.b2international.collections.PrimitiveCollectionModule;
+import com.b2international.index.Index;
+import com.b2international.index.query.Expression;
+import com.b2international.index.revision.BaseRevisionIndexTest;
+import com.b2international.index.revision.RevisionIndex;
+import com.b2international.snomed.ecl.EclStandaloneSetup;
+import com.b2international.snowowl.core.TerminologyResource;
+import com.b2international.snowowl.core.codesystem.CodeSystem;
+import com.b2international.snowowl.core.domain.BranchContext;
+import com.b2international.snowowl.core.request.RevisionIndexReadRequest;
+import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
+import com.b2international.snowowl.snomed.common.SnomedTerminologyComponentConstants;
+import com.b2international.snowowl.snomed.core.tree.Trees;
+import com.b2international.snowowl.snomed.datastore.config.SnomedCoreConfiguration;
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument;
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedDescriptionIndexEntry;
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedRefSetMemberIndexEntry;
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedRelationshipIndexEntry;
+import com.b2international.snowowl.snomed.datastore.request.SnomedRequests;
+import com.b2international.snowowl.test.commons.snomed.TestBranchContext;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Injector;
+
+/**
+ * @since 8.0
+ */
+@RunWith(Parameterized.class)
+public abstract class BaseSnomedEclEvaluationRequestTest extends BaseRevisionIndexTest {
+
+	private static final Injector INJECTOR = new EclStandaloneSetup().createInjectorAndDoEMFRegistration();
+	
+	protected static final String ROOT_ID = Concepts.ROOT_CONCEPT;
+	protected static final String OTHER_ID = Concepts.ABBREVIATION;
+	protected static final String HAS_ACTIVE_INGREDIENT = Concepts.HAS_ACTIVE_INGREDIENT;
+	protected static final String SUBSTANCE = Concepts.SUBSTANCE;
+	
+	protected static final String AXIOM = "axiom";
+	
+	private BranchContext context;
+	
+	private final String expressionForm;
+	private final boolean statementsWithValue;
+	
+	public BaseSnomedEclEvaluationRequestTest(String expressionForm, boolean statementsWithValue) {
+		this.expressionForm = expressionForm;
+		this.statementsWithValue = statementsWithValue;
+	}
+	
+	@Parameters(name = "{0} {1}")
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+			// Test CD members in all three forms
+			{ Trees.INFERRED_FORM, false },
+			{ Trees.STATED_FORM,   false },
+			{ AXIOM,               false }, // special test parameter to indicate stated form on axiom members
+			
+			// New statements with value are expected to 
+			// appear in axiom and inferred form only
+			{ Trees.INFERRED_FORM, true  },
+			{ AXIOM,               true  }, 
+		});
+	}
+	
+	@Override
+	protected Collection<Class<?>> getTypes() {
+		return Set.of(SnomedConceptDocument.class, SnomedDescriptionIndexEntry.class, SnomedRelationshipIndexEntry.class, SnomedRefSetMemberIndexEntry.class);
+	}
+
+	@Override
+	protected void configureMapper(ObjectMapper mapper) {
+		super.configureMapper(mapper);
+		mapper.setSerializationInclusion(Include.NON_NULL);
+		mapper.registerModule(new PrimitiveCollectionModule());
+	}
+	
+	@Before
+	public void setup() {
+		SnomedCoreConfiguration config = new SnomedCoreConfiguration();
+		config.setConcreteDomainSupported(true);
+		
+		context = TestBranchContext.on(MAIN)
+				.with(EclParser.class, new DefaultEclParser(INJECTOR.getInstance(IParser.class), INJECTOR.getInstance(IResourceValidator.class)))
+				.with(EclSerializer.class, new DefaultEclSerializer(INJECTOR.getInstance(ISerializer.class)))
+				.with(Index.class, rawIndex())
+				.with(RevisionIndex.class, index())
+				.with(SnomedCoreConfiguration.class, config)
+				.with(ObjectMapper.class, getMapper())
+				.with(TerminologyResource.class, createCodeSystem(MAIN))
+				.build();
+	}
+	
+	private CodeSystem createCodeSystem(String main) {
+		CodeSystem codeSystem = new CodeSystem();
+		codeSystem.setId("SNOMEDCT");
+		codeSystem.setBranchPath(main);
+		codeSystem.setSettings(Map.of(
+			SnomedTerminologyComponentConstants.CODESYSTEM_LANGUAGE_CONFIG_KEY, List.of(
+				Map.of(
+					"languageTag", "en",
+					"languageRefSetIds", List.of(Concepts.REFSET_LANGUAGE_TYPE_UK, Concepts.REFSET_LANGUAGE_TYPE_US)
+				),
+				Map.of(
+					"languageTag", "en-us",
+					"languageRefSetIds", List.of(Concepts.REFSET_LANGUAGE_TYPE_US)
+				),
+				Map.of(
+					"languageTag", "en-gb",
+					"languageRefSetIds", List.of(Concepts.REFSET_LANGUAGE_TYPE_UK)
+				)
+			)		
+		));
+		return codeSystem;
+	}
+
+	protected final Expression eval(String expression) {
+		return new RevisionIndexReadRequest<>(SnomedRequests.prepareEclEvaluation(expression)
+			// use the isInferred method decide on inferred vs stated form (this will provide support for axioms as well)
+			.setExpressionForm(isInferred() ? Trees.INFERRED_FORM : Trees.STATED_FORM) 
+			.build())
+			.execute(context)
+			.getSync();
+	}
+	
+	protected final boolean isAxiom() {
+		return AXIOM.equals(expressionForm);
+	}
+
+	protected final boolean isInferred() {
+		return Trees.INFERRED_FORM.equals(expressionForm);
+	}
+	
+	protected final String getCharacteristicType() {
+		return isInferred() ? Concepts.INFERRED_RELATIONSHIP : Concepts.STATED_RELATIONSHIP;
+	}
+	
+	protected final boolean isStatementsWithValue() {
+		return statementsWithValue;
+	}
+	
+}

--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequestPropertyFilterTest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequestPropertyFilterTest.java
@@ -1,0 +1,588 @@
+/*
+ * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.snomed.core.ecl;
+
+import static com.b2international.snowowl.test.commons.snomed.RandomSnomedIdentiferGenerator.generateDescriptionId;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+import com.b2international.commons.exceptions.BadRequestException;
+import com.b2international.index.query.Expression;
+import com.b2international.index.query.Expressions;
+import com.b2international.snowowl.core.date.DateFormats;
+import com.b2international.snowowl.core.date.EffectiveTimes;
+import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
+import com.b2international.snowowl.snomed.core.domain.Acceptability;
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument;
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedDescriptionIndexEntry;
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedDocument;
+
+/**
+ * @since 8.0
+ */
+public class SnomedEclEvaluationRequestPropertyFilterTest extends BaseSnomedEclEvaluationRequestTest {
+
+	public SnomedEclEvaluationRequestPropertyFilterTest(String expressionForm, boolean statementsWithValue) {
+		super(expressionForm, statementsWithValue);
+	}
+
+	@Test
+	public void activeOnly() throws Exception {
+		final Expression actual = eval("* {{ active=true }}");
+		final Expression expected = SnomedDocument.Expressions.active();
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void inactiveOnly() throws Exception {
+		final Expression actual = eval("* {{ active=false }}");
+		final Expression expected = SnomedDocument.Expressions.inactive();
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void moduleId() throws Exception {
+		final Expression actual = eval("* {{ moduleId= " + Concepts.MODULE_SCT_CORE + " }}");
+		final Expression expected = SnomedDocument.Expressions.modules(List.of(Concepts.MODULE_SCT_CORE));
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void term() throws Exception {
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+			.id(generateDescriptionId())
+			.active(true)
+			.moduleId(Concepts.MODULE_SCT_CORE)
+			.term("Clinical finding")
+			.conceptId(Concepts.ROOT_CONCEPT)
+			.typeId(Concepts.SYNONYM)
+			.build());
+		
+		final Expression actual = eval("* {{ term = \"Clin find\" }}");
+		final Expression expected = SnomedDocument.Expressions.ids(List.of(Concepts.ROOT_CONCEPT));
+		assertEquals(expected, actual);
+	}
+	
+	@Test(expected = BadRequestException.class)
+	public void termLessThanTwoChars() throws Exception {
+		eval("* {{ term = \"C\" }}");
+	}
+	
+	@Test
+	public void conjunctionActiveAndModuleId() throws Exception {
+		final Expression actual = eval("* {{ active = true, moduleId = " + Concepts.MODULE_SCT_CORE + " }}");
+		final Expression expected = Expressions.builder()
+			.filter(SnomedDocument.Expressions.active())
+			.filter(SnomedDocument.Expressions.modules(List.of(Concepts.MODULE_SCT_CORE)))
+			.build();
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void disjunctionActiveAndModuleId() throws Exception {
+		final Expression actual = eval("* {{ active = true OR moduleId = " + Concepts.MODULE_SCT_CORE + " }}");
+		final Expression expected = Expressions.builder()
+			.should(SnomedDocument.Expressions.active())
+			.should(SnomedDocument.Expressions.modules(List.of(Concepts.MODULE_SCT_CORE)))
+			.build();
+		assertEquals(expected, actual);
+	}
+	
+	@Test(expected = BadRequestException.class)
+	public void conjunctionDomainInconsistency() throws Exception {
+		eval("* {{ active=true AND Description.moduleId = "+ Concepts.MODULE_SCT_CORE +" }}");
+	}
+	
+	@Test(expected = BadRequestException.class)
+	public void disjunctionDomainInconsistency() throws Exception {
+		eval("* {{ Description.active=true OR moduleId = "+ Concepts.MODULE_SCT_CORE +" }}");
+	}
+	
+	@Test
+	public void descriptionType() throws Exception {
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+			.id(generateDescriptionId())
+			.active(true)
+			.moduleId(Concepts.MODULE_SCT_CORE)
+			.term("Clinical finding")
+			.conceptId(Concepts.ROOT_CONCEPT)
+			.typeId(Concepts.TEXT_DEFINITION)
+			.build());
+		
+		final Expression actual = eval("* {{ typeId = " + Concepts.TEXT_DEFINITION + " }}");
+		final Expression expected = SnomedDocument.Expressions.ids(List.of(Concepts.ROOT_CONCEPT));
+		assertEquals(expected, actual);
+	}
+	
+	@Test(expected = BadRequestException.class)
+	public void conjunctionAmbiguity() throws Exception {
+		eval("* {{ Description.active=true AND Description.moduleId = " + Concepts.MODULE_SCT_CORE + " OR term=\"clinical finding\" }}");
+	}
+	
+	@Test(expected = BadRequestException.class)
+	public void disjunctionAmbiguity() throws Exception {
+		eval("* {{ Description.active=true OR Description.moduleId = " + Concepts.MODULE_SCT_CORE + " AND term=\"clinical finding\" }}");
+	}
+	
+	@Test(expected = BadRequestException.class)
+	public void exclusionAmbiguity() throws Exception {
+		eval("* {{ Description.active=true OR Description.moduleId = " + Concepts.MODULE_SCT_CORE +" MINUS term=\"clinical finding\" }}");
+	}
+	
+	@Test
+	public void multiDomainQueryAnd() throws Exception {
+		Expression actual = eval("* {{ active=false }} AND * {{ term=\"clin find\" }}");
+		Expression expected = Expressions.builder()
+			.filter(SnomedDocument.Expressions.inactive())
+			.filter(SnomedDocument.Expressions.ids(Collections.emptySet()))
+			.build();
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void multiDomainQueryOr() throws Exception {
+		Expression actual = eval("* {{ active=false }} OR * {{ term=\"clin find\" }}");
+		Expression expected = Expressions.builder()
+			.should(SnomedDocument.Expressions.inactive())
+			.should(SnomedDocument.Expressions.ids(Collections.emptySet()))
+			.build();
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void multiDomainQueryExclusion() throws Exception {
+		Expression actual = eval("* {{ active=false }} MINUS * {{ term=\"clin find\" }}");
+		Expression expected = Expressions.builder()
+			.filter(SnomedDocument.Expressions.inactive())
+			.mustNot(SnomedDocument.Expressions.ids(Collections.emptySet()))
+			.build();
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void preferredIn() throws Exception {
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+			.id(generateDescriptionId())
+			.active(true)
+			.moduleId(Concepts.MODULE_SCT_CORE)
+			.term("Clinical finding")
+			.conceptId(Concepts.ROOT_CONCEPT)
+			.typeId(Concepts.TEXT_DEFINITION)
+			.preferredIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_UK))
+			.acceptableIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_US))
+			.build());
+		
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+			.id(generateDescriptionId())
+			.active(true)
+			.moduleId(Concepts.MODULE_SCT_CORE)
+			.term("Clinical finding")
+			.conceptId(Concepts.SUBSTANCE)
+			.typeId(Concepts.TEXT_DEFINITION)
+			.preferredIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_US))
+			.acceptableIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_UK))
+			.build());
+		
+		final Expression actual = eval("* {{ preferredIn = " + Concepts.REFSET_LANGUAGE_TYPE_UK + " }}");
+		final Expression expected = SnomedDocument.Expressions.ids(List.of(Concepts.ROOT_CONCEPT));
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void acceptableIn() throws Exception {
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+			.id(generateDescriptionId())
+			.active(true)
+			.moduleId(Concepts.MODULE_SCT_CORE)
+			.term("Clinical finding")
+			.conceptId(Concepts.ROOT_CONCEPT)
+			.typeId(Concepts.TEXT_DEFINITION)
+			.preferredIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_UK))
+			.acceptableIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_US))
+			.build());
+		
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+			.id(generateDescriptionId())
+			.active(true)
+			.moduleId(Concepts.MODULE_SCT_CORE)
+			.term("Clinical finding")
+			.conceptId(Concepts.SUBSTANCE)
+			.typeId(Concepts.TEXT_DEFINITION)
+			.preferredIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_US))
+			.acceptableIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_UK))
+			.build());
+		
+		final Expression actual = eval("* {{ acceptableIn = " + Concepts.REFSET_LANGUAGE_TYPE_UK + " }}");
+		final Expression expected = SnomedDocument.Expressions.ids(List.of(Concepts.SUBSTANCE));
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void languageRefSet() throws Exception {
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+				.id(generateDescriptionId())
+				.active(true)
+				.moduleId(Concepts.MODULE_SCT_CORE)
+				.term("Clinical finding")
+				.conceptId(Concepts.ROOT_CONCEPT)
+				.typeId(Concepts.TEXT_DEFINITION)
+				.preferredIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_UK))
+				.acceptableIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_US))
+				.build());
+		
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+				.id(generateDescriptionId())
+				.active(true)
+				.moduleId(Concepts.MODULE_SCT_CORE)
+				.term("Clinical finding")
+				.conceptId(Concepts.SUBSTANCE)
+				.typeId(Concepts.TEXT_DEFINITION)
+				.preferredIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_US))
+				.acceptableIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_UK))
+				.build());
+		
+		final Expression actual = eval("* {{ languageRefSetId = " + Concepts.REFSET_LANGUAGE_TYPE_UK + " }}");
+		final Expression expected = SnomedDocument.Expressions.ids(Set.of(Concepts.ROOT_CONCEPT, Concepts.SUBSTANCE));
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void semanticTag() throws Exception {
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+				.id(generateDescriptionId())
+				.active(true)
+				.moduleId(Concepts.MODULE_SCT_CORE)
+				.term("Clinical finding (finding)")
+				.conceptId(Concepts.ROOT_CONCEPT)
+				.typeId(Concepts.TEXT_DEFINITION)
+				.preferredIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_UK))
+				.acceptableIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_US))
+				.build());
+		
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+				.id(generateDescriptionId())
+				.active(true)
+				.moduleId(Concepts.MODULE_SCT_CORE)
+				.term("Clinical finding (clinical)")
+				.conceptId(Concepts.SUBSTANCE)
+				.typeId(Concepts.TEXT_DEFINITION)
+				.preferredIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_US))
+				.acceptableIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_UK))
+				.build());
+		
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+				.id(generateDescriptionId())
+				.active(true)
+				.moduleId(Concepts.MODULE_SCT_CORE)
+				.term("Clinical finding (disorder)")
+				.conceptId(Concepts.ATTRIBUTE)
+				.typeId(Concepts.TEXT_DEFINITION)
+				.preferredIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_US))
+				.acceptableIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_UK))
+				.build());
+		
+		
+		Expression expected = SnomedDocument.Expressions.ids(Set.of(Concepts.SUBSTANCE));
+		Expression actual = eval("* {{ semanticTag = \"clinical\" }}");
+		assertEquals(expected, actual);
+		
+		expected = SnomedDocument.Expressions.ids(Set.of(Concepts.SUBSTANCE, Concepts.ATTRIBUTE));
+		actual = eval("* {{ semanticTag != \"finding\" }}");
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void descriptionEffectiveTime() throws Exception {
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+				.id(generateDescriptionId())
+				.active(true)
+				.released(true)
+				.effectiveTime(EffectiveTimes.getEffectiveTime("20210731", DateFormats.SHORT))
+				.moduleId(Concepts.MODULE_SCT_CORE)
+				.term("Clinical finding (finding)")
+				.conceptId(Concepts.ROOT_CONCEPT)
+				.typeId(Concepts.TEXT_DEFINITION)
+				.preferredIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_UK))
+				.acceptableIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_US))
+				.build());
+		
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+				.id(generateDescriptionId())
+				.active(true)
+				.released(true)
+				.effectiveTime(EffectiveTimes.getEffectiveTime("20020131", DateFormats.SHORT))
+				.moduleId(Concepts.MODULE_SCT_CORE)
+				.term("Clinical finding (clinical)")
+				.conceptId(Concepts.SUBSTANCE)
+				.typeId(Concepts.TEXT_DEFINITION)
+				.preferredIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_US))
+				.acceptableIn(Set.of(Concepts.REFSET_LANGUAGE_TYPE_UK))
+				.build());
+		
+		Expression expected = SnomedDocument.Expressions.ids(Set.of(Concepts.ROOT_CONCEPT));
+		Expression actual = eval("* {{ Description.effectiveTime = \"20210731\" }}");
+		assertEquals(expected, actual);
+
+		expected = SnomedDocument.Expressions.ids(Set.of(Concepts.ROOT_CONCEPT));
+		actual = eval("* {{ Description.effectiveTime > \"20210605\" }}");
+		assertEquals(expected, actual);
+
+		expected = SnomedDocument.Expressions.ids(Set.of(Concepts.SUBSTANCE));
+		actual = eval("* {{ Description.effectiveTime < \"20020201\" }}");
+		assertEquals(expected, actual);
+		
+		expected = SnomedDocument.Expressions.ids(Set.of(Concepts.ROOT_CONCEPT, Concepts.SUBSTANCE));
+		actual = eval("* {{ Description.effectiveTime >= \"20020131\" }}");
+		assertEquals(expected, actual);
+		
+		expected = SnomedDocument.Expressions.ids(Set.of(Concepts.ROOT_CONCEPT, Concepts.SUBSTANCE));
+		actual = eval("* {{ Description.effectiveTime >= \"20010731\" }}");
+		assertEquals(expected, actual);
+		
+		expected = SnomedDocument.Expressions.ids(Set.of(Concepts.ROOT_CONCEPT, Concepts.SUBSTANCE));
+		actual = eval("* {{ Description.effectiveTime <= \"20210731\" }}");
+		assertEquals(expected, actual);
+		
+		expected = SnomedDocument.Expressions.ids(Set.of(Concepts.ROOT_CONCEPT, Concepts.SUBSTANCE));
+		actual = eval("* {{ Description.effectiveTime <= \"20211030\" }}");
+		assertEquals(expected, actual);
+		
+		expected = SnomedDocument.Expressions.ids(Set.of(Concepts.ROOT_CONCEPT, Concepts.SUBSTANCE));
+		actual = eval("* {{ Description.effectiveTime != \"20211030\" }}");
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void conceptEffectiveTime() throws Exception {
+		indexRevision(MAIN, SnomedConceptDocument.builder()
+				.id(Concepts.FINDING_SITE)
+				.active(true)
+				.released(true)
+				.effectiveTime(EffectiveTimes.getEffectiveTime("20210731", DateFormats.SHORT))
+				.moduleId(Concepts.MODULE_SCT_CORE)
+				.build());
+		
+		indexRevision(MAIN, SnomedConceptDocument.builder()
+				.id(Concepts.HAS_ACTIVE_INGREDIENT)
+				.active(true)
+				.released(true)
+				.effectiveTime(EffectiveTimes.getEffectiveTime("20020131", DateFormats.SHORT))
+				.moduleId(Concepts.MODULE_SCT_CORE)
+				.build());
+		
+		Expression expected = SnomedDocument.Expressions.effectiveTime(EffectiveTimes.getEffectiveTime("20210731", DateFormats.SHORT));
+		Expression actual = eval("* {{ effectiveTime = \"20210731\" }}");
+		assertEquals(expected, actual);
+	}
+	
+	@Test(expected = BadRequestException.class)
+	public void invalidLanguageCode() throws Exception {
+		eval("* {{ language = \"en-sg\" }}");
+	}
+	
+	@Test
+	public void languageCode() throws Exception {
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+				.id(generateDescriptionId())
+				.active(true)
+				.moduleId(Concepts.MODULE_SCT_CORE)
+				.term("Clinical finding")
+				.conceptId(Concepts.ROOT_CONCEPT)
+				.typeId(Concepts.TEXT_DEFINITION)
+				.languageCode("en")
+				.build());
+		
+		Expression actual = eval("* {{ language = en }}");
+		Expression expected = SnomedDocument.Expressions.ids(Set.of(Concepts.ROOT_CONCEPT));
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void caseSignificanceId() throws Exception {
+		generatePreferredDescription(Concepts.ROOT_CONCEPT);
+		
+		Expression actual = eval("* {{ caseSignificanceId = " + Concepts.ENTIRE_TERM_CASE_INSENSITIVE + " }}");
+		Expression expected = SnomedDocument.Expressions.ids(Set.of(Concepts.ROOT_CONCEPT));
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void dialectAnyAcceptability() throws Exception {
+		generatePreferredDescription(Concepts.ROOT_CONCEPT);
+		generateAcceptableDescription(Concepts.MODULE_ROOT);
+		
+		Expression actual = eval("* {{ dialect = en-gb }}");
+		Expression expected = SnomedDocument.Expressions.ids(Set.of(Concepts.ROOT_CONCEPT, Concepts.MODULE_ROOT));
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void dialectAnyAcceptabilityNotEquals() throws Exception {
+		generatePreferredDescription(Concepts.ROOT_CONCEPT);
+		generateAcceptableDescription(Concepts.MODULE_ROOT);
+		
+		Expression actual = eval("* {{ dialect != en-gb }}");
+		Expression expected = SnomedDocument.Expressions.ids(Set.of());
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void dialectPreferred() throws Exception {
+		generatePreferredDescription(Concepts.ROOT_CONCEPT);
+		// extra acceptable description on another concept to demonstrate that it won't match
+		generateAcceptableDescription(Concepts.MODULE_ROOT);
+		
+		Expression actual = eval("* {{ dialect = en-gb (preferred) }}");
+		Expression expected = SnomedDocument.Expressions.ids(Set.of(Concepts.ROOT_CONCEPT));
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void dialectPreferredNotEquals() throws Exception {
+		generatePreferredDescription(Concepts.ROOT_CONCEPT);
+		// extra acceptable description on another concept to demonstrate that it won't match
+		generateAcceptableDescription(Concepts.MODULE_ROOT);
+		
+		Expression actual = eval("* {{ dialect != en-gb (preferred) }}");
+		Expression expected = SnomedDocument.Expressions.ids(Set.of(Concepts.MODULE_ROOT));
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void dialectAcceptable() throws Exception {
+		generateAcceptableDescription(Concepts.ROOT_CONCEPT);
+		// extra preferred description on another concept to demonstrate that it won't match
+		generatePreferredDescription(Concepts.MODULE_ROOT);
+		
+		Expression actual = eval("* {{ dialect = en-gb (acceptable) }}");
+		Expression expected = SnomedDocument.Expressions.ids(Set.of(Concepts.ROOT_CONCEPT));
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void dialectAcceptableNotEquals() throws Exception {
+		generateAcceptableDescription(Concepts.ROOT_CONCEPT);
+		// extra preferred description on another concept to demonstrate that it won't match
+		generatePreferredDescription(Concepts.MODULE_ROOT);
+		
+		Expression actual = eval("* {{ dialect != en-gb (acceptable) }}");
+		Expression expected = SnomedDocument.Expressions.ids(Set.of(Concepts.MODULE_ROOT));
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void dialectIdAnyAcceptability() throws Exception {
+		generatePreferredDescription(Concepts.ROOT_CONCEPT);
+		generateAcceptableDescription(Concepts.MODULE_ROOT);
+		
+		Expression actual = eval("* {{ dialectId = " + Concepts.REFSET_LANGUAGE_TYPE_UK + " }}");
+		Expression expected = SnomedDocument.Expressions.ids(Set.of(Concepts.ROOT_CONCEPT, Concepts.MODULE_ROOT));
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void dialectIdAnyAcceptabilityNotEquals() throws Exception {
+		generatePreferredDescription(Concepts.ROOT_CONCEPT);
+		generateAcceptableDescription(Concepts.MODULE_ROOT);
+		
+		Expression actual = eval("* {{ dialectId != " + Concepts.REFSET_LANGUAGE_TYPE_UK + " }}");
+		Expression expected = SnomedDocument.Expressions.ids(Set.of());
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void dialectIdPreferred() throws Exception {
+		generatePreferredDescription(Concepts.ROOT_CONCEPT);
+		// extra acceptable description on another concept to demonstrate that it won't match
+		generateAcceptableDescription(Concepts.MODULE_ROOT);
+		
+		Expression actual = eval("* {{ dialectId = " + Concepts.REFSET_LANGUAGE_TYPE_UK + " (preferred) }}");
+		Expression expected = SnomedDocument.Expressions.ids(Set.of(Concepts.ROOT_CONCEPT));
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void dialectIdPreferredNotEquals() throws Exception {
+		generatePreferredDescription(Concepts.ROOT_CONCEPT);
+		// extra acceptable description on another concept to demonstrate that it won't match
+		generateAcceptableDescription(Concepts.MODULE_ROOT);
+		
+		Expression actual = eval("* {{ dialectId != " + Concepts.REFSET_LANGUAGE_TYPE_UK + " (preferred) }}");
+		Expression expected = SnomedDocument.Expressions.ids(Set.of(Concepts.MODULE_ROOT));
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void dialectIdAcceptable() throws Exception {
+		generateAcceptableDescription(Concepts.ROOT_CONCEPT);
+		// extra preferred description on another concept to demonstrate that it won't match
+		generatePreferredDescription(Concepts.MODULE_ROOT);
+		
+		Expression actual = eval("* {{ dialectId = " + Concepts.REFSET_LANGUAGE_TYPE_UK + " (acceptable) }}");
+		Expression expected = SnomedDocument.Expressions.ids(Set.of(Concepts.ROOT_CONCEPT));
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void dialectIdAcceptableNotEquals() throws Exception {
+		generateAcceptableDescription(Concepts.ROOT_CONCEPT);
+		// extra preferred description on another concept to demonstrate that it won't match
+		generatePreferredDescription(Concepts.MODULE_ROOT);
+		
+		Expression actual = eval("* {{ dialectId != " + Concepts.REFSET_LANGUAGE_TYPE_UK + " (acceptable) }}");
+		Expression expected = SnomedDocument.Expressions.ids(Set.of(Concepts.MODULE_ROOT));
+		assertEquals(expected, actual);
+	}
+	
+	private void generatePreferredDescription(String conceptId) {
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+				.id(generateDescriptionId())
+				.active(true)
+				.moduleId(Concepts.MODULE_SCT_CORE)
+				.term("Clinical finding")
+				.conceptId(conceptId)
+				.typeId(Concepts.TEXT_DEFINITION)
+				.languageCode("en")
+				.caseSignificanceId(Concepts.ENTIRE_TERM_CASE_INSENSITIVE)
+				.acceptabilityMap(Map.of(
+					Concepts.REFSET_LANGUAGE_TYPE_UK, Acceptability.PREFERRED
+				))
+				.build());
+	}
+	
+	private void generateAcceptableDescription(String conceptId) {
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+				.id(generateDescriptionId())
+				.active(true)
+				.moduleId(Concepts.MODULE_SCT_CORE)
+				.term("Clinical finding")
+				.conceptId(conceptId)
+				.typeId(Concepts.TEXT_DEFINITION)
+				.languageCode("en")
+				.caseSignificanceId(Concepts.ENTIRE_TERM_CASE_INSENSITIVE)
+				.acceptabilityMap(Map.of(
+					Concepts.REFSET_LANGUAGE_TYPE_UK, Acceptability.ACCEPTABLE
+				))
+				.build());
+	}
+	
+}

--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequestTest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequestTest.java
@@ -168,6 +168,20 @@ public class SnomedEclEvaluationRequestTest extends BaseSnomedEclEvaluationReque
 	}
 	
 	@Test
+	public void descendantOfAny() throws Exception {
+		// special case that converts to a negated parent query 
+		final Expression actual = eval("<*");
+		final Expression expected;
+		if (isInferred()) {
+			expected = Expressions.builder().mustNot(parents(Collections.singleton(IComponent.ROOT_ID))).build();
+		} else {
+			expected = Expressions.builder().mustNot(statedParents(Collections.singleton(IComponent.ROOT_ID))).build();
+			
+		}
+		assertEquals(expected, actual);
+	}
+	
+	@Test
 	public void descendantOrSelfOf() throws Exception {
 		final Expression actual = eval("<<"+ROOT_ID);
 		Expression expected;
@@ -211,6 +225,12 @@ public class SnomedEclEvaluationRequestTest extends BaseSnomedEclEvaluationReque
 	}
 	
 	@Test
+	public void descendantOrSelfAny() throws Exception {
+		final Expression actual = eval("<< *");
+		assertEquals(Expressions.matchAll(), actual);
+	}
+	
+	@Test
 	public void childOf() throws Exception {
 		final Expression actual = eval("<!"+ROOT_ID);
 		Expression expected; 
@@ -218,6 +238,19 @@ public class SnomedEclEvaluationRequestTest extends BaseSnomedEclEvaluationReque
 			expected = parents(Collections.singleton(ROOT_ID));
 		} else {
 			expected = statedParents(Collections.singleton(ROOT_ID));
+			
+		}
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void childOfAny() throws Exception {
+		final Expression actual = eval("<!*");
+		Expression expected; 
+		if (isInferred()) {
+			expected = Expressions.builder().mustNot(parents(Collections.singleton(IComponent.ROOT_ID))).build();
+		} else {
+			expected = Expressions.builder().mustNot(statedParents(Collections.singleton(IComponent.ROOT_ID))).build();
 			
 		}
 		assertEquals(expected, actual);
@@ -240,6 +273,12 @@ public class SnomedEclEvaluationRequestTest extends BaseSnomedEclEvaluationReque
 			.build(), 
 			actual
 		);
+	}
+	
+	@Test
+	public void childOrSelfOfAny() throws Exception {
+		final Expression actual = eval("<<! *");
+		assertEquals(Expressions.matchAll(), actual);
 	}
 	
 	@Test
@@ -292,6 +331,12 @@ public class SnomedEclEvaluationRequestTest extends BaseSnomedEclEvaluationReque
 		final Expression actual = eval(">>"+Concepts.MODULE_SCT_CORE);
 		final Expression expected = ids(Set.of(Concepts.ROOT_CONCEPT, Concepts.MODULE_ROOT, Concepts.MODULE_SCT_CORE));
 		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void ancestorOrSelfOfAny() throws Exception {
+		final Expression actual = eval(">> *");
+		assertEquals(Expressions.matchAll(), actual);
 	}
 	
 	@Test

--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/datastore/AllSnomedDatastoreTests.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/datastore/AllSnomedDatastoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,26 +19,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.b2international.snowowl.snomed.core.ecl.SnomedEclEvaluationRequestTest;
-import com.b2international.snowowl.snomed.core.ecl.SnomedEclLabelerRequestTest;
-import com.b2international.snowowl.snomed.core.ecl.SnomedEclRewriterTest;
-import com.b2international.snowowl.snomed.core.ecl.SnomedEclShortcutTest;
-import com.b2international.snowowl.snomed.core.ecl.SnomedStatedEclEvaluationTest;
+import com.b2international.snowowl.snomed.core.ecl.*;
 import com.b2international.snowowl.snomed.core.tree.TerminologyTreeTest;
 import com.b2international.snowowl.snomed.datastore.id.memory.DefaultSnomedIdentifierServiceRegressionTest;
 import com.b2international.snowowl.snomed.datastore.id.memory.DefaultSnomedIdentifierServiceTest;
-import com.b2international.snowowl.snomed.datastore.index.change.ConceptChangeProcessorAxiomTest;
-import com.b2international.snowowl.snomed.datastore.index.change.ConceptIconIdUpdaterTest;
-import com.b2international.snowowl.snomed.datastore.index.change.DescriptionChangeProcessorTest;
-import com.b2international.snowowl.snomed.datastore.index.change.PreferredDescriptionPreCommitHookTest;
-import com.b2international.snowowl.snomed.datastore.index.change.RelationshipChangeProcessorTest;
-import com.b2international.snowowl.snomed.datastore.index.change.TaxonomyPreCommitHookTest;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocumentSerializationTest;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocumentTermSortTest;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConstraintDocumentSerializationTest;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedDescriptionIndexEntrySerializationTest;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedRefSetMemberDocumentSerializationTest;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedRelationshipIndexEntrySerializationTest;
+import com.b2international.snowowl.snomed.datastore.index.change.*;
+import com.b2international.snowowl.snomed.datastore.index.entry.*;
 import com.b2international.snowowl.snomed.datastore.internal.id.SnomedIdentifierTest;
 import com.b2international.snowowl.snomed.datastore.internal.id.reservations.ReservationImplTest;
 import com.b2international.snowowl.snomed.datastore.internal.id.reservations.SnomedIdentifierReservationServiceImplTest;
@@ -72,6 +58,7 @@ import com.b2international.snowowl.snomed.validation.SnomedQueryValidationRuleEv
 	ConceptIconIdUpdaterTest.class,
 	// ECL test cases
 	SnomedEclEvaluationRequestTest.class,
+	SnomedEclEvaluationRequestPropertyFilterTest.class,
 	SnomedStatedEclEvaluationTest.class,
 	SnomedEclRewriterTest.class,
 	SnomedEclLabelerRequestTest.class,


### PR DESCRIPTION
Use the current `CodeSystem.settings.languages` configuration key to detect known dialect aliases and convert them to a set of language reference set IDs.