### PR TITLE
Support index-level request caching

### DIFF
--- a/commons/com.b2international.index.tests/src/com/b2international/index/CacheTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/CacheTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.index;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.elasticsearch.common.UUIDs;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import com.b2international.index.Fixtures.Data;
+import com.b2international.index.query.Expressions;
+import com.b2international.index.query.Query;
+import com.google.common.base.Stopwatch;
+
+/**
+ * It is possible to manually monitor cache usage via GET localhost:9200/_stats/request_cache?human
+ * 
+ * @since 8.0
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class CacheTest extends BaseIndexTest {
+
+	private static final int NUMBER_OF_DOCS = 10_000;
+	private static final int NUMBER_OF_RUNS = 10;
+
+	@Override
+	protected Collection<Class<?>> getTypes() {
+		return List.of(Fixtures.Data.class);
+	}
+
+	@Before
+	public void before() {
+		List<Data> docs = new ArrayList<>();
+		for (int i = 0; i < NUMBER_OF_DOCS; i++) {
+			Data data = new Data(UUIDs.randomBase64UUID());
+			data.setAnalyzedField("hello-" + i);
+			data.setIntField(i);
+			docs.add(data);
+		}
+		indexDocuments(docs);
+	}
+	
+	@Test
+	public void _01_uncached_hits() throws Exception {
+		Stopwatch w = Stopwatch.createUnstarted();
+		for (int i = 0; i < NUMBER_OF_RUNS; i++) {
+			w.start();
+			Hits<Data> hits = search(Query.select(Data.class)
+					.where(Expressions.matchAll())
+					.limit(NUMBER_OF_DOCS)
+					.build());
+			w.stop();
+			assertThat(hits).hasSize(NUMBER_OF_DOCS);
+		}
+		System.err.println("Avg uncached_hits resp time: " + w.elapsed(TimeUnit.MILLISECONDS) / NUMBER_OF_RUNS + "ms");
+	}
+	
+	@Test
+	public void _02_cached_hits() throws Exception {
+		Stopwatch w = Stopwatch.createUnstarted();
+		for (int i = 0; i < 10; i++) {
+			w.start();
+			Hits<Data> hits = search(Query.select(Data.class)
+					.where(Expressions.matchAll())
+					.limit(NUMBER_OF_DOCS)
+					.cached(true)
+					.build());
+			w.stop();
+			assertThat(hits).hasSize(NUMBER_OF_DOCS);
+		}
+		System.err.println("Avg cached_hits resp time: " + w.elapsed(TimeUnit.MILLISECONDS) / NUMBER_OF_RUNS + "ms");
+	}
+	
+	@Test
+	public void _03_uncached_docvalues() throws Exception {
+		Stopwatch w = Stopwatch.createUnstarted();
+		for (int i = 0; i < NUMBER_OF_RUNS; i++) {
+			w.start();
+			Hits<String[]> hits = search(Query.select(String[].class)
+					.from(Data.class)
+					.fields("id", "intField")
+					.where(Expressions.matchAll())
+					.limit(NUMBER_OF_DOCS)
+					.build());
+			w.stop();
+			assertThat(hits).hasSize(NUMBER_OF_DOCS);
+		}
+		System.err.println("Avg uncached_docvalues resp time: " + w.elapsed(TimeUnit.MILLISECONDS) / NUMBER_OF_RUNS + "ms");
+	}
+	
+	@Test
+	public void _04_cached_docvalues() throws Exception {
+		Stopwatch w = Stopwatch.createUnstarted();
+		for (int i = 0; i < NUMBER_OF_RUNS; i++) {
+			w.start();
+			Hits<String[]> hits = search(Query.select(String[].class)
+					.from(Data.class)
+					.fields("id", "intField")
+					.where(Expressions.matchAll())
+					.limit(NUMBER_OF_DOCS)
+					.cached(true)
+					.build());
+			w.stop();
+			assertThat(hits).hasSize(NUMBER_OF_DOCS);
+		}
+		System.err.println("Avg cached_docvalues resp time: " + w.elapsed(TimeUnit.MILLISECONDS) / NUMBER_OF_RUNS + "ms");
+	}
+	
+	@Test
+	public void _05_uncached_filtered_range() throws Exception {
+		Stopwatch w = Stopwatch.createUnstarted();
+		for (int i = 0; i < NUMBER_OF_RUNS; i++) {
+			w.start();
+			Hits<Data> hits = search(Query.select(Data.class)
+					.where(Expressions.matchRange("intField", 1001, 7000))
+					.limit(Integer.MAX_VALUE)
+					.build());
+			w.stop();
+			assertThat(hits).hasSize(6000);
+		}
+		System.err.println("Avg uncached_filtered_range resp time: " + w.elapsed(TimeUnit.MILLISECONDS) / NUMBER_OF_RUNS + "ms");
+	}
+	
+	@Test
+	public void _06_cached_filtered_range() throws Exception {
+		Stopwatch w = Stopwatch.createUnstarted();
+		for (int i = 0; i < NUMBER_OF_RUNS; i++) {
+			w.start();
+			Hits<Data> hits = search(Query.select(Data.class)
+					.where(Expressions.matchRange("intField", 1001, 7000))
+					.limit(Integer.MAX_VALUE)
+					.cached(true)
+					.build());
+			w.stop();
+			assertThat(hits).hasSize(6000);
+		}
+		System.err.println("Avg cached_filtered_range resp time: " + w.elapsed(TimeUnit.MILLISECONDS) / NUMBER_OF_RUNS + "ms");
+	}
+	
+}

--- a/commons/com.b2international.index/src/com/b2international/index/es/EsDocumentSearcher.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/EsDocumentSearcher.java
@@ -141,6 +141,9 @@ public class EsDocumentSearcher implements Searcher {
 		
 		final SearchRequest req = new SearchRequest(admin.getTypeIndexes(mappings).toArray(length -> new String[length]));
 		
+		// configure caching
+		req.requestCache(query.isCached());
+		
 		final SearchSourceBuilder reqSource = req.source()
 			.size(toRead)
 			.query(esQuery)

--- a/commons/com.b2international.index/src/com/b2international/index/query/DefaultQueryBuilder.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/DefaultQueryBuilder.java
@@ -38,6 +38,7 @@ class DefaultQueryBuilder<T> implements QueryBuilder<T>, AfterWhereBuilder<T> {
 	private Expression where;
 	private SortBy sortBy = SortBy.DEFAULT;
 	private boolean withScores = false;
+	private boolean cached = false;
 
 	private List<String> fields = Collections.emptyList();
 
@@ -98,6 +99,12 @@ class DefaultQueryBuilder<T> implements QueryBuilder<T>, AfterWhereBuilder<T> {
 		this.withScores = withScores;
 		return this;
 	}
+	
+	@Override
+	public AfterWhereBuilder<T> cached(boolean cached) {
+		this.cached = cached;
+		return this;
+	}
 
 	@Override
 	public Query<T> build() {
@@ -113,6 +120,7 @@ class DefaultQueryBuilder<T> implements QueryBuilder<T>, AfterWhereBuilder<T> {
 		query.setSortBy(sortBy);
 		query.setWithScores(withScores);
 		query.setFields(fields);
+		query.setCached(cached);
 		return query;
 	}
 

--- a/commons/com.b2international.index/src/com/b2international/index/query/Expressions.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/Expressions.java
@@ -144,7 +144,11 @@ public class Expressions {
 	}
 
 	public static Expression matchAnyInt(String field, Iterable<Integer> values) {
-		return new IntSetPredicate(field, values);
+		if (Iterables.size(values) == 1) {
+			return new IntPredicate(field, Iterables.getFirst(values, null));
+		} else {
+			return new IntSetPredicate(field, values);
+		}
 	}
 	
 	public static Expression matchAnyEnum(String field, Iterable<? extends Enum<?>> values) {
@@ -153,19 +157,35 @@ public class Expressions {
 	}
 	
 	public static Expression matchAny(String field, Iterable<String> values) {
-		return new StringSetPredicate(field, values);
+		if (Iterables.size(values) == 1) {
+			return new StringPredicate(field, Iterables.getFirst(values, null));
+		} else {
+			return new StringSetPredicate(field, values);
+		}
 	}
 	
 	public static Expression matchAnyLong(String field, Iterable<Long> values) {
-		return new LongSetPredicate(field, values);
+		if (Iterables.size(values) == 1) {
+			return new LongPredicate(field, Iterables.getFirst(values, null));
+		} else {
+			return new LongSetPredicate(field, values);
+		}
 	}
 	
 	public static Expression matchAnyDecimal(String field, Iterable<BigDecimal> values) {
-		return new DecimalSetPredicate(field, values);
+		if (Iterables.size(values) == 1) {
+			return new DecimalPredicate(field, Iterables.getFirst(values, null));
+		} else {
+			return new DecimalSetPredicate(field, values);
+		}
 	}
 	
 	public static Expression matchAnyDouble(String field, Iterable<Double> values) {
-		return new DoubleSetPredicate(field, values);
+		if (Iterables.size(values) == 1) {
+			return new DoublePredicate(field, Iterables.getFirst(values, null));
+		} else {
+			return new DoubleSetPredicate(field, values);
+		}
 	}
 
 	public static Expression boost(Expression expression, float boost) {

--- a/commons/com.b2international.index/src/com/b2international/index/query/Query.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/Query.java
@@ -220,7 +220,8 @@ public final class Query<T> {
 			.sortBy(getSortBy())
 			.limit(getLimit())
 			.searchAfter(getSearchAfter())
-			.withScores(isWithScores());
+			.withScores(isWithScores())
+			.cached(isCached());
 	}
 	
 	public AfterWhereBuilder<T> withSearchAfter(String searchAfter) {
@@ -230,7 +231,8 @@ public final class Query<T> {
 				.sortBy(getSortBy())
 				.limit(getLimit())
 				.searchAfter(searchAfter)
-				.withScores(isWithScores());
+				.withScores(isWithScores())
+				.cached(isCached());
 	}
 
 	/**

--- a/commons/com.b2international.index/src/com/b2international/index/query/Query.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/Query.java
@@ -91,6 +91,14 @@ public final class Query<T> {
 		 * @return
 		 */
 		AfterWhereBuilder<T> withScores(boolean withScores);
+		
+		/**
+		 * Request the underlying service to cache the results of this query when possible. By default queries are not cached.
+		 * 
+		 * @param cached - whether this query needs to be cached or not
+		 * @return
+		 */
+		AfterWhereBuilder<T> cached(boolean cached);
 	}
 
 	private String searchAfter;
@@ -98,8 +106,9 @@ public final class Query<T> {
 	private IndexSelection<T> selection;
 	private Expression where;
 	private SortBy sortBy = SortBy.DEFAULT;
-	private boolean withScores;
+	private boolean withScores = false;
 	private List<String> fields;
+	private boolean cached = false;
 
 	Query() {}
 
@@ -159,6 +168,14 @@ public final class Query<T> {
 		this.searchAfter = searchAfter;
 	}
 	
+	public boolean isCached() {
+		return cached;
+	}
+	
+	void setCached(boolean cached) {
+		this.cached = cached;
+	}
+	
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
@@ -171,6 +188,9 @@ public final class Query<T> {
 		sb.append(" LIMIT " + limit);
 		if (selection.getParentScope() != null) {
 			sb.append(" HAS_PARENT(" + selection.getParentScopeDocumentType() + ")");
+		}
+		if (cached) {
+			sb.append(" CACHED");
 		}
 		return sb.toString();
 	}
@@ -240,5 +260,5 @@ public final class Query<T> {
 	public final Stream<Hits<T>> stream(Searcher searcher) {
 		return searcher.stream(this);
 	}
-	
+
 }

--- a/commons/com.b2international.index/src/com/b2international/index/query/Query.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/Query.java
@@ -185,7 +185,11 @@ public final class Query<T> {
 		if (!SortBy.DEFAULT.equals(sortBy)) {
 			sb.append(" SORT BY " + sortBy);
 		}
-		sb.append(" LIMIT " + limit);
+		sb.append(" LIMIT(").append(limit).append(")");
+		if (searchAfter != null) {
+			sb.append(" AFTER(").append(searchAfter).append(")");
+		}
+		
 		if (selection.getParentScope() != null) {
 			sb.append(" HAS_PARENT(" + selection.getParentScopeDocumentType() + ")");
 		}

--- a/commons/com.b2international.index/src/com/b2international/index/query/SetPredicate.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/SetPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,20 +17,21 @@ package com.b2international.index.query;
 
 import java.util.Objects;
 import java.util.Set;
+import java.util.SortedSet;
 
 import com.b2international.commons.StringUtils;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 
 /**
  * @since 5.0
  */
 public abstract class SetPredicate<T> extends Predicate {
 	
-	private final Set<T> values;
+	private final SortedSet<T> values;
 
 	SetPredicate(String field, Iterable<T> values) {
 		super(field);
-		this.values = ImmutableSet.copyOf(values);
+		this.values = ImmutableSortedSet.copyOf(values);
 	}
 	
 	@Override

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/context/TerminologyResourceContentRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/context/TerminologyResourceContentRequest.java
@@ -47,6 +47,7 @@ public final class TerminologyResourceContentRequest<R> extends DelegatingReques
 		if (versionResourceURI != null) {
 			context = context.inject()
 				.bind(ResourceURI.class, versionResourceURI)
+				.bind(PathWithVersion.class, branchPathWithVersion)
 				.build();
 		}
 		

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/SearchIndexResourceRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/SearchIndexResourceRequest.java
@@ -61,7 +61,6 @@ public abstract class SearchIndexResourceRequest<C extends ServiceProvider, B, D
 			fields = configureFieldsToLoad(fields);
 		}
 		
-		
 		final Hits<D> hits = searcher.search(Query.select(getSelect())
 				.from(getFrom())
 				.fields(fields)
@@ -155,7 +154,7 @@ public abstract class SearchIndexResourceRequest<C extends ServiceProvider, B, D
 	 * @return whether the search should cache the resulting hits in the underlying index system or not
 	 */
 	protected boolean cacheHits(C context) {
-		return context.optionalService(PathWithVersion.class).isPresent();
+		return Revision.class.isAssignableFrom(getFrom()) && context.optionalService(PathWithVersion.class).isPresent();
 	}
 	
 	/**

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/SearchIndexResourceRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/SearchIndexResourceRequest.java
@@ -31,6 +31,7 @@ import com.b2international.index.revision.Revision;
 import com.b2international.index.revision.RevisionSearcher;
 import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.domain.CollectionResource;
+import com.b2international.snowowl.core.uri.ResourceURIPathResolver.PathWithVersion;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 
@@ -69,6 +70,7 @@ public abstract class SearchIndexResourceRequest<C extends ServiceProvider, B, D
 				.limit(limit())
 				.sortBy(querySortBy(context))
 				.withScores(trackScores())
+				.cached(cacheHits(context))
 				.build());
 		
 		return toCollectionResource(context, hits);
@@ -145,6 +147,15 @@ public abstract class SearchIndexResourceRequest<C extends ServiceProvider, B, D
 	 */
 	protected boolean trackScores() {
 		return false;
+	}
+	
+	/**
+	 * Subclasses may override to configure caching. By default search requests that are executed against a version URI will be cached.  
+	 * @param context - the context that can be used to determine whether caching should be enabled for this search request or not
+	 * @return whether the search should cache the resulting hits in the underlying index system or not
+	 */
+	protected boolean cacheHits(C context) {
+		return context.optionalService(PathWithVersion.class).isPresent();
 	}
 	
 	/**

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/EclExpression.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/EclExpression.java
@@ -41,6 +41,7 @@ import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.repository.RevisionDocument;
 import com.b2international.snowowl.core.request.SearchResourceRequest;
+import com.b2international.snowowl.core.uri.ResourceURIPathResolver.PathWithVersion;
 import com.b2international.snowowl.eventbus.IEventBus;
 import com.b2international.snowowl.snomed.common.SnomedRf2Headers;
 import com.b2international.snowowl.snomed.core.domain.SnomedConcepts;
@@ -117,6 +118,8 @@ public final class EclExpression {
 								.fields(SnomedConceptDocument.Fields.ID)
 								.where(expression)
 								.limit(Integer.MAX_VALUE)
+								// cache when the current context is executed against a version
+								.cached(context.optionalService(PathWithVersion.class).isPresent())
 								.build()));
 						
 					} catch (IOException e) {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/EclExpression.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/EclExpression.java
@@ -106,6 +106,7 @@ public final class EclExpression {
 	public Promise<Set<String>> resolve(final BranchContext context) {
 		if (promise == null) {
 			RevisionSearcher searcher = context.service(RevisionSearcher.class);
+			boolean cached = context.optionalService(PathWithVersion.class).isPresent();
 			promise = resolveToExpression(context)
 				.then(expression -> {
 					// shortcut to extract IDs from the query itself if possible 
@@ -119,7 +120,7 @@ public final class EclExpression {
 								.where(expression)
 								.limit(Integer.MAX_VALUE)
 								// cache when the current context is executed against a version
-								.cached(context.optionalService(PathWithVersion.class).isPresent())
+								.cached(cached)
 								.build()));
 						
 					} catch (IOException e) {


### PR DESCRIPTION
This PR introduces index-level search request caching and potential configuration on request API level via [cacheHits(ServiceProvider)](https://github.com/b2ihealthcare/snow-owl/commit/163181e3982809171ef740013a72e73df31174d3#diff-b854641ff991e8157af0c445f61bebd4c94474b2434c9ac8ae2bb8c4d1fce435R157).
By default the system will cache:
* all requests that are being executed on versioned content
* certain ECL search requests (or partial ECL search requests)