### PR TITLE
fix(fhir): set date property when requesting a versioned FHIR resource

### DIFF
--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/ResourceDocument.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/ResourceDocument.java
@@ -461,9 +461,11 @@ public final class ResourceDocument extends RevisionDocument {
 	private final Long createdAt;
 	private final Long updatedAt;
 	
-	// mapping only field, no actual purpose or use, required to support multi-index search with doc type VersionDocument
+	// mapping only fields, no actual purpose or use, required to support multi-index search with doc type VersionDocument
 	@SuppressWarnings("unused")
 	private String version;
+	@SuppressWarnings("unused")
+	private Long effectiveTime;
 	
 	public ResourceDocument(
 			final String id, 

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/FhirResourceSearchRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/FhirResourceSearchRequest.java
@@ -16,10 +16,7 @@
 package com.b2international.snowowl.fhir.core.request;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -60,7 +57,6 @@ public abstract class FhirResourceSearchRequest<B extends MetadataResource.Build
 
 	private static final Set<String> EXTERNAL_FHIR_RESOURCE_FIELDS = Set.of(
 		MetadataResource.Fields.NAME,
-		MetadataResource.Fields.DATE,
 		MetadataResource.Fields.META,
 		MetadataResource.Fields.TEXT
 	);
@@ -122,7 +118,7 @@ public abstract class FhirResourceSearchRequest<B extends MetadataResource.Build
 			
 		return prepareBundle()
 				.entry(internalResources.stream().map(codeSystem -> toFhirResourceEntry(context, codeSystem)).collect(Collectors.toList()))
-//				.after(internalCodeSystems.getSearchAfter())
+//				.after(internalResources.getSearchAfter())
 				.total(internalResources.getTotal())
 				.build();
 	}
@@ -149,14 +145,20 @@ public abstract class FhirResourceSearchRequest<B extends MetadataResource.Build
 		fieldsToLoad.removeAll(EXTERNAL_FHIR_RESOURCE_FIELDS);
 		fieldsToLoad.removeAll(getExternalFhirResourceFields());
 		// replace publisher with internal settings field (publisher is stored within resource metadata)
-		if (fieldsToLoad.contains(CodeSystem.Fields.PUBLISHER)) {
-			fieldsToLoad.remove(CodeSystem.Fields.PUBLISHER);
+		if (fieldsToLoad.contains(MetadataResource.Fields.PUBLISHER)) {
+			fieldsToLoad.remove(MetadataResource.Fields.PUBLISHER);
 			fieldsToLoad.add(ResourceDocument.Fields.SETTINGS);
 		}
 		// replace identifier with internal oid field
 		if (fieldsToLoad.contains(CodeSystem.Fields.IDENTIFIER)) {
 			fieldsToLoad.remove(CodeSystem.Fields.IDENTIFIER);
 			fieldsToLoad.add(ResourceDocument.Fields.OID);
+		}
+		
+		// for all supported FHIR Metadata Resources replace the incoming date property with the effectiveTime when requesting it
+		if (fieldsToLoad.contains(MetadataResource.Fields.DATE)) {
+			fieldsToLoad.remove(MetadataResource.Fields.DATE);
+			fieldsToLoad.add(VersionDocument.Fields.EFFECTIVE_TIME);
 		}
 		
 		// support any specific field selection changes
@@ -256,16 +258,17 @@ public abstract class FhirResourceSearchRequest<B extends MetadataResource.Build
 		
 		// optional fields
 		// we are using the ID of the resource as machine readable name
-		includeIfFieldSelected(CodeSystem.Fields.NAME, resource::getId, entry::name);
-		includeIfFieldSelected(CodeSystem.Fields.TITLE, resource::getTitle, entry::title);
-		includeIfFieldSelected(CodeSystem.Fields.URL, resource::getUrl, entry::url);
-		includeIfFieldSelected(CodeSystem.Fields.TEXT, () -> Narrative.builder().div("<div></div>").status(NarrativeStatus.EMPTY).build(), entry::text);
-		includeIfFieldSelected(CodeSystem.Fields.VERSION, resource::getVersion, entry::version);
-		includeIfFieldSelected(CodeSystem.Fields.PUBLISHER, () -> getPublisher(resource), entry::publisher);
-		includeIfFieldSelected(CodeSystem.Fields.LANGUAGE, resource::getLanguage, entry::language);
+		includeIfFieldSelected(MetadataResource.Fields.NAME, resource::getId, entry::name);
+		includeIfFieldSelected(MetadataResource.Fields.TITLE, resource::getTitle, entry::title);
+		includeIfFieldSelected(MetadataResource.Fields.URL, resource::getUrl, entry::url);
+		includeIfFieldSelected(DomainResource.Fields.TEXT, () -> Narrative.builder().div("<div></div>").status(NarrativeStatus.EMPTY).build(), entry::text);
+		includeIfFieldSelected(MetadataResource.Fields.VERSION, resource::getVersion, entry::version);
+		includeIfFieldSelected(MetadataResource.Fields.PUBLISHER, () -> getPublisher(resource), entry::publisher);
+		includeIfFieldSelected(FhirResource.Fields.LANGUAGE, resource::getLanguage, entry::language);
+		includeIfFieldSelected(MetadataResource.Fields.DATE, () -> resource.getEffectiveTime() == null ? null : new Date(resource.getEffectiveTime()), entry::date);
 		// XXX: use the resource's description in all cases
-		includeIfFieldSelected(CodeSystem.Fields.DESCRIPTION, resource::getResourceDescription, entry::description);
-		includeIfFieldSelected(CodeSystem.Fields.PURPOSE, resource::getPurpose, entry::purpose);
+		includeIfFieldSelected(MetadataResource.Fields.DESCRIPTION, resource::getResourceDescription, entry::description);
+		includeIfFieldSelected(MetadataResource.Fields.PURPOSE, resource::getPurpose, entry::purpose);
 
 		if (CompareUtils.isEmpty(fields()) || fields().contains(CodeSystem.Fields.CONTACT)) {
 			ContactDetail contact = getContact(resource);
@@ -330,6 +333,7 @@ public abstract class FhirResourceSearchRequest<B extends MetadataResource.Build
 		String toolingId;
 		String url;
 		String branchPath;
+		Long effectiveTime;
 		
 		String resourceDescription;
 		String title;
@@ -353,6 +357,10 @@ public abstract class FhirResourceSearchRequest<B extends MetadataResource.Build
 		
 		public String getVersion() {
 			return version;
+		}
+		
+		public Long getEffectiveTime() {
+			return effectiveTime;
 		}
 		
 		public String getDescription() {

--- a/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/codesystem/FhirCodeSystemApiTest.java
+++ b/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/codesystem/FhirCodeSystemApiTest.java
@@ -404,7 +404,8 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			.body("type", equalTo("searchset"))
 			.body("entry[0].resource.id", equalTo("SNOMEDCT/2002-01-31"))
 			.body("entry[0].resource.url", equalTo(SNOMEDCT_URL + "/version/20020131"))
-			.body("entry[0].resource.version", equalTo("2002-01-31"));
+			.body("entry[0].resource.version", equalTo("2002-01-31"))
+			.body("entry[0].resource.date", equalTo("2002-01-31T00:00:00.000+00:00"));
 	}
 	
 	@Test
@@ -421,9 +422,11 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			.body("entry[0].resource.id", equalTo("SNOMEDCT/2002-01-31"))
 			.body("entry[0].resource.url", equalTo(SNOMEDCT_URL + "/version/20020131"))
 			.body("entry[0].resource.version", equalTo("2002-01-31"))
+			.body("entry[0].resource.date", equalTo("2002-01-31T00:00:00.000+00:00"))
 			.body("entry[1].resource.id", equalTo("SNOMEDCT/2020-01-31"))
 			.body("entry[1].resource.url", equalTo(SNOMEDCT_URL + "/version/20200131"))
-			.body("entry[1].resource.version", equalTo("2020-01-31"));
+			.body("entry[1].resource.version", equalTo("2020-01-31"))
+			.body("entry[1].resource.date", equalTo("2020-01-31T00:00:00.000+00:00"));
 	}
 	
 	@Test


### PR DESCRIPTION
The `effectiveTime` of the version document will be used in ISO8601 format to represent the publication date.

See this page for more info:
http://hl7.org/fhir/codesystem-definitions.html#CodeSystem.date

Fixes https://snowowl.atlassian.net/browse/SO-5563