### PR TITLE
Feature: accessing versioned resource via GET endpoints using URIs

### DIFF
--- a/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/codesystem/CodeSystemApiTest.java
+++ b/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/codesystem/CodeSystemApiTest.java
@@ -534,7 +534,22 @@ public class CodeSystemApiTest extends BaseResourceApiTest {
 			.extract()
 			.as(CodeSystem.class);
 		
-		assertEquals("Updated copyright", codeSystem3.getCopyright());		
+		assertEquals("Updated copyright", codeSystem3.getCopyright());
+		
+		// check versioned resource access
+		assertVersionCreated(prepareVersionCreateRequestBody(CodeSystem.uri(codeSystemId), "v1", "2020-04-15")).statusCode(201);
+		
+		// update copyright after versioning to have a different latest revision
+		assertCodeSystemUpdated(codeSystemId, Json.object("copyright", "Updated copyright after versioning"));
+
+		// get the versioned state
+		final CodeSystem v1CodeSystemState = assertCodeSystemGet(codeSystemId + "/v1")
+				.statusCode(200)
+				.extract()
+				.as(CodeSystem.class);
+		
+		// verify that the copyright is the old version
+		assertEquals("Updated copyright", v1CodeSystemState.getCopyright());
 	}
 	
 	@Test

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/bundle/BundleRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/bundle/BundleRestService.java
@@ -130,13 +130,13 @@ public class BundleRestService extends AbstractRestService {
 		@ApiResponse(responseCode = "200", description = "OK"),
 		@ApiResponse(responseCode = "404", description = "Not found")
 	})
-	@GetMapping(value = "/{bundleId}", produces = { AbstractRestService.JSON_MEDIA_TYPE })
+	@GetMapping(value = "/{bundleId}/{versionId}", produces = { AbstractRestService.JSON_MEDIA_TYPE })
 	public Promise<Bundle> getVersioned(
 		@Parameter(description="The bundle identifier")
 		@PathVariable(value="bundleId", required = true) 
 		final String bundleId,
 		
-		@Parameter(description="The code system version")
+		@Parameter(description="The bundle version")
 		@PathVariable(value="versionId", required = true) 
 		final String versionId,
 

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/bundle/BundleRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/bundle/BundleRestService.java
@@ -103,7 +103,7 @@ public class BundleRestService extends AbstractRestService {
 		@ApiResponse(responseCode = "200", description = "OK"),
 		@ApiResponse(responseCode = "404", description = "Not found")
 	})
-	@GetMapping(value = "/{bundleId:**}", produces = { AbstractRestService.JSON_MEDIA_TYPE })
+	@GetMapping(value = "/{bundleId}", produces = { AbstractRestService.JSON_MEDIA_TYPE })
 	public Promise<Bundle> get(
 		@Parameter(description="The bundle identifier")
 		@PathVariable(value="bundleId", required = true) 
@@ -119,6 +119,34 @@ public class BundleRestService extends AbstractRestService {
 			.setExpand(selectors.getExpand())
 			.setFields(selectors.getField())
 			.buildAsync(timestamp)
+			.execute(getBus());
+	}
+	
+	@Operation(
+		summary="Retrieve bundle by its unique identifier",
+		description="Returns generic information about a single bundle associated to the given unique identifier."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "OK"),
+		@ApiResponse(responseCode = "404", description = "Not found")
+	})
+	@GetMapping(value = "/{bundleId}", produces = { AbstractRestService.JSON_MEDIA_TYPE })
+	public Promise<Bundle> getVersioned(
+		@Parameter(description="The bundle identifier")
+		@PathVariable(value="bundleId", required = true) 
+		final String bundleId,
+		
+		@Parameter(description="The code system version")
+		@PathVariable(value="versionId", required = true) 
+		final String versionId,
+
+		@ParameterObject
+		final ResourceSelectors selectors) {
+		
+		return ResourceRequests.bundles().prepareGet(Bundle.uri(bundleId, versionId))
+			.setExpand(selectors.getExpand())
+			.setFields(selectors.getField())
+			.buildAsync()
 			.execute(getBus());
 	}
 	

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/bundle/BundleRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/bundle/BundleRestService.java
@@ -23,6 +23,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.b2international.commons.exceptions.NotFoundException;
+import com.b2international.index.revision.RevisionIndex;
 import com.b2international.snowowl.core.bundle.Bundle;
 import com.b2international.snowowl.core.bundle.Bundles;
 import com.b2international.snowowl.core.events.util.Promise;
@@ -108,13 +109,13 @@ public class BundleRestService extends AbstractRestService {
 		@PathVariable(value="bundleId", required = true) 
 		final String bundleId,
 
-		@Parameter(description = "The timestamp to use for historical ('as of') queries")
+		@Parameter(description = "The timestamp to use for historical ('as of') queries", deprecated = true)
 		final Long timestamp,
 		
 		@ParameterObject
 		final ResourceSelectors selectors) {
 		
-		return ResourceRequests.bundles().prepareGet(bundleId)
+		return ResourceRequests.bundles().prepareGet(bundleId.contains(RevisionIndex.AT_CHAR) || timestamp == null ? Bundle.uri(bundleId) : Bundle.uri(bundleId).withTimestampPart(RevisionIndex.AT_CHAR + timestamp))
 			.setExpand(selectors.getExpand())
 			.setFields(selectors.getField())
 			.buildAsync(timestamp)

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/bundle/BundleRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/bundle/BundleRestService.java
@@ -103,7 +103,7 @@ public class BundleRestService extends AbstractRestService {
 		@ApiResponse(responseCode = "200", description = "OK"),
 		@ApiResponse(responseCode = "404", description = "Not found")
 	})
-	@GetMapping(value = "/{bundleId}", produces = { AbstractRestService.JSON_MEDIA_TYPE })
+	@GetMapping(value = "/{bundleId:**}", produces = { AbstractRestService.JSON_MEDIA_TYPE })
 	public Promise<Bundle> get(
 		@Parameter(description="The bundle identifier")
 		@PathVariable(value="bundleId", required = true) 

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/codesystem/CodeSystemRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/codesystem/CodeSystemRestService.java
@@ -109,10 +109,11 @@ public class CodeSystemRestService extends AbstractRestService {
 		@ApiResponse(responseCode = "200", description = "OK"),
 		@ApiResponse(responseCode = "404", description = "Not found")
 	})
-	@GetMapping(value = "/{codeSystemId:**}", produces = { AbstractRestService.JSON_MEDIA_TYPE })
+	@GetMapping(value = "/{codeSystemId}", produces = { AbstractRestService.JSON_MEDIA_TYPE })
 	public Promise<CodeSystem> get(
 		@Parameter(description="The code system identifier")
-		@PathVariable(value="codeSystemId") final String codeSystemId,
+		@PathVariable(value="codeSystemId", required = true) 
+		final String codeSystemId,
 		
 		@Parameter(description = "The timestamp to use for historical ('as of') queries", deprecated = true)
 		final Long timestamp,
@@ -121,6 +122,34 @@ public class CodeSystemRestService extends AbstractRestService {
 		final ResourceSelectors selectors) {
 		
 		return CodeSystemRequests.prepareGetCodeSystem(codeSystemId.contains(RevisionIndex.AT_CHAR) || timestamp == null ? CodeSystem.uri(codeSystemId) : CodeSystem.uri(codeSystemId).withTimestampPart(RevisionIndex.AT_CHAR + timestamp))
+			.setExpand(selectors.getExpand())
+			.setFields(selectors.getField())
+			.buildAsync()
+			.execute(getBus());
+	}
+	
+	@Operation(
+		summary="Retrieve a versioned code system by its unique identifier",
+		description="Returns generic information about a single code system associated to the given unique identifier."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "OK"),
+		@ApiResponse(responseCode = "404", description = "Not found")
+	})
+	@GetMapping(value = "/{codeSystemId}/{versionId}", produces = { AbstractRestService.JSON_MEDIA_TYPE })
+	public Promise<CodeSystem> getVersioned(
+		@Parameter(description="The code system identifier")
+		@PathVariable(value="codeSystemId", required = true) 
+		final String codeSystemId,
+		
+		@Parameter(description="The code system version")
+		@PathVariable(value="versionId", required = true) 
+		final String versionId,
+		
+		@ParameterObject
+		final ResourceSelectors selectors) {
+		
+		return CodeSystemRequests.prepareGetCodeSystem(CodeSystem.uri(codeSystemId, versionId))
 			.setExpand(selectors.getExpand())
 			.setFields(selectors.getField())
 			.buildAsync()

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/codesystem/CodeSystemRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/codesystem/CodeSystemRestService.java
@@ -24,6 +24,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.b2international.commons.exceptions.NotFoundException;
+import com.b2international.index.revision.RevisionIndex;
 import com.b2international.snowowl.core.codesystem.CodeSystem;
 import com.b2international.snowowl.core.codesystem.CodeSystemRequests;
 import com.b2international.snowowl.core.codesystem.CodeSystems;
@@ -108,21 +109,21 @@ public class CodeSystemRestService extends AbstractRestService {
 		@ApiResponse(responseCode = "200", description = "OK"),
 		@ApiResponse(responseCode = "404", description = "Not found")
 	})
-	@GetMapping(value = "/{codeSystemId}", produces = { AbstractRestService.JSON_MEDIA_TYPE })
+	@GetMapping(value = "/{codeSystemId:**}", produces = { AbstractRestService.JSON_MEDIA_TYPE })
 	public Promise<CodeSystem> get(
 		@Parameter(description="The code system identifier")
 		@PathVariable(value="codeSystemId") final String codeSystemId,
 		
-		@Parameter(description = "The timestamp to use for historical ('as of') queries")
+		@Parameter(description = "The timestamp to use for historical ('as of') queries", deprecated = true)
 		final Long timestamp,
 		
 		@ParameterObject
 		final ResourceSelectors selectors) {
 		
-		return CodeSystemRequests.prepareGetCodeSystem(codeSystemId)
+		return CodeSystemRequests.prepareGetCodeSystem(codeSystemId.contains(RevisionIndex.AT_CHAR) || timestamp == null ? CodeSystem.uri(codeSystemId) : CodeSystem.uri(codeSystemId).withTimestampPart(RevisionIndex.AT_CHAR + timestamp))
 			.setExpand(selectors.getExpand())
 			.setFields(selectors.getField())
-			.buildAsync(timestamp)
+			.buildAsync()
 			.execute(getBus());
 	}
 	

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/codesystem/ExpressionLabelService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/codesystem/ExpressionLabelService.java
@@ -52,8 +52,8 @@ public class ExpressionLabelService extends AbstractRestService {
 			@RequestBody
 			final ExpressionLabelRestInput body,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 				return CodeSystemRequests.prepareEclLabeler(body.getCodeSystemUri(), body.getExpressions())
 						.setDescriptionType(body.getDescriptionType())

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/suggest/SuggestRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/suggest/SuggestRestService.java
@@ -60,8 +60,8 @@ public class SuggestRestService extends AbstractRestService {
 		@ParameterObject
 		final SuggestRestParameters params,
 		
-		@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-		@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+		@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+		@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 		final String acceptLanguage) {
 		
 		return prepareSuggestRequest(params, acceptLanguage)
@@ -81,8 +81,8 @@ public class SuggestRestService extends AbstractRestService {
 		@RequestBody
 		final SuggestRestParameters body,
 		
-		@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-		@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+		@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+		@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 		final String acceptLanguage) {
 		return getSuggest(body, acceptLanguage);
 	}
@@ -107,8 +107,8 @@ public class SuggestRestService extends AbstractRestService {
 		@RequestParam(value = "batchTimeout", defaultValue = "120", required = false)
 		final Integer batchTimeout,
 		
-		@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-		@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+		@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+		@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 		final String acceptLanguage) {
 	
 		if (body == null) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/bundle/Bundle.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/bundle/Bundle.java
@@ -95,6 +95,10 @@ public final class Bundle extends Resource {
 		return bundleUri.startsWith(RESOURCE_TYPE) ? new ResourceURI(bundleUri) : ResourceURI.of(RESOURCE_TYPE, bundleUri);
 	}
 	
+	public static ResourceURI uri(String bundleUri, String versionId) {
+		return uri(bundleUri).withPath(versionId);
+	}
+	
 	public static Bundle from(ResourceDocument doc) {
 		final Bundle bundle = new Bundle();
 		bundle.setId(doc.getId());

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/bundle/Bundle.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/bundle/Bundle.java
@@ -16,6 +16,7 @@
 package com.b2international.snowowl.core.bundle;
 
 import com.b2international.snowowl.core.Resource;
+import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.Resources;
 import com.b2international.snowowl.core.internal.ResourceDocument;
 import com.b2international.snowowl.core.internal.ResourceDocument.Builder;
@@ -88,6 +89,10 @@ public final class Bundle extends Resource {
 				.bundleAncestorIds(getBundleAncestorIds())
 				.bundleId(getBundleId())
 				.settings(getSettings());
+	}
+
+	public static ResourceURI uri(String bundleUri) {
+		return bundleUri.startsWith(RESOURCE_TYPE) ? new ResourceURI(bundleUri) : ResourceURI.of(RESOURCE_TYPE, bundleUri);
 	}
 	
 	public static Bundle from(ResourceDocument doc) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/bundle/Bundle.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/bundle/Bundle.java
@@ -18,6 +18,7 @@ package com.b2international.snowowl.core.bundle;
 import com.b2international.snowowl.core.Resource;
 import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.Resources;
+import com.b2international.snowowl.core.branch.Branch;
 import com.b2international.snowowl.core.internal.ResourceDocument;
 import com.b2international.snowowl.core.internal.ResourceDocument.Builder;
 import com.b2international.snowowl.core.request.ResourceRequests;
@@ -92,7 +93,7 @@ public final class Bundle extends Resource {
 	}
 
 	public static ResourceURI uri(String bundleUri) {
-		return bundleUri.startsWith(RESOURCE_TYPE) ? new ResourceURI(bundleUri) : ResourceURI.of(RESOURCE_TYPE, bundleUri);
+		return bundleUri.startsWith(RESOURCE_TYPE + Branch.SEPARATOR) ? new ResourceURI(bundleUri) : ResourceURI.of(RESOURCE_TYPE, bundleUri);
 	}
 	
 	public static ResourceURI uri(String bundleUri, String versionId) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/bundle/BundleGetRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/bundle/BundleGetRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,19 @@
  */
 package com.b2international.snowowl.core.bundle;
 
-import com.b2international.snowowl.core.domain.RepositoryContext;
-import com.b2international.snowowl.core.request.GetResourceRequest;
+import com.b2international.snowowl.core.ResourceURI;
+import com.b2international.snowowl.core.request.resource.BaseGetResourceRequest;
 
 /**
  * @since 8.0
  */
 final class BundleGetRequest
-		extends GetResourceRequest<BundleSearchRequestBuilder, RepositoryContext, Bundles, Bundle> {
+		extends BaseGetResourceRequest<BundleSearchRequestBuilder, Bundles, Bundle> {
 
 	private static final long serialVersionUID = 1L;
 
-	BundleGetRequest(String id) {
-		super(id);
+	BundleGetRequest(ResourceURI resourceUri) {
+		super(resourceUri);
 	}
 
 	@Override

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/bundle/BundleGetRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/bundle/BundleGetRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,17 @@
  */
 package com.b2international.snowowl.core.bundle;
 
-import com.b2international.snowowl.core.context.ResourceRepositoryRequestBuilder;
-import com.b2international.snowowl.core.domain.RepositoryContext;
-import com.b2international.snowowl.core.request.GetResourceRequestBuilder;
+import com.b2international.snowowl.core.ResourceURI;
+import com.b2international.snowowl.core.request.resource.BaseGetResourceRequestBuilder;
 
 /**
  * @since 8.0
  */
 public final class BundleGetRequestBuilder
-		extends GetResourceRequestBuilder<BundleGetRequestBuilder, BundleSearchRequestBuilder, RepositoryContext, Bundles, Bundle>
-		implements ResourceRepositoryRequestBuilder<Bundle> {
+		extends BaseGetResourceRequestBuilder<BundleGetRequestBuilder, BundleSearchRequestBuilder, Bundles, Bundle> {
 
-	BundleGetRequestBuilder(final String id) {
-		super(new BundleGetRequest(id));
+	BundleGetRequestBuilder(final ResourceURI resourceUri) {
+		super(new BundleGetRequest(resourceUri));
 	}
 
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/bundle/BundleRequests.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/bundle/BundleRequests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package com.b2international.snowowl.core.bundle;
 
+import com.b2international.snowowl.core.ResourceURI;
+
 /**
  * @since 8.0
  */
@@ -24,8 +26,12 @@ public final class BundleRequests {
 		return new BundleCreateRequestBuilder();
 	}
 
-	public BundleGetRequestBuilder prepareGet(final String id) {
-		return new BundleGetRequestBuilder(id);
+	public BundleGetRequestBuilder prepareGet(final String resourceUri) {
+		return prepareGet(Bundle.uri(resourceUri));
+	}
+	
+	public BundleGetRequestBuilder prepareGet(final ResourceURI resourceUri) {
+		return new BundleGetRequestBuilder(resourceUri);
 	}
 	
 	public BundleSearchRequestBuilder prepareSearch() {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystem.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystem.java
@@ -21,6 +21,7 @@ import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.ResourceURIWithQuery;
 import com.b2international.snowowl.core.TerminologyResource;
+import com.b2international.snowowl.core.branch.Branch;
 import com.b2international.snowowl.core.internal.ResourceDocument;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -57,7 +58,7 @@ public final class CodeSystem extends TerminologyResource {
 	}
 	
 	public static ResourceURI uri(String codeSystemId) {
-		return codeSystemId.startsWith(RESOURCE_TYPE) ? new ResourceURI(codeSystemId) : ResourceURI.of(RESOURCE_TYPE, codeSystemId);
+		return codeSystemId.startsWith(RESOURCE_TYPE + Branch.SEPARATOR) ? new ResourceURI(codeSystemId) : ResourceURI.of(RESOURCE_TYPE, codeSystemId);
 	}
 	
 	public static ResourceURI uri(String codeSystemId, String path) {
@@ -65,7 +66,7 @@ public final class CodeSystem extends TerminologyResource {
 	}
 	
 	public static ResourceURIWithQuery uriWithQuery(String codeSystemIdWithQuery) {
-		return codeSystemIdWithQuery.startsWith(RESOURCE_TYPE) ? new ResourceURIWithQuery(codeSystemIdWithQuery) : ResourceURIWithQuery.of(RESOURCE_TYPE, codeSystemIdWithQuery);
+		return codeSystemIdWithQuery.startsWith(RESOURCE_TYPE + Branch.SEPARATOR) ? new ResourceURIWithQuery(codeSystemIdWithQuery) : ResourceURIWithQuery.of(RESOURCE_TYPE, codeSystemIdWithQuery);
 	}
 	
 	public static CodeSystem from(ResourceDocument doc) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemGetRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemGetRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,19 @@
  */
 package com.b2international.snowowl.core.codesystem;
 
-import com.b2international.snowowl.core.domain.RepositoryContext;
-import com.b2international.snowowl.core.request.GetResourceRequest;
+import com.b2international.snowowl.core.ResourceURI;
+import com.b2international.snowowl.core.request.resource.BaseGetResourceRequest;
 
 /**
  * @since 5.7
  */
 final class CodeSystemGetRequest 
-		extends GetResourceRequest<CodeSystemSearchRequestBuilder, RepositoryContext, CodeSystems, CodeSystem> {
+		extends BaseGetResourceRequest<CodeSystemSearchRequestBuilder, CodeSystems, CodeSystem> {
 
 	private static final long serialVersionUID = 1L;
 	
-	CodeSystemGetRequest(String id) {
-		super(id);
+	CodeSystemGetRequest(ResourceURI resourceUri) {
+		super(resourceUri);
 	}
 
 	@Override

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemGetRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemGetRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,17 @@
  */
 package com.b2international.snowowl.core.codesystem;
 
-import com.b2international.snowowl.core.context.ResourceRepositoryRequestBuilder;
-import com.b2international.snowowl.core.domain.RepositoryContext;
-import com.b2international.snowowl.core.request.GetResourceRequestBuilder;
+import com.b2international.snowowl.core.ResourceURI;
+import com.b2international.snowowl.core.request.resource.BaseGetResourceRequestBuilder;
 
 /**
  * @since 4.7
  */
 public final class CodeSystemGetRequestBuilder 
-		extends GetResourceRequestBuilder<CodeSystemGetRequestBuilder, CodeSystemSearchRequestBuilder, RepositoryContext, CodeSystems, CodeSystem>
-		implements ResourceRepositoryRequestBuilder<CodeSystem> {
+		extends BaseGetResourceRequestBuilder<CodeSystemGetRequestBuilder, CodeSystemSearchRequestBuilder, CodeSystems, CodeSystem> {
 
-	CodeSystemGetRequestBuilder(String uniqueId) {
-		super(new CodeSystemGetRequest(uniqueId));
+	CodeSystemGetRequestBuilder(ResourceURI resourceUri) {
+		super(new CodeSystemGetRequest(resourceUri));
 	}
 	
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemRequests.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/codesystem/CodeSystemRequests.java
@@ -40,8 +40,12 @@ public class CodeSystemRequests {
 		return new CodeSystemUpdateRequestBuilder(codeSystemId);
 	}
 
-	public static CodeSystemGetRequestBuilder prepareGetCodeSystem(final String codeSystemId) {
-		return new CodeSystemGetRequestBuilder(codeSystemId);
+	public static CodeSystemGetRequestBuilder prepareGetCodeSystem(final String codeSystemUri) {
+		return new CodeSystemGetRequestBuilder(CodeSystem.uri(codeSystemUri));
+	}
+	
+	public static CodeSystemGetRequestBuilder prepareGetCodeSystem(final ResourceURI codeSystemUri) {
+		return new CodeSystemGetRequestBuilder(codeSystemUri);
 	}
 
 	public static CodeSystemSearchRequestBuilder prepareSearchCodeSystem() {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/context/TerminologyResourceRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/context/TerminologyResourceRequest.java
@@ -96,6 +96,7 @@ public final class TerminologyResourceRequest<R> extends DelegatingRequest<Servi
 		} else {
 			// resourcePaths are just ID/PATH style expressions to reference content in a terminology repository
 			final ResourceURI referenceResourceUri = ResourceURI.of("any", resourcePath);
+			// XXX intentionally not fetching using the full resourceUri here, this might change in the future
 			Resource resource = ResourceRequests.prepareGet(referenceResourceUri).buildAsync().getRequest().execute(context);
 			if (!(resource instanceof TerminologyResource)) {
 				throw new NotFoundException("Terminology Resource", referenceResourceUri.getResourceId());

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/ResourceRepository.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/ResourceRepository.java
@@ -145,7 +145,7 @@ public final class ResourceRepository implements RevisionIndex {
 					.filterByResources(resources)
 					.stream(context)
 					.flatMap(Versions::stream)
-					.forEach(version -> {
+					.forEachOrdered(version -> {
 						staging.stageRemove(version.getId(), VersionDocument.builder()
 								.id(version.getId())
 								.build());

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/GetResourceRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/GetResourceRequestBuilder.java
@@ -25,7 +25,8 @@ public abstract class GetResourceRequestBuilder<
 	SB extends SearchResourceRequestBuilder<SB, C, SR>,
 	C extends ServiceProvider, 
 	SR,
-	R> extends IndexResourceRequestBuilder<B, C, R> {
+	R> 
+	extends IndexResourceRequestBuilder<B, C, R> {
 	
 	private final GetResourceRequest<SB, C, SR, R> request;
 

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/ResourceRequests.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/ResourceRequests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.b2international.snowowl.core.bundle.BundleRequests;
 import com.b2international.snowowl.core.internal.ResourceDocument;
 import com.b2international.snowowl.core.jobs.RemoteJobEntry;
 import com.b2international.snowowl.core.request.resource.ResourceDeleteRequestBuilder;
+import com.b2international.snowowl.core.request.resource.ResourceGetRequestBuilder;
 import com.b2international.snowowl.core.request.version.VersionCreateRequestBuilder;
 import com.b2international.snowowl.core.request.version.VersionGetRequestBuilder;
 import com.b2international.snowowl.core.request.version.VersionSearchRequestBuilder;
@@ -35,16 +36,17 @@ public final class ResourceRequests {
 		return new BundleRequests();
 	}
 	
-	public static ResourceGetRequestBuilder prepareGet(ResourceURI resourceUri) {
-		return prepareGet(resourceUri.getResourceId());
-	}
-	
 	public static ResourceUpdateRequestBuilder prepareUpdate(final String resourceId) {
 		return new ResourceUpdateRequestBuilder(resourceId);
 	}
 	
 	public static ResourceGetRequestBuilder prepareGet(String resourceId) {
-		return new ResourceGetRequestBuilder(resourceId);
+		// XXX the resourceType part of the URI won't and should not be used in the request itself, it is okay to use any here
+		return prepareGet(ResourceURI.of("any", resourceId));
+	}
+	
+	public static ResourceGetRequestBuilder prepareGet(ResourceURI resourceUri) {
+		return new ResourceGetRequestBuilder(resourceUri);
 	}
 	
 	public static ResourceSearchRequestBuilder prepareSearch() {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/RevisionIndexReadRequestTimestampProvider.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/RevisionIndexReadRequestTimestampProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.request;
+
+import com.b2international.snowowl.core.ServiceProvider;
+
+/**
+ * Interface to allow nested requests to configure the read timestamp of the current revision read operation. Usually the information to determine the
+ * actual read timestamp is carried by the nested request, this interface allows the nested request to configure the index read operation with that
+ * timestamp.
+ * 
+ * @since 8.7
+ */
+public interface RevisionIndexReadRequestTimestampProvider {
+
+	/**
+	 * Provides the actual read timestamp based on the current request configuration and the given context.
+	 * 
+	 * @param context - the context opened to read from the latest revision index snapshot
+	 * @return
+	 */
+	Long getReadTimestamp(ServiceProvider context);
+
+}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/resource/BaseGetResourceRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/resource/BaseGetResourceRequest.java
@@ -15,14 +15,14 @@
  */
 package com.b2international.snowowl.core.request.resource;
 
+import com.b2international.commons.exceptions.BadRequestException;
 import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.domain.RepositoryContext;
-import com.b2international.snowowl.core.request.GetResourceRequest;
-import com.b2international.snowowl.core.request.ResourceRequests;
-import com.b2international.snowowl.core.request.RevisionIndexReadRequestTimestampProvider;
-import com.b2international.snowowl.core.request.SearchResourceRequestBuilder;
+import com.b2international.snowowl.core.request.*;
+import com.b2international.snowowl.core.request.version.VersionSearchRequestBuilder;
 import com.b2international.snowowl.core.version.Version;
+import com.b2international.snowowl.core.version.VersionDocument;
 import com.google.common.base.Strings;
 
 /**
@@ -50,15 +50,31 @@ public abstract class BaseGetResourceRequest<SB extends SearchResourceRequestBui
 		if (!Strings.isNullOrEmpty(resourceUri.getTimestampPart())) {
 			return Long.parseLong(resourceUri.getTimestampPart().substring(1));
 		} else if (!resourceUri.isHead() && !resourceUri.isNext()) {
-			return ResourceRequests.prepareSearchVersion()
-					.one()
-					.filterByResource(resourceUri.withoutPath())
-					.filterByVersionId(resourceUri.getPath())
-					.buildAsync()
-					.execute(context)
-					.first()
-					.map(Version::getCreatedAt)
-					.orElse(null);
+			VersionSearchRequestBuilder versionSearch = ResourceRequests.prepareSearchVersion()
+				.one()
+				.filterByResource(resourceUri.withoutPath());
+			
+			if (resourceUri.isLatest()) {
+				// fetch the latest resource version if LATEST is specified in the URI
+				versionSearch.sortBy(SearchResourceRequest.Sort.fieldDesc(VersionDocument.Fields.EFFECTIVE_TIME));
+			} else {
+				// try to fetch the path as exact version if not the special LATEST is specified in the URI
+				versionSearch.filterByVersionId(resourceUri.getPath());
+			}
+			
+			// determine the final branch path, if based on the version search we find a version, then use that, otherwise use the defined path as relative branch of the code system working branch
+			return versionSearch.buildAsync()
+				.execute(context)
+				.first()
+				.map(Version::getCreatedAt)
+				.orElseGet(() -> {
+					// ignore if accessing the LATEST versioned state, but there is no version present
+					if (resourceUri.isLatest()) {
+						return null;
+					} else {
+						throw new BadRequestException("Only version paths and timestamp fragments are supported when accessing a resource via an URI. Got: %s", resourceUri.getPath());
+					}
+				});
 		}
 		return null;
 	}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/resource/BaseGetResourceRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/resource/BaseGetResourceRequest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.request.resource;
+
+import com.b2international.snowowl.core.ResourceURI;
+import com.b2international.snowowl.core.ServiceProvider;
+import com.b2international.snowowl.core.domain.RepositoryContext;
+import com.b2international.snowowl.core.request.GetResourceRequest;
+import com.b2international.snowowl.core.request.ResourceRequests;
+import com.b2international.snowowl.core.request.RevisionIndexReadRequestTimestampProvider;
+import com.b2international.snowowl.core.request.SearchResourceRequestBuilder;
+import com.b2international.snowowl.core.version.Version;
+import com.google.common.base.Strings;
+
+/**
+ * @since 8.7
+ * 
+ * @param <SB>
+ * @param <SR>
+ * @param <R>
+ */
+public abstract class BaseGetResourceRequest<SB extends SearchResourceRequestBuilder<SB, RepositoryContext, SR>, SR, R> 
+		extends GetResourceRequest<SB, RepositoryContext, SR, R>
+		implements RevisionIndexReadRequestTimestampProvider {
+
+	private static final long serialVersionUID = 1L;
+	
+	private final ResourceURI resourceUri;
+	
+	public BaseGetResourceRequest(ResourceURI resourceUri) {
+		super(resourceUri.getResourceId());
+		this.resourceUri = resourceUri;
+	}
+	
+	@Override
+	public final Long getReadTimestamp(ServiceProvider context) {
+		if (!Strings.isNullOrEmpty(resourceUri.getTimestampPart())) {
+			return Long.parseLong(resourceUri.getTimestampPart().substring(1));
+		} else if (!resourceUri.isHead() && !resourceUri.isNext()) {
+			return ResourceRequests.prepareSearchVersion()
+					.one()
+					.filterByResource(resourceUri.withoutPath())
+					.filterByVersionId(resourceUri.getPath())
+					.buildAsync()
+					.execute(context)
+					.first()
+					.map(Version::getCreatedAt)
+					.orElse(null);
+		}
+		return null;
+	}
+
+}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/resource/BaseGetResourceRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/resource/BaseGetResourceRequestBuilder.java
@@ -27,7 +27,8 @@ public abstract class BaseGetResourceRequestBuilder<
 	B extends GetResourceRequestBuilder<B, SB, RepositoryContext, SR, R>, 
 	SB extends SearchResourceRequestBuilder<SB, RepositoryContext, SR>, 
 	SR, 
-	R> extends GetResourceRequestBuilder<B, SB, RepositoryContext, SR, R> implements ResourceRepositoryRequestBuilder<R> {
+	R> 
+	extends GetResourceRequestBuilder<B, SB, RepositoryContext, SR, R> implements ResourceRepositoryRequestBuilder<R> {
 
 	public BaseGetResourceRequestBuilder(BaseGetResourceRequest<SB, SR, R> request) {
 		super(request);

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/resource/BaseGetResourceRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/resource/BaseGetResourceRequestBuilder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.request.resource;
+
+import com.b2international.snowowl.core.context.ResourceRepositoryRequestBuilder;
+import com.b2international.snowowl.core.domain.RepositoryContext;
+import com.b2international.snowowl.core.request.GetResourceRequestBuilder;
+import com.b2international.snowowl.core.request.SearchResourceRequestBuilder;
+
+/**
+ * @since 8.7
+ */
+public abstract class BaseGetResourceRequestBuilder<
+	B extends GetResourceRequestBuilder<B, SB, RepositoryContext, SR, R>, 
+	SB extends SearchResourceRequestBuilder<SB, RepositoryContext, SR>, 
+	SR, 
+	R> extends GetResourceRequestBuilder<B, SB, RepositoryContext, SR, R> implements ResourceRepositoryRequestBuilder<R> {
+
+	public BaseGetResourceRequestBuilder(BaseGetResourceRequest<SB, SR, R> request) {
+		super(request);
+	}
+
+}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/resource/ResourceGetRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/resource/ResourceGetRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,22 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.b2international.snowowl.core.request;
+package com.b2international.snowowl.core.request.resource;
 
 import com.b2international.snowowl.core.Resource;
+import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.Resources;
-import com.b2international.snowowl.core.context.ResourceRepositoryRequestBuilder;
-import com.b2international.snowowl.core.domain.RepositoryContext;
+import com.b2international.snowowl.core.request.ResourceSearchRequestBuilder;
 
 /**
  * @since 8.0
  */
-public final class ResourceGetRequestBuilder 
-		extends GetResourceRequestBuilder<ResourceGetRequestBuilder, ResourceSearchRequestBuilder, RepositoryContext, Resources, Resource>
-		implements ResourceRepositoryRequestBuilder<Resource> {
+public final class ResourceGetRequest extends BaseGetResourceRequest<ResourceSearchRequestBuilder, Resources, Resource> {
 
-	public ResourceGetRequestBuilder(String resourceId) {
-		super(new ResourceGetRequest(resourceId));
+	private static final long serialVersionUID = 1L;
+	
+	public ResourceGetRequest(ResourceURI resourceUri) {
+		super(resourceUri);
+	}
+
+	@Override
+	protected ResourceSearchRequestBuilder createSearchRequestBuilder() {
+		return new ResourceSearchRequestBuilder();
 	}
 
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/resource/ResourceGetRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/resource/ResourceGetRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,26 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.b2international.snowowl.core.request;
+package com.b2international.snowowl.core.request.resource;
 
 import com.b2international.snowowl.core.Resource;
+import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.Resources;
-import com.b2international.snowowl.core.domain.RepositoryContext;
+import com.b2international.snowowl.core.request.ResourceSearchRequestBuilder;
 
 /**
  * @since 8.0
  */
-public final class ResourceGetRequest extends GetResourceRequest<ResourceSearchRequestBuilder, RepositoryContext, Resources, Resource> {
-
-	private static final long serialVersionUID = 1L;
+public final class ResourceGetRequestBuilder 
+		extends BaseGetResourceRequestBuilder<ResourceGetRequestBuilder, ResourceSearchRequestBuilder, Resources, Resource> {
 	
-	public ResourceGetRequest(String resourceId) {
-		super(resourceId);
-	}
-
-	@Override
-	protected ResourceSearchRequestBuilder createSearchRequestBuilder() {
-		return new ResourceSearchRequestBuilder();
+	public ResourceGetRequestBuilder(ResourceURI resourceUri) {
+		super(new ResourceGetRequest(resourceUri));
 	}
 
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/version/VersionSearchRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/version/VersionSearchRequest.java
@@ -89,12 +89,12 @@ public final class VersionSearchRequest extends SearchIndexResourceRequest<Repos
 
 	@Override
 	protected Expression prepareQuery(RepositoryContext context) {
-		final ExpressionBuilder query = Expressions.builder();
+		final ExpressionBuilder query = Expressions.bool();
 
 		addIdFilter(query, VersionDocument.Expressions::ids);
 		addFilter(query, OptionKey.RESOURCE_TYPE, String.class, VersionDocument.Expressions::resourceTypes);
 		// TODO add a security filter to return commits from resources that can be accessed by the current user
-		addFilter(query, OptionKey.RESOURCE, String.class, resources -> Expressions.builder()
+		addFilter(query, OptionKey.RESOURCE, String.class, resources -> Expressions.bool()
 				.should(VersionDocument.Expressions.resources(resources))
 				.should(VersionDocument.Expressions.resourceIds(resources))
 				.build());

--- a/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirCodeSystemController.java
+++ b/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirCodeSystemController.java
@@ -268,8 +268,8 @@ public class FhirCodeSystemController extends AbstractFhirController {
 			@ParameterObject 
 			FhirCodeSystemSearchParameters params,
 
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 			
 		//TODO: replace this with something more general as described in
@@ -322,8 +322,8 @@ public class FhirCodeSystemController extends AbstractFhirController {
 			@ParameterObject
 			final FhirResourceSelectors selectors,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 		
 		return FhirRequests.codeSystems().prepareGet(id)

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/io/SnomedExportApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/io/SnomedExportApiTest.java
@@ -1468,7 +1468,7 @@ public class SnomedExportApiTest extends AbstractSnomedApiTest {
 		
 		final Map<String, Object> config = Map.of("type", Rf2ReleaseType.DELTA.name());
 		export(codeSystemId + "@1234567", config).then()
-			.statusCode(400);
+			.statusCode(404);
 	}
 	
 	@Test

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedClassificationRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedClassificationRestService.java
@@ -177,8 +177,8 @@ public class SnomedClassificationRestService extends AbstractRestService {
 			@RequestParam(value="limit", defaultValue="50", required=false) 
 			final int limit,
 			
-			@Parameter(description ="Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description ="Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 
 		return ClassificationRequests.prepareSearchEquivalentConceptSet()
@@ -247,8 +247,8 @@ public class SnomedClassificationRestService extends AbstractRestService {
 //			@PathVariable(value="conceptId")
 //			final String conceptId,
 //
-//			@Parameter(value ="Language codes and reference sets, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-//			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false)
+//			@Parameter(value ="Language codes and reference sets, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+//			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false)
 //			final String languageSetting) {
 //
 //		final List<ExtendedLocale> extendedLocales = getExtendedLocales(languageSetting);

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedConceptRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedConceptRestService.java
@@ -85,8 +85,8 @@ public class SnomedConceptRestService extends AbstractRestService {
 			@ParameterObject
 			final SnomedConceptRestSearch params,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 		
 		List<Sort> sorts = extractSortFields(params.getSort());
@@ -149,8 +149,8 @@ public class SnomedConceptRestService extends AbstractRestService {
 			@RequestBody(required = false)
 			final SnomedConceptRestSearch body,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 		
 		return searchByGet(path, body, acceptLanguage);
@@ -184,8 +184,8 @@ public class SnomedConceptRestService extends AbstractRestService {
 			@ParameterObject
 			final ResourceSelectors selectors,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 		return SnomedRequests
 					.prepareGetConcept(conceptId)

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedDescriptionRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedDescriptionRestService.java
@@ -75,8 +75,8 @@ public class SnomedDescriptionRestService extends AbstractRestService {
 			@ParameterObject
 			final SnomedDescriptionRestSearch params,
 
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 		
 		List<Sort> sorts = extractSortFields(params.getSort());
@@ -131,8 +131,8 @@ public class SnomedDescriptionRestService extends AbstractRestService {
 			@RequestBody(required = false)
 			final SnomedDescriptionRestSearch body,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 		
 		return searchByGet(path, body, acceptLanguage);
@@ -198,8 +198,8 @@ public class SnomedDescriptionRestService extends AbstractRestService {
 			@ParameterObject
 			final ResourceSelectors selectors,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 		
 		return SnomedRequests.prepareGetDescription(descriptionId)

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedReferenceSetMemberRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedReferenceSetMemberRestService.java
@@ -78,8 +78,8 @@ public class SnomedReferenceSetMemberRestService extends AbstractRestService {
 			@ParameterObject
 			final SnomedReferenceSetMemberRestSearch params,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 
 		final SnomedRefSetMemberSearchRequestBuilder req = SnomedRequests.prepareSearchMember()
@@ -124,8 +124,8 @@ public class SnomedReferenceSetMemberRestService extends AbstractRestService {
 			@RequestBody(required = false)
 			final SnomedReferenceSetMemberRestSearch params,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 		return searchByGet(branch, params, acceptLanguage);
 	}
@@ -154,8 +154,8 @@ public class SnomedReferenceSetMemberRestService extends AbstractRestService {
 			@ParameterObject
 			final ResourceSelectors selectors,
 
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 		return SnomedRequests
 				.prepareGetMember(memberId)

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedReferenceSetRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedReferenceSetRestService.java
@@ -88,8 +88,8 @@ public class SnomedReferenceSetRestService extends AbstractRestService {
 			@ParameterObject
 			final SnomedReferenceSetRestSearch params,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 		
 		List<Sort> sorts = extractSortFields(params.getSort());
@@ -131,8 +131,8 @@ public class SnomedReferenceSetRestService extends AbstractRestService {
 			@RequestBody(required = false)
 			final SnomedReferenceSetRestSearch body,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 		
 		return searchByGet(path, body, acceptLanguage);
@@ -187,8 +187,8 @@ public class SnomedReferenceSetRestService extends AbstractRestService {
 			@ParameterObject
 			final ResourceSelectors selectors,
 
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 
 		return SnomedRequests

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedRelationshipRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedRelationshipRestService.java
@@ -75,8 +75,8 @@ public class SnomedRelationshipRestService extends AbstractRestService {
 			@ParameterObject
 			final SnomedRelationshipRestSearch params,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 		return SnomedRequests
 					.prepareSearchRelationship()
@@ -128,8 +128,8 @@ public class SnomedRelationshipRestService extends AbstractRestService {
 			@RequestBody(required = false)
 			final SnomedRelationshipRestSearch params,
 		
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 		return searchByGet(path, params, acceptLanguage);
 	}
@@ -201,8 +201,8 @@ public class SnomedRelationshipRestService extends AbstractRestService {
 			@ParameterObject
 			final ResourceSelectors selectors,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 
 		return SnomedRequests.prepareGetRelationship(relationshipId)

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedRf2ExportRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedRf2ExportRestService.java
@@ -72,8 +72,8 @@ public class SnomedRf2ExportRestService extends AbstractRestService {
 			@ParameterObject
 			final SnomedRf2ExportConfiguration params,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6")
-			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
+			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
 			final String acceptLanguage) {
 		
 		final Attachment exportedFile = SnomedRequests.rf2().prepareExport()

--- a/tests/com.b2international.snowowl.test.commons/src/com/b2international/snowowl/test/commons/rest/CodeSystemApiAssert.java
+++ b/tests/com.b2international.snowowl.test.commons/src/com/b2international/snowowl/test/commons/rest/CodeSystemApiAssert.java
@@ -58,8 +58,7 @@ public abstract class CodeSystemApiAssert {
 	
 	public static ValidatableResponse assertCodeSystemGet(final String codeSystemId, final long timestamp) {
 		return givenAuthenticatedRequest(CODESYSTEMS_API)
-			.queryParam("timestamp", timestamp)
-			.get("/{id}", codeSystemId)
+			.get("/{id}", codeSystemId + "@" + timestamp)
 			.then();
 	}
 	


### PR DESCRIPTION
This PR adds the ability to access a versioned form of a resource via the following endpoints:
* `GET /bundles/:id`
* `GET /codesystems/:id`

The id argument now accepts a complete URI, including both version paths and timestamp parts.
Examples:
* `GET /codesystems/SNOMEDCT/2022-07-31`
* `GET /codesystems/SNOMEDCT@1659225600`