### PR TITLE
feat(eventbus): Enable call-time stack trace recording with JVM option

### DIFF
--- a/netty/com.b2international.snowowl.eventbus/src/com/b2international/snowowl/eventbus/IEventBus.java
+++ b/netty/com.b2international.snowowl.eventbus/src/com/b2international/snowowl/eventbus/IEventBus.java
@@ -29,7 +29,7 @@ public interface IEventBus {
 	/**
 	 * Feature flag for send-time stack tracing
 	 */
-	boolean RECORD_SEND_STACK = false;
+	boolean RECORD_SEND_STACK = Boolean.getBoolean("eventbus.record.stack");
 
 	/**
 	 * The address where handler registration and un-registration messages are sent.

--- a/netty/com.b2international.snowowl.eventbus/src/com/b2international/snowowl/internal/eventbus/EventBus.java
+++ b/netty/com.b2international.snowowl.eventbus/src/com/b2international/snowowl/internal/eventbus/EventBus.java
@@ -157,19 +157,19 @@ public class EventBus implements IEventBus {
 		}
 		
 		if (RECORD_SEND_STACK) {
-			final Throwable t = new Exception("Message was sent in this call stack").fillInStackTrace();
-			final String sendStack;
+			final Throwable t = new Exception("Message was submitted from this call stack").fillInStackTrace();
 			
 			try (StringWriter sw = new StringWriter()) {
 				t.printStackTrace(new PrintWriter(sw));
-				sendStack = sw.toString();
+				
+				final String sendStack = sw.toString();
+				Map<String, String> headersWithStack = newHashMap(message.headers());
+				headersWithStack.put("sendStack", sendStack);
+				message.headers = Map.copyOf(headersWithStack);
+				
 			} catch (IOException unexpected) {
 				// String writer should not encounter any I/O exceptions
 			}
-			
-			Map<String, String> headersWithStack = newHashMap(message.headers());
-			headersWithStack.put("sendStack", sendStack);
-			message.headers = Map.copyOf(headersWithStack);
 		}
 		
 		// Allow both local and remote handlers to process the message


### PR DESCRIPTION
Adding `-Deventbus.record.stack=true` to the JVM options will add a header with the call-time stack trace for each sent message, even if it originates on another machine. Responding with an exception prints the stack to the standard error output. This can help in diagnosing issues related to distributed messaging.