### PR TITLE
SNRAY-1117: Make "version" field mandatory to load as well

### DIFF
--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/FhirResourceSearchRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/FhirResourceSearchRequest.java
@@ -142,6 +142,9 @@ public abstract class FhirResourceSearchRequest<B extends MetadataResource.Build
 			if (!fieldsToLoad.contains(ResourceDocument.Fields.UPDATED_AT)) {
 				fieldsToLoad.add(ResourceDocument.Fields.UPDATED_AT);
 			}
+			if (!fieldsToLoad.contains(VersionDocument.Fields.VERSION)) {
+				fieldsToLoad.add(VersionDocument.Fields.VERSION);
+			}
 		}
 		
 		// remove all fields that are not part of the current resource model


### PR DESCRIPTION
The value is used in `fillResourceOnlyProperties` to distinguish between the two possible sources of a `ResourceFragment` instance (they are created either from a resource or a version document). If it is not part of the set of fields to be loaded, we can no longer determine the source correctly.

