### PR TITLE
SO-4942: Support delta RF2 exports with branch path range

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/SnomedRf2ExportRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/SnomedRf2ExportRequest.java
@@ -306,7 +306,7 @@ final class SnomedRf2ExportRequest extends ResourceRequest<BranchContext, Attach
 				// If a point-in-time branch path was given, use the timestamp information from it
 				final String referenceBranchToExport = referenceBranch.contains(RevisionIndex.AT_CHAR) 
 						? referenceBranch
-						: String.format("%s%s%s", referenceBranch, RevisionIndex.AT_CHAR, exportStartTime);
+						: RevisionIndex.toBranchAtPath(referenceBranch, exportStartTime);
 				
 				exportBranch(releaseDirectory, 
 						context, 
@@ -536,7 +536,10 @@ final class SnomedRf2ExportRequest extends ResourceRequest<BranchContext, Attach
 	private TreeSet<CodeSystemVersion> getAllExportableCodeSystemVersions(final BranchContext context, final CodeSystem codeSystemEntry) {
 		final String referenceBranch = context.path();
 		final TreeSet<CodeSystemVersion> visibleVersions = newTreeSet(EFFECTIVE_DATE_ORDERING);
-		collectExportableCodeSystemVersions(context, visibleVersions, codeSystemEntry, referenceBranch);
+		// XXX: Versions do not need to be calculated for snapshot exports, it is always done from the reference branch itself
+		if (Rf2ReleaseType.SNAPSHOT != releaseType) {
+			collectExportableCodeSystemVersions(context, visibleVersions, codeSystemEntry, referenceBranch);
+		}
 		return visibleVersions;
 	}
 

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/SnomedRf2ExportRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/SnomedRf2ExportRequest.java
@@ -50,6 +50,7 @@ import javax.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import com.b2international.commons.FileUtils;
+import com.b2international.commons.exceptions.BadRequestException;
 import com.b2international.index.revision.RevisionIndex;
 import com.b2international.snowowl.core.api.SnowowlRuntimeException;
 import com.b2international.snowowl.core.attachments.Attachment;
@@ -245,6 +246,9 @@ final class SnomedRf2ExportRequest extends ResourceRequest<BranchContext, Attach
 	@Override
 	public Attachment execute(final BranchContext context) {
 		final String referenceBranch = context.path();
+		if (referenceBranch.contains(RevisionIndex.AT_CHAR) && !Rf2ReleaseType.SNAPSHOT.equals(releaseType)) {
+			throw new BadRequestException("Only snapshot export is allowed for point-in-time branch path '%s'.", referenceBranch);
+		}
 		
 		// register export start time for later use
 		final long exportStartTime = Instant.now().toEpochMilli();
@@ -298,7 +302,12 @@ final class SnomedRf2ExportRequest extends ResourceRequest<BranchContext, Attach
 			
 			// export content from reference branch
 			if (includePreReleaseContent) {
-				final String referenceBranchToExport = String.format("%s%s%s", referenceBranch, RevisionIndex.AT_CHAR, exportStartTime);
+				
+				// If a point-in-time branch path was given, use the timestamp information from it
+				final String referenceBranchToExport = referenceBranch.contains(RevisionIndex.AT_CHAR) 
+						? referenceBranch
+						: String.format("%s%s%s", referenceBranch, RevisionIndex.AT_CHAR, exportStartTime);
+				
 				exportBranch(releaseDirectory, 
 						context, 
 						referenceBranchToExport, 


### PR DESCRIPTION
(Also includes changes from 8.x, where support for snapshot exports using branch paths with a timestamp were introduced.)