### PR TITLE
SO-5362: Support retrieval of historical state for resources

### DIFF
--- a/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/CodeSystemApiAssert.java
+++ b/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/CodeSystemApiAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,14 +45,22 @@ public abstract class CodeSystemApiAssert {
 	
 	public static ValidatableResponse assertCodeSystemSearch(final Map<String, Object> filters) {
 		return givenAuthenticatedRequest(CODESYSTEMS_API)
-				.when().queryParams(filters).get()
-				.then().assertThat();
+			.queryParams(filters)
+			.get()
+			.then();
 	}
 	
 	public static ValidatableResponse assertCodeSystemGet(final String codeSystemId) {
 		return givenAuthenticatedRequest(CODESYSTEMS_API)
-			.when().get("/{id}", codeSystemId)
-			.then().assertThat();
+			.get("/{id}", codeSystemId)
+			.then();
+	}
+	
+	public static ValidatableResponse assertCodeSystemGet(final String codeSystemId, final long timestamp) {
+		return givenAuthenticatedRequest(CODESYSTEMS_API)
+			.queryParam("timestamp", timestamp)
+			.get("/{id}", codeSystemId)
+			.then();
 	}
 	
 	public static String assertCodeSystemCreated(final Map<String, Object> requestBody) {

--- a/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/ResourceApiAssert.java
+++ b/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/ResourceApiAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,13 +34,21 @@ public class ResourceApiAssert {
 	
 	public static ValidatableResponse assertResourceSearch(final Map<String, Object> filters) {
 		return givenAuthenticatedRequest(RESOURCES_API)
-				.when().queryParams(filters).get()
-				.then().assertThat();
+			.queryParams(filters)
+			.get()
+			.then();
 	}
 	
 	public static ValidatableResponse assertResourceGet(final String resourceId) {
 		return givenAuthenticatedRequest(RESOURCES_API)
-				.when().get("/{id}", resourceId)
-				.then().assertThat();
+			.get("/{id}", resourceId)
+			.then();
+	}
+	
+	public static ValidatableResponse assertResourceGet(final String resourceId, final long timestamp) {
+		return givenAuthenticatedRequest(RESOURCES_API)
+			.queryParam("timestamp", timestamp)
+			.get("/{id}", resourceId)
+			.then();
 	}
 }

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/bundle/BundleRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/bundle/BundleRestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,16 +64,17 @@ public class BundleRestService extends AbstractRestService {
 	})
 	@GetMapping(produces = { AbstractRestService.JSON_MEDIA_TYPE })
 	public Promise<Bundles> searchByGet(@ParameterObject final BundleRestSearch params) {
+		
 		return ResourceRequests.bundles().prepareSearch()
-				.filterByIds(params.getId())
-				.filterByTitle(params.getTitle())
-				.setLimit(params.getLimit())
-				.setExpand(params.getExpand())
-				.setFields(params.getField())
-				.setSearchAfter(params.getSearchAfter())
-				.sortBy(extractSortFields(params.getSort()))
-				.buildAsync()
-				.execute(getBus());
+			.filterByIds(params.getId())
+			.filterByTitle(params.getTitle())
+			.setLimit(params.getLimit())
+			.setExpand(params.getExpand())
+			.setFields(params.getField())
+			.setSearchAfter(params.getSearchAfter())
+			.sortBy(extractSortFields(params.getSort()))
+			.buildAsync(params.getTimestamp())
+			.execute(getBus());
 	}
 	
 	@Operation(
@@ -89,9 +90,7 @@ public class BundleRestService extends AbstractRestService {
 		@ApiResponse(responseCode = "400", description = "Invalid search config"),
 	})
 	@PostMapping(value="/search", produces = { AbstractRestService.JSON_MEDIA_TYPE })
-	public Promise<Bundles> searchByPost(
-			@RequestBody
-			final BundleRestSearch params) {
+	public Promise<Bundles> searchByPost(@RequestBody(required = false) final BundleRestSearch params) {
 		return searchByGet(params);
 	}
 	
@@ -105,17 +104,21 @@ public class BundleRestService extends AbstractRestService {
 	})
 	@GetMapping(value = "/{bundleId}", produces = { AbstractRestService.JSON_MEDIA_TYPE })
 	public Promise<Bundle> get(
-			@Parameter(description="The bundle identifier")
-			@PathVariable(value="bundleId", required = true) 
-			final String bundleId,
-			
-			@ParameterObject
-			final ResourceSelectors selectors) {
+		@Parameter(description="The bundle identifier")
+		@PathVariable(value="bundleId", required = true) 
+		final String bundleId,
+
+		@Parameter(description = "The timestamp to use for historical ('as of') queries")
+		final Long timestamp,
+		
+		@ParameterObject
+		final ResourceSelectors selectors) {
+		
 		return ResourceRequests.bundles().prepareGet(bundleId)
-				.setExpand(selectors.getExpand())
-				.setFields(selectors.getField())
-				.buildAsync()
-				.execute(getBus());
+			.setExpand(selectors.getExpand())
+			.setFields(selectors.getField())
+			.buildAsync(timestamp)
+			.execute(getBus());
 	}
 	
 	@Operation(

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/codesystem/CodeSystemRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/codesystem/CodeSystemRestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.request.ResourceRequests;
 import com.b2international.snowowl.core.rest.AbstractRestService;
 import com.b2international.snowowl.core.rest.domain.ResourceRequest;
+import com.b2international.snowowl.core.rest.domain.ResourceSelectors;
 import com.b2international.snowowl.core.rest.resource.TerminologyResourceRestSearch;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -61,22 +62,23 @@ public class CodeSystemRestService extends AbstractRestService {
 	})
 	@GetMapping(produces = { AbstractRestService.JSON_MEDIA_TYPE })
 	public Promise<CodeSystems> searchByGet(@ParameterObject final TerminologyResourceRestSearch params) {
+		
 		return CodeSystemRequests.prepareSearchCodeSystem()
-				.filterByIds(params.getId())
-				.filterByOids(params.getOid())
-				.filterByTitle(params.getTitle())
-				.filterByTitleExact(params.getTitleExact())
-				.filterByToolingIds(params.getToolingId())
-				.filterByBundleIds(params.getBundleId())
-				.filterByBundleAncestorIds(params.getBundleAncestorId())
-				.filterByStatus(params.getStatus())
-				.setLimit(params.getLimit())
-				.setExpand(params.getExpand())
-				.setFields(params.getField())
-				.setSearchAfter(params.getSearchAfter())
-				.sortBy(extractSortFields(params.getSort()))
-				.buildAsync()
-				.execute(getBus());
+			.filterByIds(params.getId())
+			.filterByOids(params.getOid())
+			.filterByTitle(params.getTitle())
+			.filterByTitleExact(params.getTitleExact())
+			.filterByToolingIds(params.getToolingId())
+			.filterByBundleIds(params.getBundleId())
+			.filterByBundleAncestorIds(params.getBundleAncestorId())
+			.filterByStatus(params.getStatus())
+			.setLimit(params.getLimit())
+			.setExpand(params.getExpand())
+			.setFields(params.getField())
+			.setSearchAfter(params.getSearchAfter())
+			.sortBy(extractSortFields(params.getSort()))
+			.buildAsync(params.getTimestamp())
+			.execute(getBus());
 	}
 	
 	@Operation(
@@ -93,9 +95,7 @@ public class CodeSystemRestService extends AbstractRestService {
 		@ApiResponse(responseCode = "404", description = "Branch not found")
 	})
 	@PostMapping(value="/search", produces = { AbstractRestService.JSON_MEDIA_TYPE })
-	public @ResponseBody Promise<CodeSystems> searchByPost(
-			@RequestBody(required = false)
-			final TerminologyResourceRestSearch params) {
+	public @ResponseBody Promise<CodeSystems> searchByPost(@RequestBody(required = false) final TerminologyResourceRestSearch params) {
 		return searchByGet(params);
 	}
 
@@ -109,11 +109,20 @@ public class CodeSystemRestService extends AbstractRestService {
 	})
 	@GetMapping(value = "/{codeSystemId}", produces = { AbstractRestService.JSON_MEDIA_TYPE })
 	public Promise<CodeSystem> get(
-			@Parameter(description="The code system identifier")
-			@PathVariable(value="codeSystemId") final String codeSystemId) {
+		@Parameter(description="The code system identifier")
+		@PathVariable(value="codeSystemId") final String codeSystemId,
+		
+		@Parameter(description = "The timestamp to use for historical ('as of') queries")
+		final Long timestamp,
+		
+		@ParameterObject
+		final ResourceSelectors selectors) {
+		
 		return CodeSystemRequests.prepareGetCodeSystem(codeSystemId)
-				.buildAsync()
-				.execute(getBus());
+			.setExpand(selectors.getExpand())
+			.setFields(selectors.getField())
+			.buildAsync(timestamp)
+			.execute(getBus());
 	}
 	
 	@Operation(
@@ -128,11 +137,11 @@ public class CodeSystemRestService extends AbstractRestService {
 	@PostMapping(consumes = { AbstractRestService.JSON_MEDIA_TYPE })
 	@ResponseStatus(HttpStatus.CREATED)
 	public ResponseEntity<Void> create(
-			@RequestBody
-			final ResourceRequest<CodeSystemCreateRestInput> body,
-			
-			@RequestHeader(value = X_AUTHOR, required = false)
-			final String author) {
+		@RequestBody
+		final ResourceRequest<CodeSystemCreateRestInput> body,
+		
+		@RequestHeader(value = X_AUTHOR, required = false)
+		final String author) {
 
 		
 		final String commitComment = Strings.isNullOrEmpty(body.getCommitComment()) ? String.format("Created new Code System %s", body.getChange().getId()) : body.getCommitComment();

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/domain/BaseResourceRestSearch.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/domain/BaseResourceRestSearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,9 @@ public abstract class BaseResourceRestSearch extends ObjectRestSearch {
 	
 	@Parameter(description = "One or more container ancestor bundles to match")
 	private List<String> bundleAncestorId;
+
+	@Parameter(description = "The timestamp to use for historical ('as of') queries")
+	private Long timestamp;
 	
 	public List<String> getTitleExact() {
 		return titleExact;
@@ -66,5 +69,13 @@ public abstract class BaseResourceRestSearch extends ObjectRestSearch {
 	
 	public void setBundleAncestorId(List<String> bundleAncestorId) {
 		this.bundleAncestorId = bundleAncestorId;
+	}
+	
+	public Long getTimestamp() {
+		return timestamp;
+	}
+	
+	public void setTimestamp(Long timestamp) {
+		this.timestamp = timestamp;
 	}
 }

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/resource/ResourceRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/resource/ResourceRestService.java
@@ -44,7 +44,7 @@ public class ResourceRestService extends AbstractRestService {
 	}
 
 	@Operation(
-		summary = "Retrive Resources", 
+		summary = "Retrieve Resources", 
 		description = "Returns a collection resource containing all/filtered registered Resources."
 			+ "<p>Results are by default sorted by ID.")
 	@ApiResponses({ 
@@ -68,12 +68,12 @@ public class ResourceRestService extends AbstractRestService {
 			.setFields(params.getField())
 			.setSearchAfter(params.getSearchAfter())
 			.sortBy(extractSortFields(params.getSort()))
-			.buildAsync()
+			.buildAsync(params.getTimestamp())
 			.execute(getBus());
 	}
 	
 	@Operation(
-		summary = "Retrive Resources", 
+		summary = "Retrieve Resources", 
 		description = "Returns a collection resource containing all/filtered registered Resources."
 			+ "<p>Results are by default sorted by ID.")
 	@ApiResponses({ 
@@ -81,12 +81,12 @@ public class ResourceRestService extends AbstractRestService {
 		@ApiResponse(responseCode = "400", description = "Bad Request") 
 	})
 	@PostMapping(value = "/search", consumes = { AbstractRestService.JSON_MEDIA_TYPE })
-	public Promise<Resources> searchByPost(@RequestBody final ResourceRestSearch params) {
+	public Promise<Resources> searchByPost(@RequestBody(required = false) final ResourceRestSearch params) {
 		return searchByGet(params);
 	}
 
 	@Operation(
-		summary = "Retrieve resource by it's unique identifier", 
+		summary = "Retrieve resource by its unique identifier", 
 		description = "Returns generic information about a single resource associated to the given unique identifier."
 	)
 	@ApiResponses({ 
@@ -96,18 +96,21 @@ public class ResourceRestService extends AbstractRestService {
 	})
 	@GetMapping("/{resourceId}")
 	public Promise<Resource> get(
-			@Parameter(description = "The resource identifier") 
-			@PathVariable(value = "resourceId") 
-			final String resourceId,
-			
-			@ParameterObject
-			final ResourceSelectors selectors) {
+		@Parameter(description = "The resource identifier") 
+		@PathVariable(value = "resourceId") 
+		final String resourceId,
+		
+		@Parameter(description = "The timestamp to use for historical ('as of') queries")
+		final Long timestamp,
+		
+		@ParameterObject
+		final ResourceSelectors selectors) {
+		
 		return ResourceRequests
-				.prepareGet(resourceId)
-				.setExpand(selectors.getExpand())
-				.setFields(selectors.getField())
-				.buildAsync()
-				.execute(getBus());
+			.prepareGet(resourceId)
+			.setExpand(selectors.getExpand())
+			.setFields(selectors.getField())
+			.buildAsync(timestamp)
+			.execute(getBus());
 	}
-
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/context/ResourceRepositoryRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/context/ResourceRepositoryRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,15 +26,18 @@ import com.b2international.snowowl.core.events.RequestBuilder;
 public interface ResourceRepositoryRequestBuilder<R> extends RequestBuilder<RepositoryContext, R> {
 
 	default AsyncRequest<R> buildAsync() {
+		return buildAsync(null);
+	}
+	
+	default AsyncRequest<R> buildAsync(Long timestamp) {
 		return new AsyncRequest<>(
-			new ResourceRepositoryRequest<>(
+			new ResourceRepositoryRequest<>(timestamp, 
 				wrap(build())
 			)
-		); 
+		);
 	}
 
 	default Request<RepositoryContext, R> wrap(Request<RepositoryContext, R> req) {
 		return req;
 	}
-	
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/ResourceRepository.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/ResourceRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,10 @@ public final class ResourceRepository implements RevisionIndex {
 
 	public <T> T read(RevisionIndexRead<T> read) {
 		return index.read(Branch.MAIN_PATH, read);
+	}
+	
+	public <T> T read(long timestamp, RevisionIndexRead<T> read) {
+		return index.read(RevisionIndex.toBranchAtPath(Branch.MAIN_PATH, timestamp), read);
 	}
 	
 	@Override


### PR DESCRIPTION
Setting the `timestamp` parameter will return content that represents the state of each resource at the specified point in time.