### PR TITLE
SNRAY-124: Search concepts by membership

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptSearchApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptSearchApiTest.java
@@ -16,10 +16,16 @@
 package com.b2international.snowowl.snomed.core.rest.components;
 
 import static com.b2international.snowowl.snomed.core.rest.SnomedApiTestConstants.UK_PREFERRED_MAP;
+import static com.b2international.snowowl.snomed.core.rest.SnomedComponentRestRequests.updateComponent;
+import static com.b2international.snowowl.snomed.core.rest.SnomedRestFixtures.createNewDescription;
+import static com.b2international.snowowl.snomed.core.rest.SnomedRestFixtures.createNewRefSet;
+import static com.b2international.snowowl.snomed.core.rest.SnomedRestFixtures.createNewRefSetMember;
+import static com.b2international.snowowl.snomed.core.rest.SnomedRestFixtures.createNewConcept;
 import static com.b2international.snowowl.test.commons.rest.RestExtensions.JSON_UTF8;
 import static com.b2international.snowowl.test.commons.rest.RestExtensions.givenAuthenticatedRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
@@ -27,8 +33,9 @@ import org.junit.Test;
 import com.b2international.commons.json.Json;
 import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
 import com.b2international.snowowl.snomed.core.domain.SnomedConcepts;
+import com.b2international.snowowl.snomed.core.domain.refset.SnomedRefSetType;
 import com.b2international.snowowl.snomed.core.rest.AbstractSnomedApiTest;
-import com.b2international.snowowl.snomed.core.rest.SnomedRestFixtures;
+import com.b2international.snowowl.snomed.core.rest.SnomedComponentType;
 
 /**
  * @since 8.0.0
@@ -37,8 +44,8 @@ public class SnomedConceptSearchApiTest extends AbstractSnomedApiTest {
 	
 	@Test
 	public void searchBySemanticTag() throws Exception {
-		String conceptId = createConcept(branchPath, SnomedRestFixtures.createConceptRequestBody(Concepts.ROOT_CONCEPT));
-		SnomedRestFixtures.createNewDescription(branchPath, Json.object(
+		String conceptId = createNewConcept(branchPath, Concepts.ROOT_CONCEPT);
+		createNewDescription(branchPath, Json.object(
 			"conceptId", conceptId,
 			"moduleId", Concepts.MODULE_SCT_CORE,
 			"typeId", Concepts.FULLY_SPECIFIED_NAME,
@@ -64,8 +71,8 @@ public class SnomedConceptSearchApiTest extends AbstractSnomedApiTest {
 	 */
 	@Test
 	public void searchByBothSemanticTagAndTerm() throws Exception {
-		String conceptId = createConcept(branchPath, SnomedRestFixtures.createConceptRequestBody(Concepts.ROOT_CONCEPT));
-		SnomedRestFixtures.createNewDescription(branchPath, Json.object(
+		String conceptId = createNewConcept(branchPath, Concepts.ROOT_CONCEPT);
+		createNewDescription(branchPath, Json.object(
 			"conceptId", conceptId,
 			"moduleId", Concepts.MODULE_SCT_CORE,
 			"typeId", Concepts.FULLY_SPECIFIED_NAME,
@@ -75,7 +82,7 @@ public class SnomedConceptSearchApiTest extends AbstractSnomedApiTest {
 			"caseSignificanceId", Concepts.ENTIRE_TERM_CASE_INSENSITIVE,
 			"commitComment", "New FSN"
 		));
-		SnomedRestFixtures.createNewDescription(branchPath, Json.object(
+		createNewDescription(branchPath, Json.object(
 			"conceptId", conceptId,
 			"moduleId", Concepts.MODULE_SCT_CORE,
 			"typeId", Concepts.FULLY_SPECIFIED_NAME,
@@ -98,5 +105,33 @@ public class SnomedConceptSearchApiTest extends AbstractSnomedApiTest {
 			.extract().as(SnomedConcepts.class);
 		assertThat(hits.getTotal()).isEqualTo(1);
 	}
-	
+
+	@Test
+	public void searchByMembership() throws Exception {
+		String conceptId1 = createNewConcept(branchPath, Concepts.ROOT_CONCEPT);
+		String conceptId2 = createNewConcept(branchPath, Concepts.ROOT_CONCEPT);
+		String refSetId = createNewRefSet(branchPath, SnomedRefSetType.SIMPLE);
+		String memberId1 = createNewRefSetMember(branchPath, conceptId1, refSetId); 
+		createNewRefSetMember(branchPath, conceptId2, refSetId);
+		
+		updateComponent(
+			branchPath, 
+			SnomedComponentType.MEMBER, 
+			memberId1, 
+			Json.object(
+				"active", false,
+				"commitComment", "Inactivated reference set member"
+			)
+		).statusCode(204);
+		
+		SnomedConcepts hits = givenAuthenticatedRequest(getApiBaseUrl())
+			.accept(JSON_UTF8)
+			.queryParams(Map.of("isActiveMemberOf", List.of(refSetId)))
+			.get("/{path}/concepts/", branchPath.getPath())
+			.then().assertThat()
+			.statusCode(200)
+			.extract().as(SnomedConcepts.class);
+
+		assertThat(hits.getTotal()).isEqualTo(1);
+	}
 }

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedConceptRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedConceptRestService.java
@@ -115,6 +115,7 @@ public class SnomedConceptRestService extends AbstractRestService {
 					.filterByDescriptionLanguageRefSet(acceptLanguage)
 					.filterByDescriptionType(params.getDescriptionType())
 					.filterBySemanticTags(params.getSemanticTag())
+					.isActiveMemberOf(params.getIsActiveMemberOf())
 					.withDoi(params.getDoi())
 					.setExpand(params.getExpand())
 					.setFields(params.getField())

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/domain/SnomedConceptRestSearch.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/domain/SnomedConceptRestSearch.java
@@ -27,6 +27,9 @@ public final class SnomedConceptRestSearch extends SnomedComponentRestSearch {
 	@Parameter(description = "The definition status to match")
 	private String definitionStatus;
 
+	@Parameter(description = "Matches should be active members of the following reference set(s)")
+	private List<String> isActiveMemberOf;
+	
 	// query expressions
 	@Parameter(description = "The ECL expression to match on the inferred form")
 	private String ecl;
@@ -50,6 +53,7 @@ public final class SnomedConceptRestSearch extends SnomedComponentRestSearch {
 	private List<String> statedParent;
 	@Parameter(description = "The stated ancestor(s) to match")
 	private List<String> statedAncestor;
+
 	@Parameter(description = "doi (degree-of-interest-based scoring)")
 	private Boolean doi = null;
 
@@ -59,6 +63,14 @@ public final class SnomedConceptRestSearch extends SnomedComponentRestSearch {
 
 	public void setDefinitionStatus(String definitionStatus) {
 		this.definitionStatus = definitionStatus;
+	}
+	
+	public List<String> getIsActiveMemberOf() {
+		return isActiveMemberOf;
+	}
+	
+	public void setIsActiveMemberOf(List<String> isActiveMemberOf) {
+		this.isActiveMemberOf = isActiveMemberOf;
 	}
 
 	public List<String> getParent() {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/ReferringMemberChangeProcessor.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/ReferringMemberChangeProcessor.java
@@ -71,7 +71,7 @@ final class ReferringMemberChangeProcessor {
 	}
 	
 	private boolean byReferencedComponentType(SnomedRefSetMemberIndexEntry member) {
-		return referencedComponentType == member.getReferencedComponentType();
+		return referencedComponentType.equals(member.getReferencedComponentType());
 	}
 
 	private void addChange(final Multimap<String, RefSetMemberChange> memberChanges, SnomedRefSetMemberIndexEntry member, MemberChangeKind changeKind) {


### PR DESCRIPTION
This PR adds a new concept search property named `isActiveMemberOf`; matching concepts should have at least one active member referring to them in any of the listed reference sets.