### PR TITLE
refactor(core): Clarify that resources store bundle ancestor IDs...

### DIFF
--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/Resource.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/Resource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,10 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Set;
 
+import com.b2international.snowowl.core.domain.IComponent;
 import com.b2international.snowowl.core.internal.ResourceDocument;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.google.common.collect.ImmutableList;
 
 /**
  * @since 8.0
@@ -58,6 +60,13 @@ public abstract class Resource implements Serializable {
 			RESOURCE_TYPE,
 			TYPE_RANK
 		);
+	}
+	
+	/**
+	 * @since 8.0.1
+	 */
+	public static final class Expand {
+		public static final String RESOURCE_PATH_LABELS = "resourcePathLabels";
 	}
 	
 	// unique identifier for each resource, can be auto-generated or manually specified
@@ -99,6 +108,9 @@ public abstract class Resource implements Serializable {
 	// The ID of the bundle this resource is directly contained by
 	private String bundleId;
 
+	// The label of all bundles leading to this resource (expandable property)
+	private List<String> resourcePathLabels;
+	
 	/**
 	 * @return the type of the resource
 	 */
@@ -241,6 +253,36 @@ public abstract class Resource implements Serializable {
 	
 	public void setBundleId(String bundleId) {
 		this.bundleId = bundleId;
+	}
+	
+	/**
+	 * @return the ID of all bundles leading to the resource, starting with "-1" (the ID of the resource root)
+	 */
+	public List<String> getResourcePathSegments() {
+		final List<String> ancestorIds = getBundleAncestorIds();
+		final String parentId = getBundleId();
+		
+		if (IComponent.ROOT_ID.equals(parentId)) {
+			return ancestorIds;
+		}
+		
+		// Append our _parent ID_ to our ancestor ID array
+		return ImmutableList.<String>builder()
+			.addAll(ancestorIds)
+			.add(parentId)
+			.build();
+	}
+	
+	// XXX empty setter to make Jackson happy when deserializing
+	@JsonSetter
+	/*package*/ final void setResourcePathSegments(List<String> resourcePathSegments) {}
+	
+	public List<String> getResourcePathLabels() {
+		return resourcePathLabels;
+	}
+	
+	public void setResourcePathLabels(final List<String> resourcePathLabels) {
+		this.resourcePathLabels = resourcePathLabels;
 	}
 
 	/**

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/bundle/Bundle.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/bundle/Bundle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,11 @@
  */
 package com.b2international.snowowl.core.bundle;
 
-import java.util.List;
-
 import com.b2international.snowowl.core.Resource;
 import com.b2international.snowowl.core.Resources;
-import com.b2international.snowowl.core.domain.IComponent;
 import com.b2international.snowowl.core.internal.ResourceDocument;
 import com.b2international.snowowl.core.internal.ResourceDocument.Builder;
 import com.b2international.snowowl.core.request.ResourceRequests;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.collect.ImmutableList;
 
 /**
  * @since 8.0
@@ -109,19 +104,5 @@ public final class Bundle extends Resource {
 		bundle.setBundleAncestorIds(doc.getBundleAncestorIds());
 		bundle.setBundleId(doc.getBundleId());
 		return bundle;
-	}
-
-	@JsonIgnore
-	public List<String> getBundleAncestorIdsForChild() {
-		final List<String> ancestorIds = getBundleAncestorIds();
-		if (IComponent.ROOT_ID.equals(getBundleId())) {
-			return ancestorIds;
-		}
-		
-		// Append our _parent ID_ to our ancestor ID array to get a child resource's ancestor ID array
-		return ImmutableList.<String>builder()
-			.addAll(ancestorIds)
-			.add(getBundleId())
-			.build();
 	}
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/ResourceDocument.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/ResourceDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -466,6 +466,7 @@ public final class ResourceDocument extends RevisionDocument {
 	private final String contact;
 	private final String usage;
 	private final String purpose;
+	// Ordered ancestor bundle IDs, sorted by depth
 	private final List<String> bundleAncestorIds;
 	private final String bundleId;
 	
@@ -616,5 +617,4 @@ public final class ResourceDocument extends RevisionDocument {
 				.or(() -> Optional.ofNullable(getCreated()).map(RevisionBranchPoint::getTimestamp))
 				.orElse(null);
 	}
-	
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/BaseResourceCreateRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/BaseResourceCreateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -236,7 +236,7 @@ public abstract class BaseResourceCreateRequest implements Request<TransactionCo
 			}
 	
 			final Bundle bundleParent = bundles.first().get();
-			bundleAncestorIds = bundleParent.getBundleAncestorIdsForChild();
+			bundleAncestorIds = bundleParent.getResourcePathSegments();
 		}
 		
 		context.add(createResourceDocument(context, bundleAncestorIds));

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/BaseResourceUpdateRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/BaseResourceUpdateRequest.java
@@ -209,7 +209,7 @@ public abstract class BaseResourceUpdateRequest extends UpdateRequest<Transactio
 		}
 		
 		// Update both bundle ID and ancestor IDs on the resource
-		updated.bundleAncestorIds(parentBundle.getBundleAncestorIdsForChild());
+		updated.bundleAncestorIds(parentBundle.getResourcePathSegments());
 		updated.bundleId(parentBundle.getId());
 		
 		// Update bundle ancestor IDs on the descendants of the resource (their bundle ID does not change)
@@ -224,7 +224,7 @@ public abstract class BaseResourceUpdateRequest extends UpdateRequest<Transactio
 		
 		// Calculate new ancestor ID list for direct children of the resource. Their bundleId remains "resourceId".
 		final Map<String, List<String>> newAncestorIdsByParentId = newHashMap(Map.of(resourceId, ImmutableList.<String>builder()
-			.addAll(parentBundle.getBundleAncestorIdsForChild())
+			.addAll(parentBundle.getResourcePathSegments())
 			.add(parentBundle.getId())
 			.build()));
 		

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/BaseResourceUpdateRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/BaseResourceUpdateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.b2international.snowowl.core.request;
 import static com.google.common.collect.Maps.newHashMap;
 
 import java.util.*;
+import java.util.Map.Entry;
 
 import com.b2international.commons.collections.Collections3;
 import com.b2international.commons.exceptions.AlreadyExistsException;
@@ -203,15 +204,15 @@ public abstract class BaseResourceUpdateRequest extends UpdateRequest<Transactio
 		}
 
 		Bundle parentBundle = bundles.first().get();
-		if (parentBundle.getBundleId().equals(resourceId) || Collections3.toImmutableSet(parentBundle.getBundleAncestorIds()).contains(resourceId)) {
+		if (parentBundle.getBundleId().equals(resourceId) || parentBundle.getBundleAncestorIds().contains(resourceId)) {
 			throw new CycleDetectedException("Setting parent bundle ID to '" + bundleId + "' would create a loop.");
 		}
 		
-		// Update the "direct parent" and ancestor identifiers on the resource
+		// Update both bundle ID and ancestor IDs on the resource
 		updated.bundleAncestorIds(parentBundle.getBundleAncestorIdsForChild());
 		updated.bundleId(parentBundle.getId());
 		
-		// Update ancestors on the resource and its descendants
+		// Update bundle ancestor IDs on the descendants of the resource (their bundle ID does not change)
 		final Iterator<Resource> descendants = ResourceRequests.prepareSearch()
 			.filterByBundleAncestorId(resourceId)
 			.setLimit(5_000)
@@ -219,35 +220,53 @@ public abstract class BaseResourceUpdateRequest extends UpdateRequest<Transactio
 			.flatMap(Resources::stream)
 			.iterator();
 		
-		final Multimap<String, Resource> resourcesByParent = Multimaps.index(descendants, Resource::getBundleId);
-		final Map<String, List<String>> ancestorsForChildByParentId = newHashMap(Map.of(resourceId, ImmutableList.<String>builder()
+		final Multimap<String, Resource> resourcesByParentId = Multimaps.index(descendants, Resource::getBundleId);
+		
+		// Calculate new ancestor ID list for direct children of the resource. Their bundleId remains "resourceId".
+		final Map<String, List<String>> newAncestorIdsByParentId = newHashMap(Map.of(resourceId, ImmutableList.<String>builder()
 			.addAll(parentBundle.getBundleAncestorIdsForChild())
 			.add(parentBundle.getId())
 			.build()));
 		
-		// Start with the immediate children of the current resource
-		final Deque<Resource> toProcess = new ArrayDeque<>(resourcesByParent.get(resourceId));
+		// Start processing ancestor ID lists with the direct children of the resource
+		final Deque<Map.Entry<String, Collection<Resource>>> toProcess = new ArrayDeque<>();
+		toProcess.addLast(new AbstractMap.SimpleImmutableEntry<>(resourceId, resourcesByParentId.get(resourceId)));
 		
 		while (!toProcess.isEmpty()) {
-			final Resource current = toProcess.removeFirst();
-			final String currentId = current.getId();
-			final ResourceDocument resource = context.lookup(currentId, ResourceDocument.class);
-			final ResourceDocument.Builder currentBuilder = ResourceDocument.builder(resource);
-
-			final String parentId = current.getBundleId();
-			final List<String> ancestorIds = ancestorsForChildByParentId.get(parentId);
-			currentBuilder.bundleAncestorIds(ancestorIds);
-			context.add(currentBuilder.build());
+			final Entry<String, Collection<Resource>> entry = toProcess.removeFirst();
+			final String parentId = entry.getKey();
+			final Collection<Resource> resources = entry.getValue();
 			
-			final Collection<Resource> children = resourcesByParent.get(currentId);
-			if (!children.isEmpty()) {
-				final List<String> nextAncestorIds = ImmutableList.<String>builder()
-					.addAll(ancestorIds)
-					.add(parentId)
-					.build();
-
-				ancestorsForChildByParentId.put(currentId, nextAncestorIds);
-				toProcess.addAll(children);
+			/*
+			 * XXX: We will use the same ancestor ID list for all sibling resources. The
+			 * call removes the entry from the map as it will never be read again after this
+			 * iteration.
+			 */
+			final List<String> newAncestorIds = newAncestorIdsByParentId.remove(parentId);
+			
+			for (final Resource current : resources) {
+				final String id = current.getId();
+				final ResourceDocument resource = context.lookup(id, ResourceDocument.class);
+				final ResourceDocument.Builder resourceBuilder = ResourceDocument.builder(resource);
+				
+				resourceBuilder.bundleAncestorIds(newAncestorIds);
+				context.add(resourceBuilder.build());
+			
+				final Collection<Resource> next = resourcesByParentId.get(id);
+				if (!next.isEmpty()) {
+					/*
+					 * If the current resource has any children, make a note that we have to update
+					 * bundleAncestorIds for them as well. The bundleId for these resources remains
+					 * "id".
+					 */
+					final List<String> nextAncestorIds = ImmutableList.<String>builder()
+						.addAll(newAncestorIds)
+						.add(parentId)
+						.build();
+					
+					newAncestorIdsByParentId.put(id, nextAncestorIds);
+					toProcess.add(new AbstractMap.SimpleImmutableEntry<>(id, next));
+				}
 			}
 		}
 		


### PR DESCRIPTION
...in order of depth, ie. a bundle path/absolute path can be computed by
concatenating all ancestor IDs, the container bundle ID and optionally,
the resource ID.

The only exception are resources that reside in the resource root, where
both the container bundle ID is set to -1 and the ancestor ID array
contains a single element with -1 as the value.

Additionally, the descendant updating step in BaseResourceUpdateRequest
was refactored to process siblings in a single iteration, and reduce
memory usage slightly.