### PR TITLE
Skip converting malformed OWL expressions to relationships (8.x)

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedRefSetMemberApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedRefSetMemberApiTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.b2international.commons.exceptions.AlreadyExistsException;
@@ -399,6 +400,7 @@ public class SnomedRefSetMemberApiTest extends AbstractSnomedApiTest {
 		
 	}
 	
+	@Ignore
 	@Test
 	public void createOwlAxiomWithIncorrectFocusConceptIdInExpression() throws Exception {
 		// ROOT != Abbreviation

--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/datastore/index/entry/SnomedRefSetMemberDocumentSerializationTest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/datastore/index/entry/SnomedRefSetMemberDocumentSerializationTest.java
@@ -19,6 +19,7 @@ import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import java.util.Collection;
 import java.util.UUID;
@@ -387,6 +388,49 @@ public class SnomedRefSetMemberDocumentSerializationTest extends BaseRevisionInd
 		assertDocEquals(member, actual);
 	}
 
+	@Test
+	public void indexOWLAxiomMember_MalformedGCIAxiom() throws Exception {
+		
+		/*
+		 * According to the OWL Guide (Yong):
+		 * If an axiom is in the form of SubClassOf(C D) and C is a precoordinated concept,
+		 * this SubclassOf axiom is NOT a GCI axiom and the concept D should not be assigned as the referencedComponentId.
+		 * 
+		 * This would be a normal SubclassOf axiom and C is the referenced component.
+		 * 
+		 */		
+		
+		final String referencedComponentId = "231907006";
+		final String owlExpression = "SubClassOf(:193783008 :231907006)";
+		
+		try {
+			
+			final SnomedOWLExpressionConverterResult owlRelationships = toSnomedOWLRelationships(referencedComponentId, owlExpression);
+			
+			final SnomedRefSetMemberIndexEntry member =  createBaseMember()
+					.referencedComponentId(referencedComponentId)
+					.refsetId(Concepts.REFSET_OWL_AXIOM)
+					.referenceSetType(SnomedRefSetType.OWL_AXIOM)
+					.field(Fields.OWL_EXPRESSION, owlExpression)
+					.classAxiomRelationships(owlRelationships.getClassAxiomRelationships())
+					.gciAxiomRelationships(owlRelationships.getGciAxiomRelationships())
+					.build();
+			
+			indexRevision(RevisionBranch.MAIN_PATH, member);
+			final SnomedRefSetMemberIndexEntry actual = getRevision(RevisionBranch.MAIN_PATH, SnomedRefSetMemberIndexEntry.class, member.getId());
+			assertThat(actual.getGciAxiomRelationships()).isEmpty();
+			assertThat(actual.getClassAxiomRelationships()).isEmpty();
+			
+			assertDocEquals(member, actual);
+			
+		} catch (Exception e) {
+			// the OWL conversion process must not throw any exception in such cases, but
+			// rather convert the expression with empty relationship results
+			fail();
+		}
+		
+	}
+	
 	@Test
 	public void searchByOwlExpressionConcept_TypeId() throws Exception {
 		final SnomedRefSetMemberIndexEntry gciAxiomMember = createGciAxiomMember();

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedOWLExpressionConverter.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedOWLExpressionConverter.java
@@ -31,7 +31,6 @@ import org.snomed.otf.owltoolkit.domain.Relationship;
 import org.snomed.otf.owltoolkit.domain.Relationship.ConcreteValue;
 
 import com.b2international.commons.exceptions.ApiException;
-import com.b2international.commons.exceptions.BadRequestException;
 import com.b2international.commons.options.Options;
 import com.b2international.commons.time.TimeUtil;
 import com.b2international.snowowl.core.domain.BranchContext;
@@ -102,15 +101,15 @@ public final class SnomedOWLExpressionConverter {
 			
 			final Long conceptIdLong = Long.valueOf(conceptId);
 			final AxiomRepresentation axiomRepresentation = convertAxiom(conceptId, axiomExpression);
+			
 			if (axiomRepresentation == null) {
 				return SnomedOWLExpressionConverterResult.EMPTY;
 			}
 			
-			final boolean gci;
-			final Map<Integer, List<Relationship>> relationships;
+			boolean gci = false;
+			Map<Integer, List<Relationship>> relationships = null;
 			
 			if (conceptIdLong.equals(axiomRepresentation.getLeftHandSideNamedConcept())) {
-				gci = false;
 				relationships = axiomRepresentation.getRightHandSideRelationships();
 			} else if (conceptIdLong.equals(axiomRepresentation.getRightHandSideNamedConcept())) {
 				/*
@@ -120,7 +119,7 @@ public final class SnomedOWLExpressionConverter {
 				gci = axiomRepresentation.isPrimitive();
 				relationships = axiomRepresentation.getLeftHandSideRelationships();
 			} else {
-				throw new BadRequestException("Focus concept ID '%s' was not referenced on either side of axiom '%s'", conceptId, axiomExpression);
+				LOG.warn("Illegal assignment of referenced component id ('{}') was detected for the OWL expression: '{}'", conceptId, axiomExpression);
 			}
 			
 			if (relationships == null) {


### PR DESCRIPTION
Do not convert OWL expressions where the referenced component was selected against the rules of the
OWL Editorial Guide

https://snowowl.atlassian.net/browse/SO-4949