### PR TITLE
SO-5642: API key expiration

### DIFF
--- a/cis/com.b2international.snowowl.snomed.cis.rest/src/com/b2international/snowowl/snomed/cis/rest/CisAuthenticationService.java
+++ b/cis/com.b2international.snowowl.snomed.cis.rest/src/com/b2international/snowowl/snomed/cis/rest/CisAuthenticationService.java
@@ -61,7 +61,7 @@ public class CisAuthenticationService extends AbstractRestService {
 	public Token login(
 			@Parameter(description = "The user credentials.", required = true) 
 			@RequestBody Credentials credentials) {
-		return new Token(UserRequests.prepareLogin()
+		return new Token(UserRequests.prepareGenerateApiKey()
 				.setUsername(credentials.getUsername())
 				.setPassword(credentials.getPassword())
 				.buildAsync()

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/admin/ApiKeyCreateRequest.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/admin/ApiKeyCreateRequest.java
@@ -23,7 +23,7 @@ public class ApiKeyCreateRequest {
 	private String username;
 	private String password;
 	private String token;
-	private String expiration;
+	private String expiration = "1d";
 
 	public String getUsername() {
 		return username;

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/admin/ApiKeyCreateRequest.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/admin/ApiKeyCreateRequest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.rest.admin;
+
+/**
+ * @since 8.9
+ */
+public class ApiKeyCreateRequest {
+
+	private String username;
+	private String password;
+	private String token;
+	private String expiration;
+
+	public String getUsername() {
+		return username;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+	
+	public String getToken() {
+		return token;
+	}
+	
+	public String getExpiration() {
+		return expiration;
+	}
+	
+	public void setExpiration(String expiration) {
+		this.expiration = expiration;
+	}
+	
+	public void setPassword(String password) {
+		this.password = password;
+	}
+	
+	public void setToken(String token) {
+		this.token = token;
+	}
+	
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	
+}

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/admin/ApiKeyService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/admin/ApiKeyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2019-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,23 +28,25 @@ import com.b2international.snowowl.core.identity.User;
 import com.b2international.snowowl.core.identity.request.UserRequests;
 import com.b2international.snowowl.core.rest.AbstractRestService;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 /**
  * @since 7.2
  */
-@Tag(description = "Authorization", name = "authorization")
+@Tag(description = "API Key", name = "apikey")
 @RestController
 @RequestMapping(produces={ MediaType.APPLICATION_JSON_VALUE })
-public class AuthorizationService extends AbstractRestService {
+public class ApiKeyService extends AbstractRestService {
 
+	@Operation(deprecated = true, description = "Use the `POST /token` endpoint instead")
 	@PostMapping("/login")
 	public User login(
 			@Parameter(name = "credentials", description = "The user credentials.", required = true) 
 			@RequestBody Credentials credentials) {
 		try {
-			return UserRequests.prepareLogin()
+			return UserRequests.prepareGenerateApiKey()
 					.setUsername(credentials.getUsername())
 					.setPassword(credentials.getPassword())
 					.setToken(credentials.getToken())
@@ -52,9 +54,29 @@ public class AuthorizationService extends AbstractRestService {
 					.execute(getBus())
 					.getSync();
 		} catch (UnauthorizedException e) {
-			// convert HTTP 401 to HTTP 404 in this endpoint
+			// convert HTTP 401 to HTTP 400 in this endpoint
 			throw new BadRequestException(e.getMessage());
 		}
 	}
+	
+	@Operation(deprecated = true, description = "Use the `POST /token` endpoint instead")
+	@PostMapping("/token")
+	public User token(
+			@Parameter(name = "credentials", description = "The user credentials.", required = true) 
+			@RequestBody Credentials credentials) {
+		try {
+			return UserRequests.prepareGenerateApiKey()
+					.setUsername(credentials.getUsername())
+					.setPassword(credentials.getPassword())
+					.setToken(credentials.getToken())
+					.buildAsync()
+					.execute(getBus())
+					.getSync();
+		} catch (UnauthorizedException e) {
+			// convert HTTP 401 to HTTP 400 in this endpoint
+			throw new BadRequestException(e.getMessage());
+		}
+	}
+	
 	
 }

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/admin/ApiKeyService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/admin/ApiKeyService.java
@@ -59,16 +59,17 @@ public class ApiKeyService extends AbstractRestService {
 		}
 	}
 	
-	@Operation(deprecated = true, description = "Use the `POST /token` endpoint instead")
+	@Operation(description = "Generates a new API key using the given configuration.")
 	@PostMapping("/token")
 	public User token(
 			@Parameter(name = "credentials", description = "The user credentials.", required = true) 
-			@RequestBody Credentials credentials) {
+			@RequestBody ApiKeyCreateRequest request) {
 		try {
 			return UserRequests.prepareGenerateApiKey()
-					.setUsername(credentials.getUsername())
-					.setPassword(credentials.getPassword())
-					.setToken(credentials.getToken())
+					.setUsername(request.getUsername())
+					.setPassword(request.getPassword())
+					.setToken(request.getToken())
+					.setExpiration(request.getExpiration())
 					.buildAsync()
 					.execute(getBus())
 					.getSync();

--- a/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/identity/JWTConfigurationTest.java
+++ b/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/identity/JWTConfigurationTest.java
@@ -98,6 +98,14 @@ public class JWTConfigurationTest {
 		assertThat(token.getExpiresAt()).isEqualTo(beforeGenerationTime.plusSeconds(5));
 	}
 	
+	@Test(expected = BadRequestException.class)
+	public void hs256_withNegativeExpiresAt() throws Exception {
+		IdentityConfiguration conf = readConfig("hs256.yml");
+		JWTSupport jwtSupport = new IdentityPlugin().initJWT(env, conf);
+		// generate a key with an invalid expiration value
+		jwtSupport.generate("test@example.com", Map.of(), "-5s");
+	}
+	
 	@Test(expected = SnowOwl.InitializationException.class)
 	public void hs512_NoSecret() throws Exception {
 		IdentityConfiguration conf = readConfig("hs512_nosecret.yml");

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/client/TransportClient.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/client/TransportClient.java
@@ -224,7 +224,7 @@ public final class TransportClient implements IDisposableService {
 			initConnection();
 			
 			// try to log in with the specified username and password using the non-authorized bus instance
-			final User user = UserRequests.prepareLogin()
+			final User user = UserRequests.prepareGenerateApiKey()
 				.setUsername(username)
 				.setPassword(password)
 				.buildAsync()

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/AuthorizationHeaderVerifier.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/AuthorizationHeaderVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.b2international.snowowl.core.identity;
 
 import java.util.Base64;
 
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.b2international.commons.exceptions.UnauthorizedException;
 import com.google.common.base.Charsets;
 
@@ -79,6 +80,9 @@ public final class AuthorizationHeaderVerifier {
 	public User authJWT(final String token) {
 		try {
 			return jwtSupport.authJWT(token);
+		} catch (TokenExpiredException e) {
+			IdentityProvider.LOG.warn("Failed login attempt with an expired authorization token");
+			throw new UnauthorizedException("Incorrect authorization token");
 		} catch (Exception e) {
 			// try to authorize JWT using the global provider first, then fall back to the dedicated identity provider specific JWT authentication
 		}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/DefaultJWTGenerator.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/DefaultJWTGenerator.java
@@ -28,6 +28,7 @@ import org.elasticsearch.core.TimeValue;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTCreator.Builder;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.b2international.commons.exceptions.BadRequestException;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 
@@ -60,8 +61,12 @@ final class DefaultJWTGenerator implements JWTGenerator {
 				.withClaim(emailClaimProperty, email);
 		
 		if (!Strings.isNullOrEmpty(expiration)) {
-			TimeValue expirationTimeValue = TimeValue.parseTimeValue(expiration, "expiration");
-			builder.withExpiresAt(Date.from(instantSource.instant().plusSeconds(expirationTimeValue.getSeconds())));
+			try {
+				TimeValue expirationTimeValue = TimeValue.parseTimeValue(expiration, "expiration");
+				builder.withExpiresAt(Date.from(instantSource.instant().plusSeconds(expirationTimeValue.getSeconds())));
+ 			} catch (IllegalArgumentException e) {
+ 				throw new BadRequestException("Invalid 'expiration' value: %s", expiration).withDeveloperMessage(e.getMessage());
+ 			}
 		}
 		
 		// add claims

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/IdentityPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/IdentityPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.b2international.snowowl.core.identity;
 
 import static com.google.common.collect.Lists.newArrayListWithExpectedSize;
 
+import java.time.InstantSource;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -65,8 +66,13 @@ public final class IdentityPlugin extends Plugin {
 
 	@VisibleForTesting
 	/*package*/ JWTSupport initJWT(Environment env, final IdentityConfiguration conf) throws Exception {
+		return initJWT(env, conf, InstantSource.system());
+	}
+	
+	@VisibleForTesting
+	/*package*/ JWTSupport initJWT(Environment env, final IdentityConfiguration conf, InstantSource instantSource) throws Exception {
 		// attach global JWT support to the current identity provider configured via snowowl.yml
-		JWTSupport jwtSupport = new JWTSupport(conf);
+		JWTSupport jwtSupport = new JWTSupport(conf, instantSource);
 		jwtSupport.init();
 		return jwtSupport;
 	}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/JWTGenerator.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/JWTGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,13 +22,23 @@ import java.util.Map;
  */
 interface JWTGenerator {
 
-	String generate(String email, Map<String, Object> claims);
+	/**
+	 * Generates a JWT access token based on the given email, claims and expiration value.
+	 * 
+	 * @param email - the email address to associate with the generated key, may not be <code>null</code>
+	 * @param claims - any additional claims to set for the generated key
+	 * @param expiration - expiration to use for the generated key, if <code>null</code> or empty the token will never expire
+	 * @return
+	 */
+	String generate(String email, Map<String, Object> claims, String expiration);
 
 	/**
 	 * Generate a JWT security token from the information available in the given {@link User} object.
-	 * @param user
+	 * 
+	 * @param user - the user information to gather from this {@link User} object
+	 * @param expiration - expiration to use for the generated key, if <code>null</code> or empty the token will never expire
 	 * @return
 	 */
-	String generate(User user);
+	String generate(User user, String expiration);
 
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/request/GenerateApiKeyRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/request/GenerateApiKeyRequest.java
@@ -32,7 +32,7 @@ import com.google.common.base.Strings;
  * @since 7.2
  */
 @Unprotected
-public final class UserLoginRequest implements Request<ServiceProvider, User> {
+final class GenerateApiKeyRequest implements Request<ServiceProvider, User> {
 
 	private static final long serialVersionUID = 2L;
 
@@ -43,10 +43,17 @@ public final class UserLoginRequest implements Request<ServiceProvider, User> {
 	
 	private String token;
 
-	UserLoginRequest(String username, String password, String token) {
+	@JsonProperty
+	private String expiration;
+	
+	GenerateApiKeyRequest(String username, String password, String token) {
 		this.username = username;
 		this.password = password;
 		this.token = token;
+	}
+	
+	void setExpiration(String expiration) {
+		this.expiration = expiration;
 	}
 	
 	@Override
@@ -72,7 +79,7 @@ public final class UserLoginRequest implements Request<ServiceProvider, User> {
 		}
 		
 		// generate and attach a token
-		return user.withAccessToken(context.service(JWTSupport.class).generate(user));
+		return user.withAccessToken(context.service(JWTSupport.class).generate(user, expiration));
 	}
-	
+
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/request/GenerateApiKeyRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/request/GenerateApiKeyRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2019-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,30 +24,38 @@ import com.b2international.snowowl.core.request.SystemRequestBuilder;
 /**
  * @since 7.2
  */
-public final class UserLoginRequestBuilder extends BaseRequestBuilder<UserLoginRequestBuilder, ServiceProvider, User> implements SystemRequestBuilder<User> {
+public final class GenerateApiKeyRequestBuilder extends BaseRequestBuilder<GenerateApiKeyRequestBuilder, ServiceProvider, User> implements SystemRequestBuilder<User> {
 
 	private String username;
 	private String password;
 	private String token;
+	private String expiration;
 	
-	public UserLoginRequestBuilder setUsername(String username) {
+	public GenerateApiKeyRequestBuilder setUsername(String username) {
 		this.username = username;
 		return getSelf();
 	}
 	
-	public UserLoginRequestBuilder setPassword(String password) {
+	public GenerateApiKeyRequestBuilder setPassword(String password) {
 		this.password = password;
 		return getSelf();
 	}
 	
-	public UserLoginRequestBuilder setToken(String token) {
+	public GenerateApiKeyRequestBuilder setToken(String token) {
 		this.token = token;
+		return getSelf();
+	}
+	
+	public GenerateApiKeyRequestBuilder setExpiration(String expiration) {
+		this.expiration = expiration;
 		return getSelf();
 	}
 	
 	@Override
 	protected Request<ServiceProvider, User> doBuild() {
-		return new UserLoginRequest(username, password, token);
+		GenerateApiKeyRequest req = new GenerateApiKeyRequest(username, password, token);
+		req.setExpiration(expiration);
+		return req;
 	}
 
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/request/UserGetRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/request/UserGetRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import com.b2international.snowowl.core.request.GetResourceRequest;
  * @since 5.11
  */
 final class UserGetRequest extends GetResourceRequest<UserSearchRequestBuilder, ServiceProvider, Users, User> {
+
+	private static final long serialVersionUID = 1L;
 
 	UserGetRequest(String username) {
 		super(username);

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/request/UserRequests.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/request/UserRequests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ public final class UserRequests {
 		return new UserSearchRequestBuilder();
 	}
 
-	public static UserLoginRequestBuilder prepareLogin() {
-		return new UserLoginRequestBuilder();
+	public static GenerateApiKeyRequestBuilder prepareGenerateApiKey() {
+		return new GenerateApiKeyRequestBuilder();
 	}
 
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/request/UserSearchRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/request/UserSearchRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ import com.b2international.snowowl.core.request.SearchResourceRequest;
  * @since 5.11
  */
 final class UserSearchRequest extends SearchResourceRequest<ServiceProvider, Users> {
+
+	private static final long serialVersionUID = 1L;
 
 	UserSearchRequest() {}
 	


### PR DESCRIPTION
This PR adds a new `POST /token` endpoint with the option to configure the `expiration` time of the generated token as well. The old `POST /login` endpoint becomes deprecated.