### PR TITLE
feat(api): support expansion of `commits()` in Resource API

### DIFF
--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/Resource.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/Resource.java
@@ -64,9 +64,9 @@ public abstract class Resource implements Serializable {
 	}
 	
 	/**
-	 * @since 8.0.1
+	 * @since 8.1.0
 	 */
-	public static final class Expand {
+	public static abstract class Expand {
 		public static final String RESOURCE_PATH_LABELS = "resourcePathLabels";
 	}
 	

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/TerminologyResource.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/TerminologyResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Map;
 import com.b2international.snowowl.core.branch.Branch;
 import com.b2international.snowowl.core.branch.BranchInfo;
 import com.b2international.snowowl.core.codesystem.UpgradeInfo;
+import com.b2international.snowowl.core.commit.CommitInfos;
 import com.b2international.snowowl.core.internal.ResourceDocument;
 import com.b2international.snowowl.core.internal.ResourceDocument.Builder;
 import com.b2international.snowowl.core.version.Versions;
@@ -38,11 +39,12 @@ public abstract class TerminologyResource extends Resource {
 	/**
 	 * @since 8.0
 	 */
-	public static final class Expand {
+	public static abstract class Expand extends Resource.Expand {
 		public static final String AVAILABLE_UPGRADES = "availableUpgrades";
 		public static final String EXTENSION_OF_BRANCH_INFO = "extensionOfBranchInfo";
 		public static final String UPGRADE_INFO = "upgradeInfo";
 		public static final String VERSIONS = "versions";
+		public static final String COMMITS = "commits";
 	}
 	
 	// standard oid
@@ -71,6 +73,7 @@ public abstract class TerminologyResource extends Resource {
 	private List<ResourceURI> availableUpgrades;
 	
 	private Versions versions;
+	private CommitInfos commits;
 
 	/**
 	 * @return the assigned object identifier (OID) of this code system, eg. "{@code 3.4.5.6.10000}" (can be {@code null})
@@ -166,6 +169,14 @@ public abstract class TerminologyResource extends Resource {
 	
 	public void setVersions(Versions versions) {
 		this.versions = versions;
+	}
+	
+	public CommitInfos getCommits() {
+		return commits;
+	}
+	
+	public void setCommits(CommitInfos commits) {
+		this.commits = commits;
 	}
 	
 	/**

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/ResourceConverter.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/ResourceConverter.java
@@ -18,18 +18,20 @@ package com.b2international.snowowl.core.request;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.commons.options.Options;
-import com.b2international.snowowl.core.Resource;
-import com.b2international.snowowl.core.ResourceTypeConverter;
-import com.b2international.snowowl.core.Resources;
-import com.b2international.snowowl.core.TerminologyResource;
+import com.b2international.snowowl.core.*;
+import com.b2international.snowowl.core.commit.CommitInfo;
 import com.b2international.snowowl.core.domain.IComponent;
 import com.b2international.snowowl.core.domain.RepositoryContext;
+import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.internal.ResourceDocument;
+import com.b2international.snowowl.core.repository.RepositoryRequests;
 import com.b2international.snowowl.core.version.Versions;
+import com.b2international.snowowl.eventbus.IEventBus;
 
 /**
  * @since 8.0
@@ -68,6 +70,7 @@ public final class ResourceConverter extends BaseResourceConverter<ResourceDocum
 			return;
 		}
 
+		expandCommits(results);
 		expandResourcePathLabels(results);
 		expandVersions(results);
 	}
@@ -121,6 +124,34 @@ public final class ResourceConverter extends BaseResourceConverter<ResourceDocum
 						.execute(context());
 					res.setVersions(versions);
 				});
+		}
+	}
+	
+	private void expandCommits(List<Resource> results) {
+		if (expand().containsKey(TerminologyResource.Expand.COMMITS)) {
+			Options expandOptions = expand().getOptions(TerminologyResource.Expand.COMMITS);
+			// commit searches must be performed individually on each resource to provide correct results
+			var commitSearchRequests = results.stream()
+				.filter(TerminologyResource.class::isInstance)
+				.map(TerminologyResource.class::cast)
+				.map(res -> {
+					return RepositoryRequests.commitInfos().prepareSearchCommitInfo()
+						.filterByBranch(res.getBranchPath())
+						.setLimit(getLimit(expandOptions))
+						.setFields(expandOptions.containsKey("fields") ? expandOptions.getList("fields", String.class) : CommitInfo.Fields.DEAFULT_FIELD_SELECTION)
+						.sortBy(expandOptions.containsKey("sort") ? expandOptions.getString("sort") : null)
+						.setLocales(locales())
+						.build(res.getToolingId())
+						.execute(context().service(IEventBus.class))
+						.then(commits -> {
+							res.setCommits(commits);
+							return commits;
+						});
+				})
+				.collect(Collectors.toList());
+			
+			// wait until all search requests resolve, or timeout of 3 minutes reached
+			Promise.all(commitSearchRequests).getSync(3, TimeUnit.MINUTES);
 		}
 	}
 	


### PR DESCRIPTION
This PR introduces a new expand parameter to the Resource API, called `commits` to support single HTTP calls when listing resources along with their relevant commits.