### PR TITLE
feat(snomed): defer loading of expanded additional data...

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/converter/ModuleExpander.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/converter/ModuleExpander.java
@@ -16,14 +16,12 @@
 package com.b2international.snowowl.snomed.datastore.converter;
 
 import java.util.List;
-import java.util.SortedSet;
 
 import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.commons.options.Options;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.snomed.core.domain.SnomedComponent;
 import com.b2international.snowowl.snomed.datastore.request.SnomedConceptRequestCache;
-import com.google.common.collect.ImmutableSortedSet;
 
 /**
  * @since 7.4
@@ -44,7 +42,7 @@ final class ModuleExpander {
 		if (expand.containsKey(SnomedComponent.Expand.MODULE)) {
 			final Options moduleOptions = expand.get(SnomedComponent.Expand.MODULE, Options.class);
 
-			final SortedSet<String> moduleIds = results.stream().map(SnomedComponent::getModuleId).collect(ImmutableSortedSet.toImmutableSortedSet(String::compareTo));
+			final Iterable<String> moduleIds = results.stream().map(SnomedComponent::getModuleId)::iterator;
 			
 			context.service(SnomedConceptRequestCache.class)
 				.request(moduleIds, moduleOptions.getOptions("expand"), locales, modulesById -> {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/converter/ModuleExpander.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/converter/ModuleExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2020-2021 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,14 @@
 package com.b2international.snowowl.snomed.datastore.converter;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.SortedSet;
 
 import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.commons.options.Options;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.snomed.core.domain.SnomedComponent;
-import com.b2international.snowowl.snomed.core.domain.SnomedConcept;
-import com.b2international.snowowl.snomed.datastore.request.SnomedRequests;
+import com.b2international.snowowl.snomed.datastore.request.SnomedConceptRequestCache;
+import com.google.common.collect.ImmutableSortedSet;
 
 /**
  * @since 7.4
@@ -46,21 +44,15 @@ final class ModuleExpander {
 		if (expand.containsKey(SnomedComponent.Expand.MODULE)) {
 			final Options moduleOptions = expand.get(SnomedComponent.Expand.MODULE, Options.class);
 
-			final Set<String> moduleIds = results.stream().map(SnomedComponent::getModuleId).collect(Collectors.toSet());
+			final SortedSet<String> moduleIds = results.stream().map(SnomedComponent::getModuleId).collect(ImmutableSortedSet.toImmutableSortedSet(String::compareTo));
 			
-			final Map<String, SnomedConcept> modulesById = SnomedRequests.prepareSearchConcept()
-				.all()
-				.filterByIds(moduleIds)
-				.setExpand(moduleOptions.getOptions("expand"))
-				.setLocales(locales)
-				.build()
-				.execute(context)
-				.stream()
-				.collect(Collectors.toMap(SnomedConcept::getId, c -> c));
+			context.service(SnomedConceptRequestCache.class)
+				.request(moduleIds, moduleOptions.getOptions("expand"), locales, modulesById -> {
+					for (SnomedComponent component : results) {
+						component.setModule(modulesById.get(component.getModuleId()));
+					}
+				});
 			
-			for (SnomedComponent component : results) {
-				component.setModule(modulesById.get(component.getModuleId()));
-			}
 		}
 	}
 	

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/converter/SnomedRelationshipConverter.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/converter/SnomedRelationshipConverter.java
@@ -141,10 +141,9 @@ public final class SnomedRelationshipConverter extends BaseRevisionResourceConve
 	private void expandDestination(List<SnomedRelationship> results) {
 		if (expand().containsKey(SnomedRelationship.Expand.DESTINATION)) {
 			final Options destinationOptions = expand().get(SnomedRelationship.Expand.DESTINATION, Options.class);
-			final Set<String> destinationConceptIds = FluentIterable.from(results)
+			final Iterable<String> destinationConceptIds = FluentIterable.from(results)
 				.filter(r -> !r.hasValue()) // skip expand on relationships with value
-				.transform(SnomedRelationship::getDestinationId)
-				.toSet();
+				.transform(SnomedRelationship::getDestinationId);
 			
 			context().service(SnomedConceptRequestCache.class)
 				.request(destinationConceptIds, destinationOptions.getOptions("expand"), locales(), destinationConceptsById -> {
@@ -164,7 +163,7 @@ public final class SnomedRelationshipConverter extends BaseRevisionResourceConve
 	private void expandSource(List<SnomedRelationship> results) {
 		if (expand().containsKey(SnomedRelationship.Expand.SOURCE)) {
 			final Options sourceOptions = expand().get(SnomedRelationship.Expand.SOURCE, Options.class);
-			final Set<String> sourceConceptIds = FluentIterable.from(results).transform(SnomedRelationship::getSourceId).toSet();
+			final Iterable<String> sourceConceptIds = FluentIterable.from(results).transform(SnomedRelationship::getSourceId);
 
 			context().service(SnomedConceptRequestCache.class)
 				.request(sourceConceptIds, sourceOptions.getOptions("expand"), locales(), sourceConceptsById -> {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptCachingRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptCachingRequest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.snomed.datastore.request;
+
+import com.b2international.snowowl.core.domain.BranchContext;
+import com.b2international.snowowl.core.events.DelegatingRequest;
+import com.b2international.snowowl.core.events.Request;
+
+/**
+ * @since 8.1
+ * @param <R>
+ */
+public final class SnomedConceptCachingRequest<R> extends DelegatingRequest<BranchContext, BranchContext, R> {
+
+	private static final long serialVersionUID = 1L;
+	
+	public SnomedConceptCachingRequest(Request<BranchContext, R> next) {
+		super(next);
+	}
+
+	@Override
+	public R execute(BranchContext context) {
+		SnomedConceptRequestCache cache = new SnomedConceptRequestCache();
+		R response = next(context.inject().bind(SnomedConceptRequestCache.class, cache).build());
+		// compute the cache if the next callback returns successfully
+		cache.compute(context);
+		return response; 
+	}
+
+}

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptRequestCache.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptRequestCache.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.snomed.datastore.request;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import com.b2international.commons.http.ExtendedLocale;
+import com.b2international.commons.options.Options;
+import com.b2international.snowowl.core.domain.BranchContext;
+import com.b2international.snowowl.core.domain.IComponent;
+import com.b2international.snowowl.snomed.core.domain.SnomedConcept;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedSet;
+
+/**
+ * @since 8.1.0
+ */
+public class SnomedConceptRequestCache {
+
+	private final Map<FetchConfig, Map<String, SnomedConcept>> cache = new HashMap<>(); 
+	private final Deque<FetchConfig> requestedFetches = new ArrayDeque<>();
+	
+	public void request(Iterable<String> ids, Options expand, List<ExtendedLocale> locales, Consumer<Map<String, SnomedConcept>> onConceptsReady) {
+		requestedFetches.add(new FetchConfig(ids, expand, locales, onConceptsReady));
+	}
+	
+	public Map<String, SnomedConcept> get(BranchContext context, Iterable<String> ids, Options expand, List<ExtendedLocale> locales) {
+		FetchConfig config = new FetchConfig(ids, expand, locales, concepts -> {});
+		if (cache.containsKey(config)) {
+			return cache.get(config);
+		} else {
+			requestedFetches.add(config);
+			compute(context);
+			return cache.get(config);
+		}
+	}
+	
+	public void compute(BranchContext context) {
+		// run until all requested fetches are resolved
+		while (!requestedFetches.isEmpty()) {
+			// using the currently first requestedFetch config
+			// check if there are similar fetchConfigs requested earlier, and if yes, try to fetch them now, so they can be referenced later from the cache, and immediately get populated via the callback
+			FetchConfig config = requestedFetches.getFirst();
+			final Set<FetchConfig> configsToFetch = requestedFetches.stream()
+					.filter(cfg -> Objects.equals(config.expand, cfg.expand) && Objects.equals(config.locales, cfg.locales))
+					.collect(Collectors.toSet());
+			// remove them from the requested fetches
+			requestedFetches.removeAll(configsToFetch);
+
+			// search for configs using the same expand and locales, merge the IDs and fetch all of them together
+			final Set<String> ids = configsToFetch.stream().flatMap(cfg -> cfg.ids.stream()).collect(Collectors.toSet());
+			
+			context.log().info("Fetching concepts: ids={}, expand={}, locales={}", ids, config.expand, config.locales);
+			Map<String, SnomedConcept> fetchedConcepts = SnomedRequests.prepareSearchConcept()
+					.setLimit(ids.size())
+					.filterByIds(ids)
+					.setExpand(config.expand)
+					.setLocales(config.locales)
+					.build()
+					.execute(context)
+					.stream()
+					.collect(Collectors.toMap(IComponent::getId, c -> c));
+			
+			// populate the cache for each fetch config and call the callback
+			configsToFetch.forEach(cfg -> {
+				ImmutableMap.Builder<String, SnomedConcept> configConcepts = ImmutableMap.builder();
+				cfg.ids.forEach(idToCache -> {
+					configConcepts.put(idToCache, fetchedConcepts.get(idToCache));
+				});
+				ImmutableMap<String, SnomedConcept> concepts = configConcepts.build();
+				cache.put(cfg, concepts);
+				cfg.onConceptsReady.accept(concepts);
+			});
+		}
+	}
+	
+	private static final class FetchConfig {
+		
+		private final SortedSet<String> ids;
+		private final Options expand;
+		private final List<ExtendedLocale> locales;
+		private final Consumer<Map<String, SnomedConcept>> onConceptsReady;
+		
+		public FetchConfig(Iterable<String> ids, Options expand, List<ExtendedLocale> locales, Consumer<Map<String, SnomedConcept>> onConceptsReady) {
+			this.ids = ImmutableSortedSet.copyOf(ids);
+			this.expand = expand;
+			this.locales = locales;
+			this.onConceptsReady = onConceptsReady;
+		}
+		
+		@Override
+		public int hashCode() {
+			return Objects.hash(ids, expand, locales);
+		}
+		
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) return true;
+			if (obj == null) return false;
+			if (getClass() != obj.getClass()) return false;
+			FetchConfig other = (FetchConfig) obj;
+			return Objects.equals(ids, other.ids)
+					&& Objects.equals(expand, other.expand)
+					&& Objects.equals(locales, other.locales);
+		}
+		
+	}
+	
+}

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedContentRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedContentRequestBuilder.java
@@ -16,6 +16,8 @@
 package com.b2international.snowowl.snomed.datastore.request;
 
 import com.b2international.snowowl.core.context.TerminologyResourceContentRequestBuilder;
+import com.b2international.snowowl.core.domain.BranchContext;
+import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.snomed.common.SnomedTerminologyComponentConstants;
 
 /**
@@ -24,6 +26,11 @@ import com.b2international.snowowl.snomed.common.SnomedTerminologyComponentConst
  */
 public interface SnomedContentRequestBuilder<R> extends TerminologyResourceContentRequestBuilder<R> {
 
+	@Override
+	default Request<BranchContext, R> wrap(Request<BranchContext, R> req) {
+		return TerminologyResourceContentRequestBuilder.super.wrap(new SnomedConceptCachingRequest<>(req));
+	}
+	
 	@Override
 	default String getToolingId() {
 		return SnomedTerminologyComponentConstants.TOOLING_ID;

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedSearchRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedSearchRequestBuilder.java
@@ -22,7 +22,6 @@ import com.b2international.snowowl.core.date.DateFormats;
 import com.b2international.snowowl.core.date.EffectiveTimes;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.domain.PageableCollectionResource;
-import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.request.SearchPageableCollectionResourceRequestBuilder;
 import com.b2international.snowowl.snomed.datastore.request.SnomedSearchRequest.OptionKey;
 
@@ -137,9 +136,4 @@ public abstract class SnomedSearchRequestBuilder<B extends SnomedSearchRequestBu
 		return addOption(OptionKey.ECL_EXPRESSION_FORM, expressionForm);
 	}
 	
-	@Override
-	public Request<BranchContext, R> wrap(Request<BranchContext, R> req) {
-		return SnomedContentRequestBuilder.super.wrap(new SnomedConceptCachingRequest<>(req));
-	}
-
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedSearchRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedSearchRequestBuilder.java
@@ -22,6 +22,7 @@ import com.b2international.snowowl.core.date.DateFormats;
 import com.b2international.snowowl.core.date.EffectiveTimes;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.domain.PageableCollectionResource;
+import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.request.SearchPageableCollectionResourceRequestBuilder;
 import com.b2international.snowowl.snomed.datastore.request.SnomedSearchRequest.OptionKey;
 
@@ -134,6 +135,11 @@ public abstract class SnomedSearchRequestBuilder<B extends SnomedSearchRequestBu
 	 */
 	public final B setEclExpressionForm(String expressionForm) {
 		return addOption(OptionKey.ECL_EXPRESSION_FORM, expressionForm);
+	}
+	
+	@Override
+	public Request<BranchContext, R> wrap(Request<BranchContext, R> req) {
+		return SnomedContentRequestBuilder.super.wrap(new SnomedConceptCachingRequest<>(req));
 	}
 
 }


### PR DESCRIPTION
...to dedupe requests going to Elasticsearch and reduce load on both the
ES cluster and the termserver.

This effectively improves search performance of concepts with
additionally fetched concept data on multiple components (using the expand API), including
descriptions, relationships, members (deduped expanded fields are:
`module`, `type`, `source`, `destination`, `caseSignificance`,
`modifier`, `definitionStatus`, `languageRefSet` and others).