### PR TITLE
chore(commons): Update H2 from 1.4.199 to 2.1.210

### DIFF
--- a/commons/com.b2international.commons/.classpath
+++ b/commons/com.b2international.commons/.classpath
@@ -10,7 +10,7 @@
 	<classpathentry kind="src" path="src/"/>
 	<classpathentry exported="true" kind="lib" path="lib/LatencyUtils-2.0.3.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/bucket4j-core-4.4.1.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/h2-1.4.199.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/h2-2.1.210.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/hibernate-validator-5.3.6.Final.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jboss-logging-3.3.0.Final.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jgrapht-core-1.3.0.jar"/>

--- a/commons/com.b2international.commons/META-INF/MANIFEST.MF
+++ b/commons/com.b2international.commons/META-INF/MANIFEST.MF
@@ -108,7 +108,7 @@ Import-Package: org.slf4j;version="1.7.25"
 Bundle-ClassPath: .,
  lib/LatencyUtils-2.0.3.jar,
  lib/bucket4j-core-4.4.1.jar,
- lib/h2-1.4.199.jar,
+ lib/h2-2.1.210.jar,
  lib/hibernate-validator-5.3.6.Final.jar,
  lib/jboss-logging-3.3.0.Final.jar,
  lib/jgrapht-core-1.3.0.jar,

--- a/commons/com.b2international.commons/pom.xml
+++ b/commons/com.b2international.commons/pom.xml
@@ -23,7 +23,7 @@
 		<validation.api.version>1.1.0.Final</validation.api.version>
 		<bucket4j.version>4.4.1</bucket4j.version>
 		<javax.annotation.version>1.3.1</javax.annotation.version>
-		<h2.version>1.4.199</h2.version>
+		<h2.version>2.1.210</h2.version>
 	</properties>
 
 	<!-- NOTE: in case of dependency changes, please update "includeArtifactIds" in maven-dependency-plugin's configuration as well, listing all (exact and transitive) dependency artifacts -->


### PR DESCRIPTION
Existing scripts are using Groovy's built-in SQL facilities so H2 only serves as a JDBC driver for an embedded database. We no longer rely on its low-level functionality.