### PR TITLE
SO-4985: Update extension namespace-module assignment logic

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/SnomedClassificationRestRequests.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/SnomedClassificationRestRequests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import static org.junit.Assert.fail;
 import java.util.Map;
 import java.util.Set;
 
+import com.b2international.commons.json.Json;
 import com.b2international.snowowl.core.api.IBranchPath;
 import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
 import com.b2international.snowowl.snomed.datastore.config.SnomedCoreConfiguration;
@@ -91,12 +92,10 @@ public abstract class SnomedClassificationRestRequests {
 	}
 
 	public static ValidatableResponse beginClassificationSave(IBranchPath branchPath, String classificationId) {
-		Map<String, Object> requestBody = ImmutableMap.<String, Object>of(
-			"status", ClassificationStatus.SAVED.toString(),
-			"module", Concepts.MODULE_SCT_CORE,
-			"namespace", ""
-		);
+		return beginClassificationSave(classificationId, createClassificationSaveBody());
+	}
 
+	public static ValidatableResponse beginClassificationSave(String classificationId, Json requestBody) {
 		return givenAuthenticatedRequest(SnomedApiTestConstants.SCT_API)
 				.contentType(ContentType.JSON)
 				.body(requestBody)
@@ -104,6 +103,14 @@ public abstract class SnomedClassificationRestRequests {
 				.then()
 				.assertThat()
 				.statusCode(204);
+	}
+
+	public static Json createClassificationSaveBody() {
+		return Json.object(
+			"status", ClassificationStatus.SAVED.toString(),
+			"module", Concepts.MODULE_SCT_CORE,
+			"namespace", ""
+		);
 	}
 
 	public static ValidatableResponse waitForClassificationSaveJob(IBranchPath branchPath, String classificationId) throws InterruptedException {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/DefaultNamespaceAndModuleAssigner.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/DefaultNamespaceAndModuleAssigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ public final class DefaultNamespaceAndModuleAssigner implements SnomedNamespaceA
 	}
 	
 	@Override
-	public void init(final String defaultNamespace, final String defaultModule) {
+	public void init(final String defaultNamespace, final String defaultModule, BranchContext context) {
 		this.defaultNamespace = defaultNamespace;
 		this.defaultModule = defaultModule;
 	}
@@ -56,11 +56,11 @@ public final class DefaultNamespaceAndModuleAssigner implements SnomedNamespaceA
 	}
 
 	@Override
-	public void collectRelationshipNamespacesAndModules(final Set<String> conceptIds, final BranchContext context) {
+	public void collectRelationshipModules(final Set<String> conceptIds) {
 	}
 
 	@Override
-	public void collectConcreteDomainModules(final Set<String> conceptIds, final BranchContext context) {
+	public void collectConcreteDomainModules(final Set<String> conceptIds) {
 	}
 
 	@Override

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/ExtensionNamespaceAndModuleAssigner.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/ExtensionNamespaceAndModuleAssigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,23 +17,34 @@ package com.b2international.snowowl.snomed.datastore.id.assigner;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Set;
+import java.util.*;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import com.b2international.collections.PrimitiveMaps;
 import com.b2international.collections.longs.LongKeyLongMap;
+import com.b2international.snowowl.core.branch.Branch;
+import com.b2international.snowowl.core.codesystem.CodeSystem;
+import com.b2international.snowowl.core.codesystem.CodeSystemRequests;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.plugin.Component;
 import com.b2international.snowowl.snomed.cis.SnomedIdentifiers;
-import com.b2international.snowowl.snomed.common.SnomedConstants;
+import com.b2international.snowowl.snomed.common.SnomedTerminologyComponentConstants;
 import com.b2international.snowowl.snomed.core.domain.SnomedConcept;
 import com.b2international.snowowl.snomed.datastore.index.entry.SnomedComponentDocument;
 import com.b2international.snowowl.snomed.datastore.request.SnomedRequests;
 import com.google.common.collect.Sets;
 
 /**
- * Simple assigner that allocates the namespaces and modules for relationships
- * and concrete domains to match the source concept's namespace.
+ * Simple namespace-module assigner applicable for extension authoring.
+ * <p>
+ * Relationship <b>namespaces</b> match the source concept's namespace, unless
+ * the source concept's module is not in the current code system's module list,
+ * in which case the specified <code>defaultNamespace</code> value will be used.
+ * <p>
+ * Relationship and concrete domain <b>modules</b> match the source concept's
+ * module, unless it is not in the current code system's module list, in which
+ * case the specified <code>defaultModule</code> value is used.
  * 
  * @since 5.11.5
  */
@@ -42,24 +53,69 @@ public final class ExtensionNamespaceAndModuleAssigner implements SnomedNamespac
 	
 	private final LongKeyLongMap relationshipModuleMap = PrimitiveMaps.newLongKeyLongOpenHashMap();
 	private final LongKeyLongMap concreteDomainModuleMap = PrimitiveMaps.newLongKeyLongOpenHashMap();
+	private final Set<String> extensionModuleIds = Sets.newHashSet();
 	
 	private String defaultNamespace;
 	private String defaultModule;
-	
-	private Set<String> internationalModuleIds = Sets.newHashSet();
+	private BranchContext context;
 
 	public ExtensionNamespaceAndModuleAssigner() {}
 	
 	@Override
-	public void init(final String defaultNamespace, final String defaultModule) {
+	public void init(final String defaultNamespace, final String defaultModule, final BranchContext context) {
 		this.defaultNamespace = defaultNamespace;
 		this.defaultModule = defaultModule;
+		this.context = context;
+
+		relationshipModuleMap.clear();
+		concreteDomainModuleMap.clear();
+		extensionModuleIds.clear();
+		
+		initExtensionParentModules();
 	}
 	
+	private void initExtensionParentModules() {
+		final String path = context.path();
+		final Map<String, CodeSystem> snomedCodeSystems = CodeSystemRequests.prepareSearchCodeSystem()
+			.all()
+			.filterByToolingId(SnomedTerminologyComponentConstants.TERMINOLOGY_ID)
+			.build()
+			.execute(context)
+			.stream()
+			/*
+			 * The current branch should be either a working branch, or a descendant of the
+			 * code system's working branch.
+			 */
+			.filter(cs -> path.equals(cs.getBranchPath()) || path.startsWith(cs.getBranchPath() + Branch.SEPARATOR))
+			.collect(Collectors.toMap(cs -> cs.getShortName(), cs -> cs));
+		
+		final Optional<CodeSystem> currentCodeSystem = snomedCodeSystems.values()
+			.stream()
+			// Longest matching working branch path (or prefix) wins
+			.max(Comparator.comparing(cs -> cs.getBranchPath().length()));
+
+		// Collect module IDs based on code system metadata
+		if (!currentCodeSystem.isEmpty()) {
+			final Collection<String> moduleIds = (Collection<String>) currentCodeSystem.get()
+				.getAdditionalProperties()
+				.getOrDefault(SnomedTerminologyComponentConstants.CODESYSTEM_MODULES_CONFIG_KEY, List.of());
+			
+			extensionModuleIds.addAll(moduleIds);
+		}
+	}
+
 	@Override
 	public String getRelationshipNamespace(final String sourceConceptId) {
-		String namespace = SnomedIdentifiers.getNamespace(sourceConceptId);
-		return namespace.isEmpty() ? defaultNamespace : namespace;
+		final String sourceConceptNamespace = SnomedIdentifiers.getNamespace(sourceConceptId);
+		final long sourceConceptIdAsLong = Long.parseLong(sourceConceptId);
+		checkArgument(relationshipModuleMap.containsKey(sourceConceptIdAsLong), "The relationship module ID for '%s' was not collected.", sourceConceptId);
+		final String moduleId = Long.toString(relationshipModuleMap.get(sourceConceptIdAsLong));
+		
+		if (!extensionModuleIds.contains(moduleId)) {
+			return defaultNamespace;
+		}
+		
+		return sourceConceptNamespace;
 	}
 
 	@Override
@@ -68,7 +124,7 @@ public final class ExtensionNamespaceAndModuleAssigner implements SnomedNamespac
 		checkArgument(relationshipModuleMap.containsKey(sourceConceptIdAsLong), "The relationship module ID for '%s' was not collected.", sourceConceptId);
 		final String moduleId = Long.toString(relationshipModuleMap.get(sourceConceptIdAsLong));
 		
-		if (internationalModuleIds.contains(moduleId)) {
+		if (!extensionModuleIds.contains(moduleId)) {
 			return defaultModule;
 		}
 		
@@ -81,7 +137,7 @@ public final class ExtensionNamespaceAndModuleAssigner implements SnomedNamespac
 		checkArgument(concreteDomainModuleMap.containsKey(referencedConceptIdAsLong), "The concrete domain member module ID for '%s' was not collected.", referencedConceptId);
 		final String moduleId = Long.toString(concreteDomainModuleMap.get(referencedConceptIdAsLong));
 		
-		if (internationalModuleIds.contains(moduleId)) {
+		if (!extensionModuleIds.contains(moduleId)) {
 			return defaultModule;
 		}
 		
@@ -89,42 +145,28 @@ public final class ExtensionNamespaceAndModuleAssigner implements SnomedNamespac
 	}
 
 	@Override
-	public void collectRelationshipNamespacesAndModules(final Set<String> conceptIds, final BranchContext context) {
+	public void collectRelationshipModules(final Set<String> conceptIds) {
 		relationshipModuleMap.clear();
 
-		collectModules(conceptIds, context, c -> {
+		collectModules(conceptIds, c -> {
 			final long conceptId = Long.parseLong(c.getId());
 			final long moduleId = Long.parseLong(c.getModuleId());
 			relationshipModuleMap.put(conceptId, moduleId);
 		});
-		
-		initializeInternationalModules(context);
 	}
 
 	@Override
-	public void collectConcreteDomainModules(final Set<String> conceptIds, final BranchContext context) {
+	public void collectConcreteDomainModules(final Set<String> conceptIds) {
 		concreteDomainModuleMap.clear();
 
-		collectModules(conceptIds, context, c -> {
+		collectModules(conceptIds, c -> {
 			final long conceptId = Long.parseLong(c.getId());
 			final long moduleId = Long.parseLong(c.getModuleId());
 			concreteDomainModuleMap.put(conceptId, moduleId);
 		});
 	}
 	
-	private void initializeInternationalModules(BranchContext context) {
-		if (internationalModuleIds.isEmpty()) {
-			SnomedRequests.prepareSearchConcept()
-				.all()
-				.filterByActive(true)
-				.filterByEcl(String.format("<<%s", SnomedConstants.Concepts.IHTSDO_MAINTAINED_MODULE))
-				.build()
-				.execute(context)
-				.forEach(concept -> internationalModuleIds.add(concept.getId()));
-		}
-	}
-	
-	private void collectModules(final Set<String> conceptIds, final BranchContext context, final Consumer<SnomedConcept> consumer) {
+	private void collectModules(final Set<String> conceptIds, final Consumer<SnomedConcept> consumer) {
 		SnomedRequests.prepareSearchConcept()
 			.setLimit(conceptIds.size())
 			.filterByIds(conceptIds)
@@ -149,5 +191,4 @@ public final class ExtensionNamespaceAndModuleAssigner implements SnomedNamespac
 	public String toString() {
 		return String.format("%s[defaultNamespace: '%s', defaultModule: '%s']", getName(), defaultNamespace, defaultModule);
 	}
-	
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/SnomedNamespaceAndModuleAssigner.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/SnomedNamespaceAndModuleAssigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package com.b2international.snowowl.snomed.datastore.id.assigner;
 import java.util.Set;
 
 import com.b2international.commons.exceptions.FormattedRuntimeException;
-import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.plugin.ClassPathScanner;
 
@@ -43,8 +42,9 @@ public interface SnomedNamespaceAndModuleAssigner {
 	 * 
 	 * @param defaultNamespace
 	 * @param defaultModule
+	 * @param context
 	 */
-	void init(String defaultNamespace, String defaultModule);
+	void init(String defaultNamespace, String defaultModule, BranchContext context);
 
 	/**
 	 * Returns an SCTID to be registered to a relationship based on its source concept ID.
@@ -75,15 +75,13 @@ public interface SnomedNamespaceAndModuleAssigner {
 
 	/**
 	 * @param conceptIds
-	 * @param context
 	 */
-	void collectRelationshipNamespacesAndModules(Set<String> conceptIds, BranchContext context);
+	void collectRelationshipModules(Set<String> conceptIds);
 
 	/**
 	 * @param conceptIds
-	 * @param context
 	 */
-	void collectConcreteDomainModules(Set<String> conceptIds, BranchContext context);
+	void collectConcreteDomainModules(Set<String> conceptIds);
 
 	/**
 	 * Clears the internal maps of this assigner.
@@ -99,13 +97,15 @@ public interface SnomedNamespaceAndModuleAssigner {
 	 * @param namespace
 	 * @return
 	 */
-	static SnomedNamespaceAndModuleAssigner create(ServiceProvider context, String assignerType, String moduleId, String namespace) {
-		SnomedNamespaceAndModuleAssigner assigner = context.service(ClassPathScanner.class).getComponentsByInterface(SnomedNamespaceAndModuleAssigner.class)
-				.stream()
-				.filter(a -> assignerType.equals(a.getName()))
-				.findFirst()
-				.orElseThrow(() -> new FormattedRuntimeException("Couldn't find namespace and module assigner '%s'.", assignerType));
-		assigner.init(namespace, moduleId);
+	static SnomedNamespaceAndModuleAssigner create(BranchContext context, String assignerType, String moduleId, String namespace) {
+		final SnomedNamespaceAndModuleAssigner assigner = context.service(ClassPathScanner.class)
+			.getComponentsByInterface(SnomedNamespaceAndModuleAssigner.class)
+			.stream()
+			.filter(a -> assignerType.equals(a.getName()))
+			.findFirst()
+			.orElseThrow(() -> new FormattedRuntimeException("Couldn't find namespace and module assigner '%s'.", assignerType));
+		
+		assigner.init(namespace, moduleId, context);
 		return assigner;
 	}
 

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/SaveJobRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/SaveJobRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -287,7 +287,7 @@ final class SaveJobRequest implements Request<BranchContext, Boolean>, BranchAcc
 						SnomedRelationship::getSourceId)); // values: source concept ID of the "origin" relationship
 			
 			conceptIds.removeAll(conceptIdsToSkip);
-			namespaceAndModuleAssigner.collectRelationshipNamespacesAndModules(conceptIds, context);
+			namespaceAndModuleAssigner.collectRelationshipModules(conceptIds);
 
 			for (final RelationshipChange change : nextChanges) {
 				final ReasonerRelationship relationship = change.getRelationship();
@@ -375,7 +375,7 @@ final class SaveJobRequest implements Request<BranchContext, Boolean>, BranchAcc
 
 			// Concepts which will be inactivated as part of equivalent concept merging should be excluded
 			conceptIds.removeAll(conceptIdsToSkip);
-			namespaceAndModuleAssigner.collectConcreteDomainModules(conceptIds, context);
+			namespaceAndModuleAssigner.collectConcreteDomainModules(conceptIds);
 
 			for (final ConcreteDomainChange change : nextChanges) {
 				final ReasonerConcreteDomainMember referenceSetMember = change.getConcreteDomainMember();
@@ -501,7 +501,7 @@ final class SaveJobRequest implements Request<BranchContext, Boolean>, BranchAcc
 			}
 		}
 		
-		assigner.collectRelationshipNamespacesAndModules(relationshipChangeConceptIds, context);
+		assigner.collectRelationshipModules(relationshipChangeConceptIds);
 		
 		for (final SnomedConcept conceptToKeep : equivalentConcepts.keySet()) {
 			
@@ -536,7 +536,7 @@ final class SaveJobRequest implements Request<BranchContext, Boolean>, BranchAcc
 		
 		// CD members are always "outbound", however, so the concept SCTID set can be reduced
 		assigner.clear();
-		assigner.collectConcreteDomainModules(conceptIdsToKeep, context);
+		assigner.collectConcreteDomainModules(conceptIdsToKeep);
 		
 		for (final SnomedConcept conceptToKeep : equivalentConcepts.keySet()) {
 			for (final SnomedReferenceSetMember member : conceptToKeep.getMembers()) {
@@ -555,7 +555,7 @@ final class SaveJobRequest implements Request<BranchContext, Boolean>, BranchAcc
 		
 		// Descriptions are also "outbound"
 		assigner.clear();
-		assigner.collectRelationshipNamespacesAndModules(conceptIdsToKeep, context);
+		assigner.collectRelationshipModules(conceptIdsToKeep);
 
 		for (final SnomedConcept conceptToKeep : equivalentConcepts.keySet()) {
 			for (final SnomedDescription description : conceptToKeep.getDescriptions()) {
@@ -574,7 +574,7 @@ final class SaveJobRequest implements Request<BranchContext, Boolean>, BranchAcc
 		
 		// Inactivation of "removed" concepts also requires modules to be collected according to the assigner rules
 		assigner.clear();
-		assigner.collectRelationshipNamespacesAndModules(conceptIdsToSkip, context);
+		assigner.collectRelationshipModules(conceptIdsToSkip);
 		
 		for (final SnomedConcept conceptToRemove : equivalentConcepts.values()) {
 			// Check if the concept needs to be removed or deactivated

--- a/tests/com.b2international.snowowl.test.commons/src/com/b2international/snowowl/test/commons/codesystem/CodeSystemRestRequests.java
+++ b/tests/com.b2international.snowowl.test.commons/src/com/b2international/snowowl/test/commons/codesystem/CodeSystemRestRequests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,12 @@ import static com.b2international.snowowl.test.commons.rest.RestExtensions.given
 import java.util.Map;
 import java.util.Set;
 
+import com.b2international.commons.json.Json;
 import com.b2international.snowowl.core.api.IBranchPath;
 import com.b2international.snowowl.core.uri.CodeSystemURI;
 import com.b2international.snowowl.snomed.common.SnomedTerminologyComponentConstants;
 import com.b2international.snowowl.snomed.datastore.SnomedDatastoreActivator;
 import com.b2international.snowowl.test.commons.ApiTestConstants;
-import com.google.common.collect.ImmutableMap;
 
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
@@ -44,28 +44,37 @@ public abstract class CodeSystemRestRequests {
 	}
 	
 	private static ValidatableResponse createCodeSystem(CodeSystemURI extensionOf, IBranchPath branchPath, String shortName) {
-		ImmutableMap.Builder<String, Object> requestBody = ImmutableMap.<String, Object>builder()
-				.put("name", shortName)
-				.put("shortName", shortName)
-				.put("citation", "citation")
-				.put("iconPath", "iconPath")
-				.put("repositoryId", SnomedDatastoreActivator.REPOSITORY_UUID)
-				.put("terminologyId", SnomedTerminologyComponentConstants.TERMINOLOGY_ID)
-				.put("oid", "oid_" + shortName)
-				.put("primaryLanguage", "primaryLanguage")
-				.put("organizationLink", "organizationLink");
-		
-		if (extensionOf != null) {
-			requestBody.put("extensionOf", extensionOf);
-		} else if (branchPath != null) {
-			requestBody.put("branchPath", branchPath.getPath());
-		}
-		
+		return createCodeSystem(createCodeSystemBody(extensionOf, branchPath, shortName));
+	}
+
+	public static ValidatableResponse createCodeSystem(Json requestBody) {
 		return givenAuthenticatedRequest(ApiTestConstants.ADMIN_API)
 				.contentType(ContentType.JSON)
-				.body(requestBody.build())
+				.body(requestBody)
 				.post("/codesystems")
 				.then();
+	}
+
+	public static Json createCodeSystemBody(CodeSystemURI extensionOf, IBranchPath branchPath, String shortName) {
+		Json requestBody = Json.object(
+			"name", shortName,
+			"shortName", shortName,
+			"citation", "citation",
+			"iconPath", "iconPath",
+			"repositoryId", SnomedDatastoreActivator.REPOSITORY_UUID,
+			"terminologyId", SnomedTerminologyComponentConstants.TERMINOLOGY_ID,
+			"oid", "oid_" + shortName,
+			"primaryLanguage", "primaryLanguage",
+			"organizationLink", "organizationLink"
+		);
+		
+		if (extensionOf != null) {
+			requestBody = requestBody.with("extensionOf", extensionOf);
+		} else if (branchPath != null) {
+			requestBody = requestBody.with("branchPath", branchPath.getPath());
+		}
+		
+		return requestBody;
 	}
 
 	public static ValidatableResponse getCodeSystem(String id) {


### PR DESCRIPTION
The current code system is derived from the `BranchContext` path, and extension module IDs are retrieved from code system metadata. 

For all inferred or redundant components where the source/referenced concept's module is not in the code system's module list, the module ID will be set to `defaultModuleId`, otherwise the source concept's module will be used. 

The same logic applies to the namespace portion of relationship SCTIDs as well (note that the decision is still made based on the source concept's *module*, not its namespace).