### PR TITLE
SO-4943: Duplicate revision after synchronizing existing upgrade branch (8.x)

### DIFF
--- a/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranch.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranch.java
@@ -394,7 +394,7 @@ public final class RevisionBranch extends MetadataHolderImpl {
     	
     	// add all remaining merge sources to the visible segment list
     	latestMergeSources.values().forEach(latestMergeSource -> {
-    		// TODO start timestamp???
+    		// start timestamp is intentionally zero here, because the branchId itself is enough to select content that happened on the branch until the mergeSource timestamp
     		visibleSegments.add(new RevisionSegment(latestMergeSource.getBranchId(), 0L, latestMergeSource.getTimestamp()));
     	});
     	

--- a/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
@@ -1075,7 +1075,8 @@ public final class StagingArea {
 			
 				for (String updatedId : updatedRevisionsById.keySet()) {
 					if (oldRevisionsById.containsKey(updatedId)) {
-						stageChange(oldRevisionsById.get(updatedId), updatedRevisionsById.get(updatedId), squash);
+						// actual changed revisions should always register themselves for commit if there is a revision on the target
+						stageChange(oldRevisionsById.get(updatedId), updatedRevisionsById.get(updatedId), true);
 					} else {
 						stageNew(updatedRevisionsById.get(updatedId), squash);
 					}
@@ -1098,7 +1099,8 @@ public final class StagingArea {
 				
 				newRevisions.forEach(rev -> {
 					if (oldRevisionsById.containsKey(rev.getId())) {
-						stageChange(oldRevisionsById.get(rev.getId()), rev, squash);
+						// actual changed revisions should always register themselves for commit if there is a revision on the target 
+						stageChange(oldRevisionsById.get(rev.getId()), rev, true); 
 					} else {
 						stageNew(rev, squash);
 					}

--- a/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
@@ -883,13 +883,13 @@ public final class StagingArea {
 		applyPropertyUpdates(toRef, propertyUpdatesToApply);
 		
 		// apply new objects
-		applyNewObjects(added, fromRef, toRef, squash);
+		applyNewObjects(added, mergeFromBranchRef, toRef, squash);
 		
 		// apply changed objects
-		applyChangedObjects(changed, fromRef, toRef, squash);
+		applyChangedObjects(changed, mergeFromBranchRef, toRef, squash);
 		
 		// always apply deleted objects, they set the revised timestamp properly without introducing any new document
-		applyRemovedObjects(removed, fromRef, toRef, squash);
+		applyRemovedObjects(removed, mergeFromBranchRef, toRef, squash);
 		
 		// any externally marked revised revisions should be applied here
 		revisionsToReviseOnMergeSource.putAll(externalRevisionsToReviseOnMergeSource);

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/AbstractSnomedApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/AbstractSnomedApiTest.java
@@ -155,7 +155,7 @@ public abstract class AbstractSnomedApiTest extends AbstractApiTest {
 	}
 	
 	protected final ValidatableResponse assertUpdateRelationship(final String path, final String relationshipId, Map<String, Object> update) {
-		return SnomedComponentRestRequests.updateComponent(branchPath, SnomedComponentType.RELATIONSHIP, relationshipId, update);
+		return SnomedComponentRestRequests.updateComponent(path, SnomedComponentType.RELATIONSHIP, relationshipId, update);
 	}
 	
 	protected final String createConcept(ResourceURI codeSystemURI, Map<String, Object> body) {

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/ext/AbstractSnomedExtensionApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/ext/AbstractSnomedExtensionApiTest.java
@@ -38,6 +38,7 @@ import io.restassured.response.ValidatableResponse;
 public abstract class AbstractSnomedExtensionApiTest extends AbstractSnomedApiTest {
 	
 	protected static final String SNOMEDCT = SnomedContentRule.SNOMEDCT_ID;
+	protected static final ResourceURI SNOMEDCT_URI = SnomedContentRule.SNOMEDCT;
 	protected static final String EXT_BASE_SI_VERSION = "2019-07-31";
 	
 	protected final ResourceURI baseInternationalCodeSystem = SnomedContentRule.SNOMEDCT.withPath(EXT_BASE_SI_VERSION);

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/ext/SnomedExtensionUpgradeTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/ext/SnomedExtensionUpgradeTest.java
@@ -1342,7 +1342,7 @@ public class SnomedExtensionUpgradeTest extends AbstractSnomedExtensionApiTest {
 	}
 	
 	@Test
-	public void upgrade25UpgradeAndSyncOverInactivatedInferredRelationship() throws Exception {
+	public void aupgrade25UpgradeAndSyncOverInactivatedInferredRelationship() throws Exception {
 		// create a new SI parent concept which points to the ROOT and version it
 		String intParentConceptId = createConcept(SNOMEDCT_URI, createConceptRequestBody(Concepts.ROOT_CONCEPT, Concepts.MODULE_SCT_CORE));
 		// also create the inferred relationship, which will be inactivated
@@ -1398,7 +1398,7 @@ public class SnomedExtensionUpgradeTest extends AbstractSnomedExtensionApiTest {
 		assertThat(extensionConceptOnUpgradeAfterSync.getParentIdsAsString())
 			.containsOnly(intParentConceptId);
 		assertThat(extensionConceptOnUpgradeAfterSync.getAncestorIdsAsString())
-			.containsOnly(IComponent.ROOT_ID);
+			.containsOnly(Concepts.ROOT_CONCEPT, IComponent.ROOT_ID);
 		assertThat(extensionConceptOnUpgradeAfterSync.getEffectiveTime())
 			.isEqualTo(firstExtensionVersion);
 		assertThat(extensionConceptOnUpgradeAfterSync.isReleased())


### PR DESCRIPTION
This PR fixes a rare revision duplication issue when performing synchronization on an upgrade branch from the original branch.