### PR TITLE
SO-5406 freeze retired resources

### DIFF
--- a/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchingTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchingTest.java
@@ -108,14 +108,6 @@ public class RevisionBranchingTest extends BaseRevisionIndexTest {
 			.isEqualTo(branchName);
 	}
 	
-	@Test
-	public void tilde() throws Exception {
-		String branchName = "~1.0";
-		assertBranchCreate(branchName)
-			.extracting(RevisionBranch::getName)
-			.isEqualTo(branchName);
-	}
-	
 	@Test(expected = BadRequestException.class)
 	public void percent() throws Exception {
 		String branchName = "%xy";

--- a/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranch.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranch.java
@@ -70,7 +70,7 @@ public final class RevisionBranch extends MetadataHolderImpl {
 	/**
 	 * Allowed set of characters for a branch name.
 	 */
-	public static final String DEFAULT_ALLOWED_BRANCH_NAME_CHARACTER_SET = "a-zA-Z0-9.~_-";
+	public static final String DEFAULT_ALLOWED_BRANCH_NAME_CHARACTER_SET = "a-zA-Z0-9._-";
 
 	/**
 	 * The maximum length of a branch.

--- a/core/com.b2international.snowowl.core/META-INF/MANIFEST.MF
+++ b/core/com.b2international.snowowl.core/META-INF/MANIFEST.MF
@@ -29,7 +29,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.9.0",
  io.github.classgraph.classgraph;bundle-version="4.8.90",
  com.b2international.groovy;bundle-version="3.0.9",
  com.b2international.snomed.ecl;bundle-version="1.6.0";visibility:=reexport,
- com.github.f4b6a3.uuid;bundle-version="4.6.1"
+ com.github.f4b6a3.uuid;bundle-version="4.6.1";visibility:=reexport
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: com.auth0.jwt,

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/Resource.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/Resource.java
@@ -34,6 +34,9 @@ public abstract class Resource implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
+	// known retired status value from FHIR, TODO make it configurable when needed
+	public static final String RETIRED_STATUS = "retired";
+
 	/**
 	 * @since 8.0
 	 */

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/context/DefaultTerminologyResourceContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/context/DefaultTerminologyResourceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.b2international.snowowl.core.context;
 
+import com.b2international.snowowl.core.Resource;
 import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.TerminologyResource;
@@ -28,6 +29,7 @@ public final class DefaultTerminologyResourceContext extends DelegatingContext i
 	public DefaultTerminologyResourceContext(final ServiceProvider delegate, ResourceURI resourceUri, TerminologyResource resource) {
 		super(delegate);
 		bind(ResourceURI.class, resourceUri);
+		bind(Resource.class, resource);
 		bind(TerminologyResource.class, resource);
 	}
 

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/context/TerminologyResourceRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/context/TerminologyResourceRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,8 @@ public final class TerminologyResourceRequest<R> extends DelegatingRequest<Servi
 		this.toolingId = toolingId;
 		this.resourcePath = resourcePath;
 		if (resourcePath.startsWith(Branch.MAIN_PATH) && Strings.isNullOrEmpty(toolingId)) {
-			throw new BadRequestException("Reflective access ('repositoryId/path') to terminology resource content is not supported in this request builder.");
+			throw new BadRequestException("Reflective access ('repositoryId/path') to terminology resource content is not supported in this API.")
+				.withDeveloperMessage("No toolingId is specified on API level to ensure the correct reflective access to underlying terminology.");
 		}
 	}
 	

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/id/IDs.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/id/IDs.java
@@ -15,14 +15,13 @@
  */
 package com.b2international.snowowl.core.id;
 
-import java.util.Arrays;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import org.elasticsearch.common.UUIDs;
 
 import com.b2international.commons.exceptions.BadRequestException;
 import com.github.f4b6a3.uuid.codec.base.Base62Codec;
-import com.github.f4b6a3.uuid.codec.base.BaseN;
 import com.google.common.base.Charsets;
 import com.google.common.hash.Hashing;
 
@@ -33,8 +32,11 @@ import com.google.common.hash.Hashing;
  */
 public class IDs {
 
-	public static final BaseN BASE64 = new BaseN("A-Za-z0-9-_");
-	public static final BaseN BASE62 = new BaseN("A-Za-z0-9");
+	public static final String BASE62_CHARSET = "A-Za-z0-9";
+	public static final String BASE64_CHARSET = "A-Za-z0-9-_";
+	
+	public static final Pattern BASE62 = Pattern.compile("["+ BASE62_CHARSET +"]+");
+	public static final Pattern BASE64 = Pattern.compile("["+ BASE64_CHARSET +"]+");
 	
 	/**
 	 * Generates a time-based UUID (similar to Flake IDs), which is preferred when generating an ID to be indexed into a Lucene index as primary key. This methods uses Base 62 encoding of UUIDs to omit the usage of non-alpha/numeric characters entirely.
@@ -88,16 +90,16 @@ public class IDs {
 	}
 	
 	public static void checkBase62(String value, String property) {
-		checkBaseN(value, BASE62, value);
+		checkBaseN(value, property, BASE62, BASE62_CHARSET);
 	}
 	
 	public static void checkBase64(String value, String property) {
-		checkBaseN(value, BASE64, value);
+		checkBaseN(value, property, BASE64, BASE64_CHARSET);
 	}
 	
-	public static void checkBaseN(String value, BaseN baseN, String property) {
-		if (baseN.isValid(value)) {
-			throw new BadRequestException("%s'%s' uses an illegal character. Allowed characters are '%s'.", property == null ? "" : property.concat(" "), Arrays.toString(BASE62.getAlphabet().array()));
+	private static void checkBaseN(String value, String property, Pattern pattern, String allowedCharacterSet) {
+		if (!pattern.matcher(value).matches()) {
+			throw new BadRequestException("%s'%s' uses an illegal character. Allowed characters are '%s'.", property == null ? "" : property.concat(" "), value, allowedCharacterSet);
 		}
 	}
 	

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/id/IDs.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/id/IDs.java
@@ -15,11 +15,14 @@
  */
 package com.b2international.snowowl.core.id;
 
+import java.util.Arrays;
 import java.util.UUID;
 
 import org.elasticsearch.common.UUIDs;
 
+import com.b2international.commons.exceptions.BadRequestException;
 import com.github.f4b6a3.uuid.codec.base.Base62Codec;
+import com.github.f4b6a3.uuid.codec.base.BaseN;
 import com.google.common.base.Charsets;
 import com.google.common.hash.Hashing;
 
@@ -30,6 +33,9 @@ import com.google.common.hash.Hashing;
  */
 public class IDs {
 
+	public static final BaseN BASE64 = new BaseN("A-Za-z0-9-_");
+	public static final BaseN BASE62 = new BaseN("A-Za-z0-9");
+	
 	/**
 	 * Generates a time-based UUID (similar to Flake IDs), which is preferred when generating an ID to be indexed into a Lucene index as primary key. This methods uses Base 62 encoding of UUIDs to omit the usage of non-alpha/numeric characters entirely.
 	 * 
@@ -79,6 +85,20 @@ public class IDs {
 	 */
 	public static String sha1(String value) {
 		return Hashing.sha1().hashString(value, Charsets.UTF_8).toString();
+	}
+	
+	public static void checkBase62(String value, String property) {
+		checkBaseN(value, BASE62, value);
+	}
+	
+	public static void checkBase64(String value, String property) {
+		checkBaseN(value, BASE64, value);
+	}
+	
+	public static void checkBaseN(String value, BaseN baseN, String property) {
+		if (baseN.isValid(value)) {
+			throw new BadRequestException("%s'%s' uses an illegal character. Allowed characters are '%s'.", property == null ? "" : property.concat(" "), Arrays.toString(BASE62.getAlphabet().array()));
+		}
 	}
 	
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/BaseResourceCreateRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/BaseResourceCreateRequest.java
@@ -21,15 +21,14 @@ import java.util.Optional;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import com.b2international.commons.exceptions.AlreadyExistsException;
-import com.b2international.commons.exceptions.BadRequestException;
 import com.b2international.commons.exceptions.NotFoundException;
-import com.b2international.index.revision.RevisionBranch.BranchNameValidator;
 import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.bundle.Bundle;
 import com.b2international.snowowl.core.bundle.Bundles;
 import com.b2international.snowowl.core.domain.IComponent;
 import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.core.events.Request;
+import com.b2international.snowowl.core.id.IDs;
 import com.b2international.snowowl.core.identity.User;
 import com.b2international.snowowl.core.internal.ResourceDocument;
 import com.b2international.snowowl.core.internal.ResourceDocument.Builder;
@@ -43,7 +42,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public abstract class BaseResourceCreateRequest implements Request<TransactionContext, String> {
 	
 	protected static final long serialVersionUID = 1L;
-
+	
 	// the new ID, if not specified, it will be auto-generated
 	@JsonProperty
 	@NotEmpty
@@ -184,12 +183,8 @@ public abstract class BaseResourceCreateRequest implements Request<TransactionCo
 	@Override
 	public final String execute(TransactionContext context) {
 		// validate ID before use, IDs sometimes being used as branch paths, so must be a valid branch path
-		try {
-			context.service(BranchNameValidator.class).checkName(id);
-		} catch (BadRequestException e) {
-			throw new BadRequestException(e.getMessage().replace("Branch name", getClass().getSimpleName().replace("CreateRequest", ".id")));
-		}
-		
+		IDs.checkBase64(id, getClass().getSimpleName().replace("CreateRequest", ".id"));
+			
 		// validate URL format
 		getResourceURLSchemaSupport(context).validate(url);
 		

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/TerminologyResourceCommitRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/TerminologyResourceCommitRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,12 @@
  */
 package com.b2international.snowowl.core.request;
 
+import java.util.Set;
+
+import com.b2international.snowowl.core.Resource;
 import com.b2international.snowowl.core.context.TerminologyResourceContentRequestBuilder;
+import com.b2international.snowowl.core.domain.BranchContext;
+import com.b2international.snowowl.core.events.Request;
 
 /**
  * @since 8.0
@@ -24,9 +29,16 @@ public class TerminologyResourceCommitRequestBuilder
 		extends RepositoryCommitRequestBuilder<TerminologyResourceCommitRequestBuilder>
 		implements TerminologyResourceContentRequestBuilder<CommitResult> {
 	
+	public static final Set<String> READ_ONLY_STATUSES = Set.of(Resource.RETIRED_STATUS);
+
 	@Override
 	public boolean snapshot() {
 		return false;
+	}
+
+	@Override
+	public Request<BranchContext, CommitResult> wrap(Request<BranchContext, CommitResult> req) {
+		return new TerminologyResourceStatusCheckRequest<>(TerminologyResourceContentRequestBuilder.super.wrap(req), READ_ONLY_STATUSES);
 	}
 	
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/TerminologyResourceStatusCheckRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/TerminologyResourceStatusCheckRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.request;
+
+import java.util.Collection;
+import java.util.SortedSet;
+
+import com.b2international.commons.exceptions.BadRequestException;
+import com.b2international.snowowl.core.ServiceProvider;
+import com.b2international.snowowl.core.TerminologyResource;
+import com.b2international.snowowl.core.events.DelegatingRequest;
+import com.b2international.snowowl.core.events.Request;
+import com.google.common.collect.ImmutableSortedSet;
+
+/**
+ * @since 8.2
+ * 
+ * @param <C>
+ * @param <T>
+ * @param <R>
+ */
+public final class TerminologyResourceStatusCheckRequest<C extends ServiceProvider, R> extends DelegatingRequest<C, C, R> {
+
+	private static final long serialVersionUID = 1L;
+	private final SortedSet<String> forbiddenStatuses;
+
+	public TerminologyResourceStatusCheckRequest(Request<C, R> next, Collection<String> forbiddenStatuses) {
+		super(next);
+		this.forbiddenStatuses = forbiddenStatuses == null ? ImmutableSortedSet.of() : ImmutableSortedSet.copyOf(forbiddenStatuses);
+	}
+
+	@Override
+	public R execute(C context) {
+		TerminologyResource resource = context.service(TerminologyResource.class);
+		
+		if (forbiddenStatuses.contains(resource.getStatus())) {
+			throw new BadRequestException("Executing this request is forbidden on resources with one of the following states '%s'. Resource '%s' is in '%s' status.", this.forbiddenStatuses, resource.getTitle(), resource.getStatus());
+		} else {
+			return next(context);
+		}
+		
+	}
+
+}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/version/VersionCreateRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/version/VersionCreateRequest.java
@@ -114,6 +114,10 @@ public final class VersionCreateRequest implements Request<RepositoryContext, Bo
 		context.service(BranchNameValidator.class).checkName(version);
 		
 		TerminologyResource resourceToVersion = resourcesById.get(resource);
+
+		if (TerminologyResourceCommitRequestBuilder.READ_ONLY_STATUSES.contains(resourceToVersion.getStatus())) {
+			throw new BadRequestException("Resource '%s' cannot be versioned in its current status '%s'.", resourceToVersion.getTitle(), resourceToVersion.getStatus());
+		}
 		
 		// TODO resurrect or eliminate tooling dependencies
 		final List<TerminologyResource> resourcesToVersion = List.of(resourcesById.get(resource));


### PR DESCRIPTION
This PR ensures that retired resources cannot be versioned and their contents cannot be edited unless their status changes back to something else than `retired`.
