### PR TITLE
Adapt batch size of reindex requests

### DIFF
--- a/commons/com.b2international.index.tests/src/com/b2international/index/ReindexResultSerializationTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/ReindexResultSerializationTest.java
@@ -54,6 +54,7 @@ public class ReindexResultSerializationTest {
 				.destinationIndex("destinationIndex")
 				.remoteAddress("remoteAddress")
 				.refresh(true)
+				.retries(Long.valueOf(2L))
 				.build();
 
 		simpleReindexResult = ReindexResult.builder()
@@ -66,7 +67,7 @@ public class ReindexResultSerializationTest {
 				.build();
 
 
-		serializedResponse = "{\"took\":\"123 ns\",\"createdDocuments\":1,\"updatedDocuments\":1,\"deletedDocuments\":1,\"noops\":1,\"versionConflicts\":2,\"totalDocuments\":1,\"sourceIndex\":\"sourceIndex\",\"destinationIndex\":\"destinationIndex\",\"remoteAddress\":\"remoteAddress\",\"refresh\":true}";
+		serializedResponse = "{\"took\":\"123 ns\",\"createdDocuments\":1,\"updatedDocuments\":1,\"deletedDocuments\":1,\"noops\":1,\"versionConflicts\":2,\"totalDocuments\":1,\"sourceIndex\":\"sourceIndex\",\"destinationIndex\":\"destinationIndex\",\"remoteAddress\":\"remoteAddress\",\"refresh\":true,\"retries\":2}";
 		simpleSerializedResponse = "{\"took\":\"123 ns\",\"totalDocuments\":1,\"sourceIndex\":\"sourceIndex\",\"destinationIndex\":\"destinationIndex\",\"remoteAddress\":\"remoteAddress\",\"refresh\":false}";
 
 	}

--- a/commons/com.b2international.index/src/com/b2international/index/es/client/EsClient.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/client/EsClient.java
@@ -80,7 +80,7 @@ public interface EsClient extends AutoCloseable {
 	
 	BulkByScrollResponse deleteByQuery(String index, int batchSize, QueryBuilder query) throws IOException;
 	
-	BulkByScrollResponse reindex(String sourceIndex, String destinationIndex, RemoteInfo remoteInfo, boolean refresh) throws IOException;
+	BulkByScrollResponse reindex(String sourceIndex, String destinationIndex, RemoteInfo remoteInfo, boolean refresh, int batchSize) throws IOException;
 	
 	static EsClient create(final EsClientConfiguration configuration) {
 		return ClientPool.create(configuration);

--- a/commons/com.b2international.index/src/com/b2international/index/es/client/http/EsHttpClient.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/client/http/EsHttpClient.java
@@ -191,7 +191,7 @@ public final class EsHttpClient extends EsClientBase {
 	}
 	
 	@Override
-	public BulkByScrollResponse reindex(String sourceIndex, String destinationIndex, RemoteInfo remoteInfo, boolean refresh) throws IOException {
+	public BulkByScrollResponse reindex(String sourceIndex, String destinationIndex, RemoteInfo remoteInfo, boolean refresh, int batchSize) throws IOException {
 		
 		ReindexRequest reindexRequest = new ReindexRequest();
 		
@@ -199,6 +199,7 @@ public final class EsHttpClient extends EsClientBase {
 		reindexRequest.setDestIndex(destinationIndex);
 		reindexRequest.setRemoteInfo(remoteInfo);
 		reindexRequest.setRefresh(refresh);
+		reindexRequest.setSourceBatchSize(batchSize);
 		reindexRequest.setAbortOnVersionConflict(false);
 		
 		return client.reindex(reindexRequest, EXTENDED_DEFAULT);

--- a/commons/com.b2international.index/src/com/b2international/index/es/client/tcp/EsTcpClient.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/client/tcp/EsTcpClient.java
@@ -133,9 +133,11 @@ public final class EsTcpClient extends EsClientBase {
 	}
 	
 	@Override
-	public BulkByScrollResponse reindex(String sourceIndex, String destinationIndex, RemoteInfo remoteInfo, boolean refresh) throws IOException {
+	public BulkByScrollResponse reindex(String sourceIndex, String destinationIndex, RemoteInfo remoteInfo, boolean refresh, int batchSize) throws IOException {
 		
 		ReindexRequestBuilder rirb = new ReindexRequestBuilder(client, ReindexAction.INSTANCE);
+		
+		rirb.source().setSize(batchSize);
 		
 		return rirb
 			.source(sourceIndex)

--- a/commons/com.b2international.index/src/com/b2international/index/es/reindex/ReindexResult.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/reindex/ReindexResult.java
@@ -48,6 +48,8 @@ public class ReindexResult implements Serializable {
 	private final String remoteAddress;
 
 	private final boolean refresh;
+	
+	private final Long retries;
 
 	public static Builder builder() {
 		return new Builder();
@@ -72,6 +74,8 @@ public class ReindexResult implements Serializable {
 		private String remoteAddress;
 
 		private boolean refresh;
+		
+		private Long retries;
 
 		private Builder() {}
 
@@ -129,10 +133,15 @@ public class ReindexResult implements Serializable {
 			this.refresh = refresh;
 			return this;
 		}
+		
+		public Builder retries(Long retries) {
+			this.retries = retries;
+			return this;
+		}
 
 		public ReindexResult build() {
 			return new ReindexResult(took, createdDocuments, updatedDocuments, deletedDocuments, noops, versionConflicts, totalDocuments, sourceIndex,
-					destinationIndex, remoteAddress, refresh);
+					destinationIndex, remoteAddress, refresh, retries);
 		}
 
 	}
@@ -148,7 +157,8 @@ public class ReindexResult implements Serializable {
 			String sourceIndex,
 			String destinationIndex,
 			String remoteAddress,
-			boolean refresh) {
+			boolean refresh,
+			Long retries) {
 		this.took = took;
 		this.createdDocuments = createdDocuments;
 		this.updatedDocuments = updatedDocuments;
@@ -160,6 +170,7 @@ public class ReindexResult implements Serializable {
 		this.destinationIndex = destinationIndex;
 		this.remoteAddress = remoteAddress;
 		this.refresh = refresh;
+		this.retries = retries;
 	}
 
 	public String getTook() {
@@ -205,6 +216,10 @@ public class ReindexResult implements Serializable {
 	public boolean isRefresh() {
 		return refresh;
 	}
+	
+	public Long getRetries() {
+		return retries;
+	}
 
 	@Override
 	public String toString() {
@@ -221,28 +236,29 @@ public class ReindexResult implements Serializable {
 			.add("destinationIndex", destinationIndex)
 			.add("remoteAddress", remoteAddress)
 			.add("refresh", refresh)
+			.add("retries", retries)
 			.toString();
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(createdDocuments, deletedDocuments, destinationIndex, noops, refresh, remoteAddress, sourceIndex, took, totalDocuments,
-				updatedDocuments, versionConflicts);
+		return Objects.hash(createdDocuments, deletedDocuments, destinationIndex, noops, refresh, remoteAddress, retries, sourceIndex, took,
+				totalDocuments, updatedDocuments, versionConflicts);
 	}
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj) {
+		if (this == obj)
 			return true;
-		}
-		if (obj == null || getClass() != obj.getClass()) {
+		if (obj == null)
 			return false;
-		}
-		final ReindexResult other = (ReindexResult) obj;
+		if (getClass() != obj.getClass())
+			return false;
+		ReindexResult other = (ReindexResult) obj;
 		return Objects.equals(createdDocuments, other.createdDocuments) && Objects.equals(deletedDocuments, other.deletedDocuments)
 				&& Objects.equals(destinationIndex, other.destinationIndex) && Objects.equals(noops, other.noops) && refresh == other.refresh
-				&& Objects.equals(remoteAddress, other.remoteAddress) && Objects.equals(sourceIndex, other.sourceIndex)
-				&& Objects.equals(took, other.took) && totalDocuments == other.totalDocuments
+				&& Objects.equals(remoteAddress, other.remoteAddress) && Objects.equals(retries, other.retries)
+				&& Objects.equals(sourceIndex, other.sourceIndex) && Objects.equals(took, other.took) && totalDocuments == other.totalDocuments
 				&& Objects.equals(updatedDocuments, other.updatedDocuments) && Objects.equals(versionConflicts, other.versionConflicts);
 	}
 


### PR DESCRIPTION
Automatically retry reindex with a smaller batch size in case the documents are larger than the default 100 Mb on-heap buffer