### PR TITLE
SNRAY-315: Add support for resource URIs with timestamp part

### DIFF
--- a/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/uri/ResourceURITest.java
+++ b/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/uri/ResourceURITest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import com.b2international.commons.exceptions.BadRequestException;
 import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.codesystem.CodeSystem;
 
@@ -62,4 +63,16 @@ public class ResourceURITest {
 		assertEquals("a/b", uri.getPath());
 	}
 	
+	@Test
+	public void timestampPart() throws Exception {
+		final ResourceURI uri = CodeSystem.uri("SNOMEDCT-EXT/a/b@1234567890");
+		assertEquals("SNOMEDCT-EXT", uri.getResourceId());
+		assertEquals("a/b", uri.getPath());
+		assertEquals("@1234567890", uri.getTimestampPart());
+	}
+	
+	@Test(expected = BadRequestException.class)
+	public void timestampPartValidation() throws Exception {
+		CodeSystem.uri("SNOMEDCT-EXT/a/b@yesterday");
+	}
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ResourceURI.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ResourceURI.java
@@ -40,7 +40,7 @@ public final class ResourceURI implements Serializable, Comparable<ResourceURI> 
 	private static final long serialVersionUID = 1L;
 
 	@JsonIgnore
-	private static final Pattern URI_PATTERN = Pattern.compile("^([^\\/]+)[\\/]{1}([^\\/]+)(([\\/]{1}[^\\/\\s]+)*)$");
+	private static final Pattern URI_PATTERN = Pattern.compile("^([^\\/]+)[\\/]{1}([^\\/]+)(([\\/]{1}[^\\/\\s@]+)*)(@[^\\s]+)?$");
 	
 	/**
 	 * Special path key, that represents the latest released version of a code system.
@@ -70,6 +70,9 @@ public final class ResourceURI implements Serializable, Comparable<ResourceURI> 
 	// relative location or version of the resource
 	private final String path;
 	
+	// timestamp part as String, for point-in-time resource URIs
+	private final String timestampPart;
+	
 	@JsonCreator
 	public ResourceURI(String uri) throws BadRequestException {
 		if (Strings.isNullOrEmpty(uri)) {
@@ -85,10 +88,25 @@ public final class ResourceURI implements Serializable, Comparable<ResourceURI> 
 			throw new BadRequestException("Malformed Resource URI value: '%s' must be in format '<resourceType>/<resourceId>/<path>'.", uri);
 		}
 		// ignore HEAD in path part by automatically removing it from the uri
-		this.uri = uri.replaceAll("/HEAD", ""); 
+		this.uri = uri.replaceFirst("/HEAD", ""); 
 		this.resourceType = matcher.group(1);
 		this.resourceId = matcher.group(2);
-		this.path = CompareUtils.isEmpty(matcher.group(3)) ? HEAD : matcher.group(3).substring(1); // removes the leading slash character
+		// remove leading slash from match
+		this.path = CompareUtils.isEmpty(matcher.group(3)) ? HEAD : matcher.group(3).substring(1);
+		
+		try {
+
+			if (CompareUtils.isEmpty(matcher.group(5))) {
+				this.timestampPart = "";
+			} else {
+				// test that a valid numeric value was given after the 'at' symbol
+				Long.parseLong(matcher.group(5).substring(1));
+				this.timestampPart = matcher.group(5);
+			}
+			
+		} catch (NumberFormatException e) {
+			throw new BadRequestException("Malformed Resource URI value: timestamp part of '%s' must be in format '@<numeric value>", uri);
+		}
 	}
 	
 	public String getUri() {
@@ -107,6 +125,10 @@ public final class ResourceURI implements Serializable, Comparable<ResourceURI> 
 		return path;
 	}
 	
+	public String getTimestampPart() {
+		return timestampPart;
+	}
+	
 	public boolean isLatest() {
 		return LATEST.equals(getPath());
 	}
@@ -122,7 +144,12 @@ public final class ResourceURI implements Serializable, Comparable<ResourceURI> 
 	public ResourceURI withPath(String path) {
 		return Strings.isNullOrEmpty(path) ? ResourceURI.of(resourceType, resourceId) : ResourceURI.branch(resourceType, resourceId, path);
 	}
-	
+
+	@JsonIgnore
+	public ResourceURI withTimestampPart(String timestampPart) {
+		return withPath(getPath() + timestampPart);
+	}
+
 	@JsonIgnore
 	public ResourceURI withoutPath() {
 		return new ResourceURI(String.join(Branch.SEPARATOR, resourceType, resourceId));
@@ -132,7 +159,7 @@ public final class ResourceURI implements Serializable, Comparable<ResourceURI> 
 	public String withoutResourceType() {
 		return isHead() ? resourceId : String.join(Branch.SEPARATOR, resourceId, path);
 	}
-	
+
 	public ResourceURI asLatest() {
 		return ResourceURI.latest(resourceType, resourceId);
 	}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ResourceURI.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ResourceURI.java
@@ -40,7 +40,7 @@ public final class ResourceURI implements Serializable, Comparable<ResourceURI> 
 	private static final long serialVersionUID = 1L;
 
 	@JsonIgnore
-	private static final Pattern URI_PATTERN = Pattern.compile("^([^\\/]+)[\\/]{1}([^\\/]+)(([\\/]{1}[^\\/\\s@]+)*)(@[^\\s]+)?$");
+	private static final Pattern URI_PATTERN = Pattern.compile("^([^\\/]+)[\\/]{1}([^\\/@]+)(([\\/]{1}[^\\/\\s@]+)*)(@[^\\s]+)?$");
 	
 	/**
 	 * Special path key, that represents the latest released version of a code system.

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/context/TerminologyResourceRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/context/TerminologyResourceRequest.java
@@ -98,8 +98,11 @@ public final class TerminologyResourceRequest<R> extends DelegatingRequest<Servi
 				throw new NotFoundException("Terminology Resource", referenceResourceUri.getResourceId());
 			}
 			this.resource = (TerminologyResource) resource;
-			this.resourceUri = this.resource.getResourceURI().withPath(referenceResourceUri.getPath());
-			this.branchPath = context.service(ResourceURIPathResolver.class).resolve(context, referenceResourceUri, resource);
+			this.resourceUri = this.resource.getResourceURI()
+				.withPath(referenceResourceUri.getPath())
+				.withTimestampPart(referenceResourceUri.getTimestampPart());
+			this.branchPath = context.service(ResourceURIPathResolver.class)
+				.resolve(context, referenceResourceUri, resource);
 		}		
 	}
 

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/uri/DefaultResourceURIPathResolver.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/uri/DefaultResourceURIPathResolver.java
@@ -68,12 +68,15 @@ public final class DefaultResourceURIPathResolver implements ResourceURIPathReso
 			TerminologyResource terminologyResource = (TerminologyResource) resource;
 			if (uriToResolve.isHead()) {
 				// use code system working branch directly when HEAD is specified
-				return new PathWithVersion(terminologyResource.getBranchPath());
+				final String workingBranchPath = terminologyResource.getBranchPath() + uriToResolve.getTimestampPart();
+				return new PathWithVersion(workingBranchPath);
 			}
 			
 			// prevent running version search if path does not look like a versionId (single path segment)
+			final String relativeBranchPath = terminologyResource.getRelativeBranchPath(uriToResolve.getPath());
 			if (uriToResolve.getPath().contains(Branch.SEPARATOR)) {
-				return new PathWithVersion(terminologyResource.getRelativeBranchPath(uriToResolve.getPath()));
+				final String absoluteBranchPath = relativeBranchPath + uriToResolve.getTimestampPart();
+				return new PathWithVersion(absoluteBranchPath);
 			}
 				
 			VersionSearchRequestBuilder versionSearch = ResourceRequests.prepareSearchVersion()
@@ -89,20 +92,23 @@ public final class DefaultResourceURIPathResolver implements ResourceURIPathReso
 			}
 			
 			// determine the final branch path, if based on the version search we find a version, then use that, otherwise use the defined path as relative branch of the code system working branch
-			Versions versions = versionSearch
-				.buildAsync()
+			Versions versions = versionSearch.buildAsync()
 				.getRequest()
 				.execute(context);
 			
 			return versions.first()
-				.map(v -> new PathWithVersion(v.getBranchPath(), v.getVersionResourceURI()))
+				.map(v -> {
+					final String versionBranchPath = v.getBranchPath() + uriToResolve.getTimestampPart();
+					final ResourceURI versionResourceURI = v.getVersionResourceURI().withTimestampPart(uriToResolve.getTimestampPart());
+					return new PathWithVersion(versionBranchPath, versionResourceURI);
+				})
 				.orElseGet(() -> {
 					if (uriToResolve.isLatest() || !allowBranches) {
 						throw new BadRequestException("No Resource version is present in '%s'. Explicit '%s' can be used to retrieve the latest work in progress version of the Resource.", 
 							terminologyResource.getId(), terminologyResource.getId());
 					}
 					
-					return new PathWithVersion(terminologyResource.getRelativeBranchPath(uriToResolve.getPath())); 
+					return new PathWithVersion(relativeBranchPath); 
 				});
 		}
 		

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/io/SnomedExportApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/io/SnomedExportApiTest.java
@@ -54,6 +54,7 @@ import com.b2international.commons.Pair;
 import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.commons.json.Json;
 import com.b2international.snowowl.core.ApplicationContext;
+import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.api.IBranchPath;
 import com.b2international.snowowl.core.attachments.Attachment;
 import com.b2international.snowowl.core.attachments.AttachmentRegistry;
@@ -63,6 +64,7 @@ import com.b2international.snowowl.core.codesystem.CodeSystem;
 import com.b2international.snowowl.core.date.DateFormats;
 import com.b2international.snowowl.core.date.EffectiveTimes;
 import com.b2international.snowowl.core.events.util.Promise;
+import com.b2international.snowowl.core.request.CommitResult;
 import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
 import com.b2international.snowowl.snomed.common.SnomedRf2Headers;
 import com.b2international.snowowl.snomed.core.domain.*;
@@ -73,6 +75,7 @@ import com.b2international.snowowl.snomed.core.rest.SnomedApiTestConstants;
 import com.b2international.snowowl.snomed.core.rest.SnomedComponentType;
 import com.b2international.snowowl.snomed.datastore.request.SnomedRequests;
 import com.b2international.snowowl.test.commons.codesystem.CodeSystemRestRequests;
+import com.b2international.snowowl.test.commons.rest.RestExtensions;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -1412,6 +1415,81 @@ public class SnomedExportApiTest extends AbstractSnomedApiTest {
 			
 		assertArchiveContainsFiles(exportArchive, files);
 		
+	}
+	
+	@Test
+	public void exportDeltaWithBranchPoint() throws Exception {
+		
+		String codeSystemId = "SNOMEDCT-delta-with-branch-at";
+		createCodeSystem(branchPath, codeSystemId).statusCode(201);
+		
+		final Map<String, Object> config = Map.of("type", Rf2ReleaseType.DELTA.name());
+		export(codeSystemId + "@1234567", config).then()
+			.statusCode(400);
+	}
+	
+	@Test
+	public void exportSnapshotWithBranchPoint() throws Exception {
+		
+		final String codeSystemId = "SNOMEDCT-snapshot-with-branch-at";
+		createCodeSystem(branchPath, codeSystemId).statusCode(201);
+		
+		final CommitResult commitResult = SnomedRequests.prepareCommit()
+			.setBody(SnomedRequests.prepareNewRelationship()
+				.setId(new NamespaceIdStrategy(""))
+				.setActive(true)
+				.setCharacteristicTypeId(Concepts.INFERRED_RELATIONSHIP)
+				.setDestinationId(Concepts.ROOT_CONCEPT)
+				.setModifierId(Concepts.EXISTENTIAL_RESTRICTION_MODIFIER)
+				.setModuleId(Concepts.MODULE_SCT_CORE)
+				.setRelationshipGroup(0)
+				.setSourceId(Concepts.ACCEPTABILITY)
+				.setTypeId(Concepts.IS_A)
+				.setUnionGroup(0))
+			.setCommitComment("Created new relationship")
+			.setAuthor(RestExtensions.USER)
+			.build(ResourceURI.of(CodeSystem.RESOURCE_TYPE, codeSystemId))
+			.execute(getBus())
+			.getSync(1L, TimeUnit.MINUTES);
+		
+		final long timestamp = commitResult.getCommitTimestamp() - 1L;
+		final String relationshipId = commitResult.getResultAs(String.class);
+		
+		// id, effectiveTime, active, moduleId, sourceId, destinationId, relationshipGroup, typeId, characteristicTypeId, modifierId
+		final String relationshipLine = getComponentLine(List.of(
+			relationshipId, 
+			"", 
+			"1", 
+			Concepts.MODULE_SCT_CORE, 
+			Concepts.ACCEPTABILITY, 
+			Concepts.ROOT_CONCEPT, 
+			"0", 
+			Concepts.IS_A, 
+			Concepts.INFERRED_RELATIONSHIP, 
+			Concepts.EXISTENTIAL_RESTRICTION_MODIFIER));
+		
+		final Map<String, Object> config = Map.of(
+			"type", Rf2ReleaseType.SNAPSHOT.name(),
+			"includeUnpublished", true
+		);
+		
+		final File exportArchive = doExport(codeSystemId, config);
+		
+		final String relationshipFileName = "sct2_Relationship_Snapshot";
+		final Multimap<String, Pair<Boolean, String>> fileToLinesMap = ArrayListMultimap.<String, Pair<Boolean, String>>create();
+		fileToLinesMap.put(relationshipFileName, Pair.of(true, relationshipLine));
+		
+		assertArchiveContainsLines(exportArchive, fileToLinesMap);
+		
+		/* 
+		 * A snapshot export with a timestamp set before creating the relationship should result in the relationship
+		 * not appearing in the export file.
+		 */
+		final File exportArchiveWithTimestamp = doExport(codeSystemId + "@" + timestamp, config);
+		fileToLinesMap.clear();
+		fileToLinesMap.put(relationshipFileName, Pair.of(false, relationshipLine));
+		
+		assertArchiveContainsLines(exportArchiveWithTimestamp, fileToLinesMap);
 	}
 	
 	private static String getLanguageRefsetMemberId(IBranchPath branchPath, String descriptionId, String languageRefsetId) {


### PR DESCRIPTION
The format changes to `{type}/{name}[/{path}][@{timestamp}]`, where both `path` and `timestamp` are optional. The timestamp should be a valid 64-bit value. Resource names and paths may not contain any 'at' characters.