### PR TITLE
SO-5412: make upload and download buffer size configurable (8.x)

### DIFF
--- a/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/attachments/AttachmentRegistryTest.java
+++ b/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/attachments/AttachmentRegistryTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import com.b2international.commons.exceptions.NotFoundException;
 import com.b2international.snowowl.core.ServiceProvider;
+import com.b2international.snowowl.core.client.TransportConfiguration;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.identity.IdentityProvider;
 import com.b2international.snowowl.core.repository.ApiRequestHandler;
@@ -44,6 +45,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 /**
  * @since 5.7
  */
+@SuppressWarnings("restriction")
 public class AttachmentRegistryTest {
 
 	private static final Path FOLDER = Paths.get("target", AttachmentRegistry.class.getSimpleName().toLowerCase());
@@ -108,7 +110,7 @@ public class AttachmentRegistryTest {
 	
 	@Test
 	public void uploadWithClient() throws Exception {
-		final AttachmentRegistryClient client = new AttachmentRegistryClient(bus);
+		final AttachmentRegistryClient client = new AttachmentRegistryClient(bus, TransportConfiguration.DEFAULT_UPLOAD_CHUNK_SIZE, TransportConfiguration.DEFAULT_DOWNLOAD_CHUNK_SIZE);
 
 		final UUID id = UUID.randomUUID();
 		upload(client, id, "file-reg-upload.zip");
@@ -121,7 +123,7 @@ public class AttachmentRegistryTest {
 
 	@Test
 	public void deleteWithClient() throws Exception {
-		final AttachmentRegistryClient client = new AttachmentRegistryClient(bus);
+		final AttachmentRegistryClient client = new AttachmentRegistryClient(bus, TransportConfiguration.DEFAULT_UPLOAD_CHUNK_SIZE, TransportConfiguration.DEFAULT_DOWNLOAD_CHUNK_SIZE);
 		
 		final UUID id = UUID.randomUUID();
 		upload(id, "file-reg-upload.zip");

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/attachments/AttachmentPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/attachments/AttachmentPlugin.java
@@ -17,6 +17,7 @@ package com.b2international.snowowl.core.attachments;
 
 import java.nio.file.Path;
 
+import com.b2international.snowowl.core.client.TransportConfiguration;
 import com.b2international.snowowl.core.config.SnowOwlConfiguration;
 import com.b2international.snowowl.core.plugin.Component;
 import com.b2international.snowowl.core.setup.Environment;
@@ -41,10 +42,14 @@ public final class AttachmentPlugin extends Plugin {
 			attachmentRegistry.register(bus);
 			env.services().registerService(AttachmentRegistry.class, attachmentRegistry);
 		} else {
+			
+			TransportConfiguration transportConfig = env.service(SnowOwlConfiguration.class).getModuleConfig(TransportConfiguration.class);
+			
 			env.services().addServiceListener(IEventBus.class, (oldBus, newBus) -> {
-				final AttachmentRegistryClient attachmentRegistryClient = new AttachmentRegistryClient(newBus);
+				final AttachmentRegistryClient attachmentRegistryClient = new AttachmentRegistryClient(newBus, transportConfig.getUploadChunkSize(), transportConfig.getDownloadChunkSize());
 				env.services().registerService(AttachmentRegistry.class, attachmentRegistryClient);
 			});
+			
 		}
 	}
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/attachments/AttachmentRegistryClient.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/attachments/AttachmentRegistryClient.java
@@ -35,12 +35,14 @@ import com.google.common.hash.HashingOutputStream;
  */
 public final class AttachmentRegistryClient implements AttachmentRegistry {
 	
-	public static final int BUFFER_SIZE = 131_072;
-
 	private final IEventBus bus;
+	private final int uploadChunkSize;
+	private final int downloadChunkSize;
 
-	public AttachmentRegistryClient(IEventBus bus) {
+	public AttachmentRegistryClient(IEventBus bus, int uploadChunkSize, int downloadChunkSize) {
 		this.bus = bus;
+		this.uploadChunkSize = uploadChunkSize;
+		this.downloadChunkSize = downloadChunkSize;
 	}
 
 	@Override
@@ -58,7 +60,7 @@ public final class AttachmentRegistryClient implements AttachmentRegistry {
 	private Promise<Boolean> sendNextChunk(UUID attachmentId, HashingInputStream hin) {
 		try {
 			
-			final byte[] chunk = hin.readNBytes(BUFFER_SIZE);
+			final byte[] chunk = hin.readNBytes(uploadChunkSize);
 			
 			if (chunk.length > 0) {
 				
@@ -100,6 +102,7 @@ public final class AttachmentRegistryClient implements AttachmentRegistry {
 
 		return AttachmentRequests.prepareDownloadChunk()
 			.setAttachmentId(attachmentId)
+			.setChunkSize(downloadChunkSize)
 			.buildAsync()
 			.execute(bus)
 			.thenWith(chunk -> {
@@ -122,6 +125,7 @@ public final class AttachmentRegistryClient implements AttachmentRegistry {
 						.execute(bus);
 				}
 			});
+		
 	}
 
 	@Override

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/attachments/request/DownloadChunkRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/attachments/request/DownloadChunkRequest.java
@@ -22,7 +22,6 @@ import javax.validation.constraints.NotNull;
 
 import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.attachments.AttachmentRegistry;
-import com.b2international.snowowl.core.attachments.AttachmentRegistryClient;
 import com.b2international.snowowl.core.attachments.InternalAttachmentRegistry;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.events.util.RequestHeaders;
@@ -34,9 +33,12 @@ import com.b2international.snowowl.eventbus.netty.EventBusNettyUtil;
 	
 	@NotNull
 	private final UUID attachmentId;
+
+	private int chunkSize;
 	
-	/*package*/ DownloadChunkRequest(final UUID attachmentId) {
+	/*package*/ DownloadChunkRequest(final UUID attachmentId, int chunkSize) {
 		this.attachmentId = attachmentId;
+		this.chunkSize = chunkSize;
 	}
 
 	@Override
@@ -45,8 +47,8 @@ import com.b2international.snowowl.eventbus.netty.EventBusNettyUtil;
 		final RequestHeaders requestHeaders = context.service(RequestHeaders.class);
 		final String clientId = requestHeaders.header(EventBusNettyUtil.HEADER_CLIENT_ID, "<local>");
 		
-		final byte[] buffer = new byte[AttachmentRegistryClient.BUFFER_SIZE];
-		final int bytesRead = service.downloadChunk(clientId, attachmentId, buffer, AttachmentRegistryClient.BUFFER_SIZE);
+		final byte[] buffer = new byte[chunkSize];
+		final int bytesRead = service.downloadChunk(clientId, attachmentId, buffer, chunkSize);
 		
 		if (bytesRead > 0) {
 			return Arrays.copyOf(buffer, bytesRead);

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/attachments/request/DownloadChunkRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/attachments/request/DownloadChunkRequestBuilder.java
@@ -18,6 +18,7 @@ package com.b2international.snowowl.core.attachments.request;
 import java.util.UUID;
 
 import com.b2international.snowowl.core.ServiceProvider;
+import com.b2international.snowowl.core.client.TransportConfiguration;
 import com.b2international.snowowl.core.events.BaseRequestBuilder;
 import com.b2international.snowowl.core.request.SystemRequestBuilder;
 
@@ -26,6 +27,8 @@ public class DownloadChunkRequestBuilder
 	implements SystemRequestBuilder<byte[]> {
 
 	private UUID attachmentId;
+	
+	private int chunkSize = TransportConfiguration.DEFAULT_DOWNLOAD_CHUNK_SIZE;
 
 	/*package*/ DownloadChunkRequestBuilder() { }
 	
@@ -34,8 +37,13 @@ public class DownloadChunkRequestBuilder
 		return getSelf();
 	}
 	
+	public DownloadChunkRequestBuilder setChunkSize(int chunkSize) {
+		this.chunkSize = chunkSize;
+		return getSelf();
+	}
+	
 	@Override
 	protected DownloadChunkRequest doBuild() {
-		return new DownloadChunkRequest(attachmentId);
+		return new DownloadChunkRequest(attachmentId, chunkSize);
 	}
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/client/TransportConfiguration.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/client/TransportConfiguration.java
@@ -33,6 +33,8 @@ public class TransportConfiguration {
 	private static final int DEFAULT_WATCHDOG_TIMEOUT_SECONDS = 300;
 	private static final String DEFAULT_CERTIFICATE_PATH = "";
 	private static final int DEFAULT_MAX_OBJECT_SIZE = Integer.MAX_VALUE - 1024;
+	public static final int DEFAULT_UPLOAD_CHUNK_SIZE = 10_485_760; // 10 Mb
+	public static final int DEFAULT_DOWNLOAD_CHUNK_SIZE = 1_048_576; // 1 Mb 
 	
 	@Min(0)
 	@Max(300)
@@ -49,6 +51,12 @@ public class TransportConfiguration {
 	
 	@Min(0)
 	private int maxObjectSize = DEFAULT_MAX_OBJECT_SIZE;
+	
+	@Min(0)
+	private int uploadChunkSize = DEFAULT_UPLOAD_CHUNK_SIZE;
+	
+	@Min(0)
+	private int downloadChunkSize = DEFAULT_DOWNLOAD_CHUNK_SIZE;
 	
 	/**
 	 * @return the number of seconds to wait before a connection attempt times out at login.
@@ -131,4 +139,25 @@ public class TransportConfiguration {
 	public void setMaxObjectSize(int maxObjectSize) {
 		this.maxObjectSize = maxObjectSize;
 	}
+	
+	@JsonProperty
+	public int getUploadChunkSize() {
+		return uploadChunkSize;
+	}
+	
+	@JsonProperty
+	public void setUploadChunkSize(int uploadChunkSize) {
+		this.uploadChunkSize = uploadChunkSize;
+	}
+	
+	@JsonProperty
+	public int getDownloadChunkSize() {
+		return downloadChunkSize;
+	}
+	
+	@JsonProperty
+	public void setDownloadChunkSize(int downloadChunkSize) {
+		this.downloadChunkSize = downloadChunkSize;
+	}
+	
 }


### PR DESCRIPTION
- set default upload buffer size to 10 Mb
- set default download buffer size to 1 Mb

When large enough files were being uploaded with a small upload buffer
size, promise evaluation halted the upload process possibly of the
reason: the number of upload chunks is equal to the number of promises
wrapped into each other in AttachmentRegistryClient.upload()