### PR TITLE
fix(core): Make derived field on User transient

### DIFF
--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/User.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/User.java
@@ -42,7 +42,7 @@ public final class User implements Serializable {
 	private final List<Role> roles;
 	
 	// derived cached value
-	private final Supplier<List<Permission>> permissions = Suppliers.memoize(() -> {
+	private transient final Supplier<List<Permission>> permissions = Suppliers.memoize(() -> {
 		return getRoles().stream().flatMap(role -> role.getPermissions().stream()).distinct().collect(Collectors.toList());
 	});
 


### PR DESCRIPTION
The corresponding property is already &commat; JsonIgnore-d; it needs to be absent from the binary serialization as well.