### PR TITLE
fix(fhir.core): Use "createdAt" for point-in-time resource document...

### DIFF
--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/FhirResourceSearchRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/FhirResourceSearchRequest.java
@@ -140,6 +140,9 @@ public abstract class FhirResourceSearchRequest<B extends MetadataResource.Build
 			if (!fieldsToLoad.contains(ResourceDocument.Fields.TOOLING_ID)) {
 				fieldsToLoad.add(ResourceDocument.Fields.TOOLING_ID);
 			}
+			if (!fieldsToLoad.contains(ResourceDocument.Fields.CREATED_AT)) {
+				fieldsToLoad.add(ResourceDocument.Fields.CREATED_AT);
+			}
 			if (!fieldsToLoad.contains(ResourceDocument.Fields.UPDATED_AT)) {
 				fieldsToLoad.add(ResourceDocument.Fields.UPDATED_AT);
 			}
@@ -211,7 +214,7 @@ public abstract class FhirResourceSearchRequest<B extends MetadataResource.Build
 				.fields(fields)
 				.where(Expressions.bool()
 					.filter(ResourceDocument.Expressions.id(fragment.getResourceURI().getResourceId()))
-					.filter(ResourceDocument.Expressions.validAsOf(fragment.getCreated().getTimestamp()))
+					.filter(ResourceDocument.Expressions.validAsOf(fragment.getCreatedAt()))
 					.build())
 				.limit(1)
 				.build());


### PR DESCRIPTION
...queries instead of "created"'s timestamp portion for backwards compatibility in datasets where no FHIR resource metadata is stored on version documents.