### PR TITLE
SNRAY-1244: authorization performance improvements

### DIFF
--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/authorization/AuthorizedRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/authorization/AuthorizedRequest.java
@@ -119,7 +119,7 @@ public final class AuthorizedRequest<R> extends DelegatingRequest<ServiceProvide
 				// throw a Forbidden Exception if the user does not have permission to perform the request
 				context.optionalService(AuthorizationService.class)
 					.orElse(AuthorizationService.DEFAULT)
-					.checkPermission(user, requiredPermissionsToExecute);
+					.checkPermission(context, user, requiredPermissionsToExecute);
 			}
 		}
 		


### PR DESCRIPTION
This PR adds a simple authorization shortcut to each request where the request only cares about a single resource and it does not need to fetch all visible resources. This yields 50% performance gain on not cacheable requests (`100ms` -> `50ms`) while a massive 80% on cacheable requests (`50ms` -> `10ms`).