### PR TITLE
feat(core): allow fully customizable indices settings in `snowowl.yml` configuration file

### DIFF
--- a/cis/com.b2international.snowowl.snomed.cis/src/com/b2international/snowowl/snomed/cis/SnomedIdentifierPlugin.java
+++ b/cis/com.b2international.snowowl.snomed.cis/src/com/b2international/snowowl/snomed/cis/SnomedIdentifierPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.elasticsearch.core.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +29,7 @@ import com.b2international.index.Index;
 import com.b2international.index.Indexes;
 import com.b2international.index.mapping.Mappings;
 import com.b2international.snowowl.core.config.IndexSettings;
+import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.config.SnowOwlConfiguration;
 import com.b2international.snowowl.core.plugin.Component;
 import com.b2international.snowowl.core.setup.ConfigurationRegistry;
@@ -116,7 +118,12 @@ public final class SnomedIdentifierPlugin extends Plugin {
 
 		switch (conf.getStrategy()) {
 		case EMBEDDED:
-			final Index index = Indexes.createIndex(SNOMED_IDS_INDEX, env.service(ObjectMapper.class), new Mappings(SctId.class), env.service(IndexSettings.class));
+			final Index index = Indexes.createIndex(
+				SNOMED_IDS_INDEX, 
+				env.service(ObjectMapper.class), 
+				new Mappings(SctId.class), 
+				env.service(IndexSettings.class).forIndex(env.service(RepositoryConfiguration.class).getIndexConfiguration(), SNOMED_IDS_INDEX, Map.of())
+			);
 			index.admin().create();
 			final ItemIdGenerationStrategy generationStrategy = new SequentialItemIdGenerationStrategy(reservationService); 
 			identifierService = new DefaultSnomedIdentifierService(index, generationStrategy, reservationService, conf);

--- a/cis/com.b2international.snowowl.snomed.cis/src/com/b2international/snowowl/snomed/cis/SnomedIdentifierPlugin.java
+++ b/cis/com.b2international.snowowl.snomed.cis/src/com/b2international/snowowl/snomed/cis/SnomedIdentifierPlugin.java
@@ -21,7 +21,6 @@ import java.nio.file.Files;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.elasticsearch.core.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,7 +121,7 @@ public final class SnomedIdentifierPlugin extends Plugin {
 				SNOMED_IDS_INDEX, 
 				env.service(ObjectMapper.class), 
 				new Mappings(SctId.class), 
-				env.service(IndexSettings.class).forIndex(env.service(RepositoryConfiguration.class).getIndexConfiguration(), SNOMED_IDS_INDEX, Map.of())
+				env.service(IndexSettings.class).forIndex(env.service(RepositoryConfiguration.class).getIndexConfiguration(), SNOMED_IDS_INDEX)
 			);
 			index.admin().create();
 			final ItemIdGenerationStrategy generationStrategy = new SequentialItemIdGenerationStrategy(reservationService); 

--- a/commons/com.b2international.index/src/com/b2international/index/IndexClientFactory.java
+++ b/commons/com.b2international.index/src/com/b2international/index/IndexClientFactory.java
@@ -58,9 +58,13 @@ public interface IndexClientFactory {
 	
 	/**
 	 * Configuration key to specify the number of shards for the index.
-	 * Currently only the index.es fragment supports.
 	 */
 	String NUMBER_OF_SHARDS = "number_of_shards";
+	
+	/**
+	 * Configuration key to specify the number of replicas for the index.
+	 */
+	String NUMBER_OF_REPLICAS = "number_of_replicas";
 
 	/**
 	 * Configuration key to specify the concurrency level for bulk commit operations.
@@ -201,6 +205,15 @@ public interface IndexClientFactory {
 	 */
 	int DEFAULT_COMMIT_WATERMARK_HIGH_VALUE = 50_000;
 
+	/**
+	 * Default number_of_shards value for all indices.
+	 */
+	String DEFAULT_NUMBER_OF_SHARDS = "1";
+
+	/**
+	 * Default number_of_replicas value for all indices. 
+	 */
+	String DEFAULT_NUMBER_OF_REPLICAS = "0";
 
 	/**
 	 * Create a new {@link IndexClient} with the given name.

--- a/commons/com.b2international.index/src/com/b2international/index/Indexes.java
+++ b/commons/com.b2international.index/src/com/b2international/index/Indexes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class Indexes {
 	}
 	
 	public static IndexClient createIndexClient(String name, ObjectMapper mapper, Mappings mappings) {
-		return FACTORY.createClient(name, configure(mapper), mappings, Collections.<String, Object>emptyMap());
+		return FACTORY.createClient(name, configure(mapper), mappings, Collections.emptyMap());
 	}
 	
 	public static IndexClient createIndexClient(String name, ObjectMapper mapper, Mappings mappings, Map<String, Object> settings) {

--- a/core/com.b2international.snowowl.core.rest.tests/src/configuration/snowowl.yml
+++ b/core/com.b2international.snowowl.core.rest.tests/src/configuration/snowowl.yml
@@ -1,9 +1,15 @@
 #
-# Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+# Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
 #
 
 identity:
   providers:
     - file:
         name: users
+
+# to verify that the number_of_shards can be customized via config file
+repository:
+  index:
+    resources:
+      number_of_shards: "2"
 

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/config/IndexConfiguration.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/config/IndexConfiguration.java
@@ -15,14 +15,19 @@
  */
 package com.b2international.snowowl.core.config;
 
+import java.util.Map;
+
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
 import org.hibernate.validator.constraints.NotEmpty;
 
 import com.b2international.index.IndexClientFactory;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap.Builder;
+import com.google.common.collect.Maps;
 
 /**
  * @since 5.0
@@ -71,6 +76,8 @@ public class IndexConfiguration {
 	@Min(5_000)
 	@Max(IndexClientFactory.DEFAULT_COMMIT_WATERMARK_HIGH_VALUE)
 	private int commitWatermarkHigh = IndexClientFactory.DEFAULT_COMMIT_WATERMARK_HIGH_VALUE;
+	
+	private Map<String, Object> customIndexConfigurations = Maps.newHashMapWithExpectedSize(1);
 	
 	@JsonProperty
 	public String getCommitInterval() {
@@ -218,6 +225,16 @@ public class IndexConfiguration {
 	
 	public void setCommitWatermarkLow(int commitWatermarkLow) {
 		this.commitWatermarkLow = commitWatermarkLow;
+	}
+	
+	@JsonAnyGetter
+	public Map<String, Object> getCustomIndexConfigurations() {
+		return customIndexConfigurations;
+	}
+	
+	@JsonAnySetter
+	public void setCustomIndexConfigurations(String indexName, Object config) {
+		this.customIndexConfigurations.put(indexName, config);
 	}
 
 	public void configure(Builder<String, Object> settings) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/config/IndexConfiguration.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/config/IndexConfiguration.java
@@ -40,8 +40,6 @@ public class IndexConfiguration {
 	@NotEmpty
 	private String commitInterval = IndexClientFactory.DEFAULT_TRANSLOG_SYNC_INTERVAL;
 	@Min(1)
-	private Integer numberOfShards = 6;
-	@Min(1)
 	private int commitConcurrencyLevel = Math.max(1, Runtime.getRuntime().availableProcessors() / 4);
 	@Min(1)
 	private int bulkActionSize = IndexClientFactory.DEFAULT_BULK_ACTIONS_SIZE;
@@ -89,16 +87,6 @@ public class IndexConfiguration {
 		this.commitInterval = commitInterval;
 	}
 
-	@JsonProperty
-	public void setNumberOfShards(Integer numberOfShards) {
-		this.numberOfShards = numberOfShards;
-	}
-	
-	@JsonProperty
-	public Integer getNumberOfShards() {
-		return numberOfShards;
-	}
-	
 	@JsonProperty
 	public int getCommitConcurrencyLevel() {
 		return commitConcurrencyLevel;

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/config/IndexSettings.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/config/IndexSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 package com.b2international.snowowl.core.config;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.b2international.commons.options.HashMapOptions;
 
 /**
@@ -25,5 +28,22 @@ import com.b2international.commons.options.HashMapOptions;
 public final class IndexSettings extends HashMapOptions {
 
 	private static final long serialVersionUID = -8695509362236134666L;
+
+	/**
+	 * Configures and returns an index specific settings map to use when initializing the given index.
+	 * 
+	 * @param config - the main index configuration object
+	 * @param indexName - the index to configure
+	 * @param defaultIndexSettings - default settings if there is no customized configuration available in the configuration file
+	 * @return
+	 */
+	public Map<String, Object> forIndex(IndexConfiguration config, String indexName, Map<String, Object> defaultIndexSettings) {
+		Object customIndexSettings = config.getCustomIndexConfigurations().getOrDefault(indexName, defaultIndexSettings);
+		Map<String,Object> settings = new HashMap<>(this);
+		if (customIndexSettings instanceof Map<?, ?>) {
+			settings.putAll((Map<String, Object>) customIndexSettings);
+		}
+		return settings;
+	}
 
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/config/IndexSettings.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/config/IndexSettings.java
@@ -34,6 +34,17 @@ public final class IndexSettings extends HashMapOptions {
 	 * 
 	 * @param config - the main index configuration object
 	 * @param indexName - the index to configure
+	 * @return
+	 */
+	public Map<String, Object> forIndex(IndexConfiguration config, String indexName) {
+		return forIndex(config, indexName, Map.of());
+	}
+	
+	/**
+	 * Configures and returns an index specific settings map to use when initializing the given index.
+	 * 
+	 * @param config - the main index configuration object
+	 * @param indexName - the index to configure
 	 * @param defaultIndexSettings - default settings if there is no customized configuration available in the configuration file
 	 * @return
 	 */

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/SnowOwlPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/SnowOwlPlugin.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.b2international.index.Index;
-import com.b2international.index.IndexClientFactory;
 import com.b2international.index.Indexes;
 import com.b2international.index.mapping.Mappings;
 import com.b2international.index.revision.DefaultRevisionIndex;
@@ -66,9 +65,6 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 public final class SnowOwlPlugin extends Plugin {
 
 	private static final String RESOURCES_INDEX = "resources";
-	private static final Map<String, Object> RESOURCES_INDEX_DEFAULT_SETTINGS = Map.of(
-		IndexClientFactory.NUMBER_OF_SHARDS, 3
-	);
 
 	@Override
 	public void init(SnowOwlConfiguration configuration, Environment env) {
@@ -97,7 +93,7 @@ public final class SnowOwlPlugin extends Plugin {
 				RESOURCES_INDEX, 
 				mapper, 
 				new Mappings(ResourceDocument.class, VersionDocument.class), 
-				env.service(IndexSettings.class).forIndex(env.service(RepositoryConfiguration.class).getIndexConfiguration(), RESOURCES_INDEX, RESOURCES_INDEX_DEFAULT_SETTINGS)
+				env.service(IndexSettings.class).forIndex(env.service(RepositoryConfiguration.class).getIndexConfiguration(), RESOURCES_INDEX)
 			);
 			
 			final RevisionIndex revisionIndex = new DefaultRevisionIndex(resourceIndex, env.service(TimestampProvider.class), mapper);

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/locks/LockPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/locks/LockPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,13 @@
  */
 package com.b2international.snowowl.core.internal.locks;
 
+import org.elasticsearch.core.Map;
+
 import com.b2international.index.Index;
 import com.b2international.index.Indexes;
 import com.b2international.index.mapping.Mappings;
 import com.b2international.snowowl.core.config.IndexSettings;
+import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.config.SnowOwlConfiguration;
 import com.b2international.snowowl.core.locks.DatastoreLockIndexEntry;
 import com.b2international.snowowl.core.locks.DefaultOperationLockManager;
@@ -36,10 +39,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @Component
 public final class LockPlugin extends Plugin {
 
+	private static final String LOCKS_INDEX = "locks";
+
 	@Override
 	public void preRun(SnowOwlConfiguration configuration, Environment env) throws Exception {
 		if (env.isServer()) {
-			final Index locksIndex = Indexes.createIndex("locks", env.service(ObjectMapper.class), new Mappings(DatastoreLockIndexEntry.class), env.service(IndexSettings.class));
+			final Index locksIndex = Indexes.createIndex(
+				LOCKS_INDEX, 
+				env.service(ObjectMapper.class), 
+				new Mappings(DatastoreLockIndexEntry.class), 
+				env.service(IndexSettings.class).forIndex(env.service(RepositoryConfiguration.class).getIndexConfiguration(), LOCKS_INDEX, Map.of())
+			);
 			final DefaultOperationLockManager lockManager = new DefaultOperationLockManager(locksIndex);
 			final RemoteLockTargetListener remoteLockTargetListener = new RemoteLockTargetListener();
 			lockManager.addLockTargetListener(new Slf4jOperationLockTargetListener());

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/locks/LockPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/locks/LockPlugin.java
@@ -15,8 +15,6 @@
  */
 package com.b2international.snowowl.core.internal.locks;
 
-import org.elasticsearch.core.Map;
-
 import com.b2international.index.Index;
 import com.b2international.index.Indexes;
 import com.b2international.index.mapping.Mappings;
@@ -48,7 +46,7 @@ public final class LockPlugin extends Plugin {
 				LOCKS_INDEX, 
 				env.service(ObjectMapper.class), 
 				new Mappings(DatastoreLockIndexEntry.class), 
-				env.service(IndexSettings.class).forIndex(env.service(RepositoryConfiguration.class).getIndexConfiguration(), LOCKS_INDEX, Map.of())
+				env.service(IndexSettings.class).forIndex(env.service(RepositoryConfiguration.class).getIndexConfiguration(), LOCKS_INDEX)
 			);
 			final DefaultOperationLockManager lockManager = new DefaultOperationLockManager(locksIndex);
 			final RemoteLockTargetListener remoteLockTargetListener = new RemoteLockTargetListener();
@@ -61,6 +59,5 @@ public final class LockPlugin extends Plugin {
 			env.services().registerService(IOperationLockManager.class, RpcUtil.createProxy(env.container(), IOperationLockManager.class));
 		}
 	}
-	
 	
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/validation/ValidationPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/validation/ValidationPlugin.java
@@ -78,7 +78,7 @@ public final class ValidationPlugin extends Plugin {
 				VALIDATIONS_INDEX, 
 				mapper, 
 				new Mappings(ValidationIssue.class, ValidationRule.class, ValidationWhiteList.class), 
-				env.service(IndexSettings.class).forIndex(env.service(RepositoryConfiguration.class).getIndexConfiguration(), VALIDATIONS_INDEX, Map.of())
+				env.service(IndexSettings.class).forIndex(env.service(RepositoryConfiguration.class).getIndexConfiguration(), VALIDATIONS_INDEX)
 			);
 			
 			final ValidationRepository repository = new ValidationRepository(validationIndex);

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/validation/ValidationPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/validation/ValidationPlugin.java
@@ -34,6 +34,7 @@ import com.b2international.index.mapping.Mappings;
 import com.b2international.index.query.Expressions;
 import com.b2international.index.query.Query;
 import com.b2international.snowowl.core.config.IndexSettings;
+import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.config.SnowOwlConfiguration;
 import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.b2international.snowowl.core.plugin.Component;
@@ -62,6 +63,8 @@ public final class ValidationPlugin extends Plugin {
 
 	private static final Logger LOG = LoggerFactory.getLogger("validation");
 	
+	private static final String VALIDATIONS_INDEX = "validations";
+	
 	@Override
 	public void addConfigurations(ConfigurationRegistry registry) {
 		registry.add("validation", ValidationConfiguration.class);
@@ -72,10 +75,10 @@ public final class ValidationPlugin extends Plugin {
 		if (env.isServer()) {
 			final ObjectMapper mapper = env.service(ObjectMapper.class);
 			final Index validationIndex = Indexes.createIndex(
-				"validations", 
+				VALIDATIONS_INDEX, 
 				mapper, 
 				new Mappings(ValidationIssue.class, ValidationRule.class, ValidationWhiteList.class), 
-				env.service(IndexSettings.class)
+				env.service(IndexSettings.class).forIndex(env.service(RepositoryConfiguration.class).getIndexConfiguration(), VALIDATIONS_INDEX, Map.of())
 			);
 			
 			final ValidationRepository repository = new ValidationRepository(validationIndex);

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryPlugin.java
@@ -71,6 +71,8 @@ public final class RepositoryPlugin extends Plugin {
 
 	private static final Logger LOG = LoggerFactory.getLogger("core");
 	
+	private static final String JOBS_INDEX = "jobs";
+	
 	@Override
 	public void addConfigurations(ConfigurationRegistry registry) {
 		registry.add("repository", RepositoryConfiguration.class);
@@ -199,7 +201,12 @@ public final class RepositoryPlugin extends Plugin {
 	
 	private void initializeJobSupport(Environment env, SnowOwlConfiguration configuration) {
 		final ObjectMapper objectMapper = env.service(ObjectMapper.class);
-		final Index jobsIndex = Indexes.createIndex("jobs", objectMapper, new Mappings(RemoteJobEntry.class), env.service(IndexSettings.class));
+		final Index jobsIndex = Indexes.createIndex(
+			JOBS_INDEX, 
+			objectMapper, 
+			new Mappings(RemoteJobEntry.class), 
+			env.service(IndexSettings.class).forIndex(env.service(RepositoryConfiguration.class).getIndexConfiguration(), JOBS_INDEX)
+		);
 		// TODO make this configurable
 		final long defaultJobCleanUpInterval = TimeUnit.MINUTES.toMillis(1);
 		env.services()

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/TerminologyRepository.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/TerminologyRepository.java
@@ -18,12 +18,14 @@ package com.b2international.snowowl.core.repository;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.Map;
 
 import org.slf4j.Logger;
 
 import com.b2international.commons.exceptions.RequestTimeoutException;
-import com.b2international.index.*;
+import com.b2international.index.DefaultIndex;
+import com.b2international.index.Index;
+import com.b2international.index.IndexClient;
+import com.b2international.index.Indexes;
 import com.b2international.index.es.client.EsClusterStatus;
 import com.b2international.index.mapping.Mappings;
 import com.b2international.index.revision.BaseRevisionBranching;
@@ -86,10 +88,7 @@ public final class TerminologyRepository extends ServiceContext implements Repos
 			repositoryId, 
 			mapper, 
 			mappings, 
-			context.service(IndexSettings.class).forIndex(indexConfiguration, repositoryId, Map.of(
-				// TODO decide the fate of the global number of shards settings key
-				IndexClientFactory.NUMBER_OF_SHARDS, indexConfiguration.getNumberOfShards() 
-			))
+			context.service(IndexSettings.class).forIndex(indexConfiguration, repositoryId)
 		);
 		final Index index = new DefaultIndex(indexClient);
 		final RevisionIndex revisionIndex = new DefaultRevisionIndex(index, context.service(TimestampProvider.class), mapper);

--- a/docker/config/snowowl.yml
+++ b/docker/config/snowowl.yml
@@ -17,6 +17,11 @@ identity:
 #        userIdProperty: uid
 #        usePool: false
 
+#repository:
+#  index:
+#    snomed:
+#      number_of_shards: "3"
+
 monitoring:
   enabled: true
 


### PR DESCRIPTION
Each index can receive its own custom settings object nested under `repository.index` via its index name. If not specified, index
initialization will fall back to the default values.