### PR TITLE
Force version creation deletes a branch document even when responds with HTTP 400 Bad Request

### DIFF
--- a/commons/com.b2international.index.test.tools/src/com/b2international/index/revision/BaseRevisionIndexTest.java
+++ b/commons/com.b2international.index.test.tools/src/com/b2international/index/revision/BaseRevisionIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ public abstract class BaseRevisionIndexTest {
 	}
 	
 	protected String createBranch(String parent, String child) {
-		return branching().createBranch(parent, child, new MetadataImpl());
+		return branching().createBranch(parent, child, new MetadataImpl(), false);
 	}
 	
 	protected long currentTime() {

--- a/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchingTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchingTest.java
@@ -211,7 +211,7 @@ public class RevisionBranchingTest extends BaseRevisionIndexTest {
 	public void whenCreatingBranchWithMetadata_ThenItShouldBeStored() throws Exception {
 		final Metadata metadata = new MetadataImpl();
 		metadata.put("key", "value");
-		final String b = branching().createBranch(MAIN, "b", metadata);
+		final String b = branching().createBranch(MAIN, "b", metadata, false);
 		assertEquals("value", getBranch(b).metadata().get("key"));
 	}
 	
@@ -254,7 +254,7 @@ public class RevisionBranchingTest extends BaseRevisionIndexTest {
 	@Test
 	public void updateMetadata() throws Exception {
 		final BaseRevisionBranching branching = branching();
-		final String branchA = branching.createBranch(MAIN, "a", new MetadataImpl(ImmutableMap.<String, Object>of("test", 0)));
+		final String branchA = branching.createBranch(MAIN, "a", new MetadataImpl(ImmutableMap.<String, Object>of("test", 0)), false);
 		final long commitTimestamp = currentTime();
 		final IndexWrite<Void> timestampUpdate = branching.update(branchA, RevisionBranch.Scripts.COMMIT, ImmutableMap.of("headTimestamp", commitTimestamp));
 		final IndexWrite<Void> metadataUpdate = branching.update(branchA, RevisionBranch.Scripts.WITH_METADATA, ImmutableMap.of("metadata", new MetadataImpl(ImmutableMap.<String, Object>of("test", 1))));
@@ -285,7 +285,7 @@ public class RevisionBranchingTest extends BaseRevisionIndexTest {
 	}
 	
 	private ObjectAssert<RevisionBranch> assertBranchCreate(String branchName) {
-		final String branchPath = branching().createBranch(MAIN, branchName, null);
+		final String branchPath = branching().createBranch(MAIN, branchName, null, false);
 		return assertThat(branching().get(branchPath));
 	}
 	

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/Branch.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/Branch.java
@@ -236,4 +236,24 @@ public final class Branch implements MetadataHolder, Serializable {
 	public static final List<String> split(String path) {
 		return BRANCH_PATH_SPLITTER.splitToList(path);
 	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder
+			.append("Branch [branchId=").append(branchId)
+			.append(", isDeleted=").append(isDeleted)
+			.append(", metadata=").append(metadata)
+			.append(", name=").append(name)
+			.append(", parentPath=").append(parentPath)
+			.append(", baseTimestamp=").append(baseTimestamp)
+			.append(", headTimestamp=").append(headTimestamp)
+			.append(", state=").append(state)
+			.append(", branchPath=").append(branchPath)
+			.append(", mergeSources=").append(mergeSources)
+			.append(", children=").append(children).append("]");
+		return builder.toString();
+	}
+	
+		
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/BranchCreateRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/BranchCreateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,15 +29,19 @@ import com.b2international.snowowl.core.identity.Permission;
  */
 public final class BranchCreateRequest extends BranchBaseRequest<String> implements AccessControl {
 
+	private static final long serialVersionUID = 1L;
+	
 	private final String parent;
 	private final String name;
 	private final Metadata metadata;
+	private final boolean force;
 
-	public BranchCreateRequest(final String parent, final String name, final Metadata metadata) {
+	public BranchCreateRequest(final String parent, final String name, final Metadata metadata, final boolean force) {
 		super(path(parent, name));
 		this.parent = parent;
 		this.name = name;
 		this.metadata = nullToEmpty(metadata);
+		this.force = force;
 	}
 
 	private static Metadata nullToEmpty(Metadata metadata) {
@@ -60,10 +64,14 @@ public final class BranchCreateRequest extends BranchBaseRequest<String> impleme
 		return metadata;
 	}
 	
+	public boolean isForce() {
+		return force;
+	}
+	
 	@Override
 	public String execute(RepositoryContext context) {
 		try {
-			return context.service(BaseRevisionBranching.class).createBranch(getParent(), getName(), getMetadata());
+			return context.service(BaseRevisionBranching.class).createBranch(getParent(), getName(), getMetadata(), force);
 		} catch (NotFoundException e) {
 			// if parent not found, convert it to BadRequestException
 			throw e.toBadRequestException();

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/BranchCreateRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/BranchCreateRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,11 @@ package com.b2international.snowowl.core.branch;
 
 import com.b2international.commons.options.Metadata;
 import com.b2international.commons.options.MetadataImpl;
+import com.b2international.snowowl.core.context.TerminologyResourceContentRequestBuilder;
 import com.b2international.snowowl.core.domain.RepositoryContext;
 import com.b2international.snowowl.core.events.BaseRequestBuilder;
 import com.b2international.snowowl.core.events.Request;
+import com.b2international.snowowl.core.request.CommitResult;
 import com.b2international.snowowl.core.request.RepositoryRequestBuilder;
 
 /**
@@ -30,6 +32,7 @@ public final class BranchCreateRequestBuilder extends BaseRequestBuilder<BranchC
 	private String parent;
 	private String name;
 	private Metadata metadata = new MetadataImpl();
+	private boolean force = false;
 	
 	BranchCreateRequestBuilder() {}
 	
@@ -40,17 +43,22 @@ public final class BranchCreateRequestBuilder extends BaseRequestBuilder<BranchC
 	
 	public BranchCreateRequestBuilder setName(String name) {
 		this.name = name;
-		return this;
+		return getSelf();
 	}
 	
 	public BranchCreateRequestBuilder setParent(String parent) {
 		this.parent = parent;
-		return this;
+		return getSelf();
+	}
+	
+	public BranchCreateRequestBuilder force(boolean force) {
+		this.force = force;
+		return getSelf();
 	}
 	
 	@Override
 	protected Request<RepositoryContext, String> doBuild() {
-		return new BranchCreateRequest(parent, name, metadata);
+		return new BranchCreateRequest(parent, name, metadata, force);
 	}
-	
+
 }


### PR DESCRIPTION
This PR fixes a very rare issue when a branch document got deleted due to an incorrect force recreation attempt of an earlier/older version.
