### PR TITLE
Support `Accept-Language: "*"` headers

### DIFF
--- a/commons/com.b2international.commons.test/.launch/commons-tests.launch
+++ b/commons/com.b2international.commons.test/.launch/commons-tests.launch
@@ -37,6 +37,7 @@
     <stringAttribute key="product" value=""/>
     <booleanAttribute key="run_in_ui_thread" value="true"/>
     <setAttribute key="selected_target_bundles">
+        <setEntry value="assertj-core@default:default"/>
         <setEntry value="ch.qos.logback.classic@default:default"/>
         <setEntry value="ch.qos.logback.core@default:default"/>
         <setEntry value="com.diffplug.osgi.extension.sun.misc@default:false"/>

--- a/commons/com.b2international.commons.test/META-INF/MANIFEST.MF
+++ b/commons/com.b2international.commons.test/META-INF/MANIFEST.MF
@@ -10,4 +10,5 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
  org.junit;bundle-version="4.11.0",
  org.mockito.mockito-core;bundle-version="3.11.2",
  com.b2international.snowowl.test.dependencies,
- com.b2international.collections.jackson;bundle-version="7.1.0"
+ com.b2international.collections.jackson;bundle-version="7.1.0",
+ assertj-core;bundle-version="3.24.1"

--- a/commons/com.b2international.commons.test/src/com/b2international/commons/graph/LongTarjanTest.java
+++ b/commons/com.b2international.commons.test/src/com/b2international/commons/graph/LongTarjanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import com.b2international.collections.PrimitiveSets;
 import com.b2international.collections.longs.LongCollections;
 import com.b2international.collections.longs.LongKeyLongMap;
 import com.b2international.collections.longs.LongSet;
-import com.b2international.commons.graph.LongTarjan;
 import com.google.common.collect.ImmutableList;
 
 /**

--- a/commons/com.b2international.commons.test/src/com/b2international/commons/http/AcceptLanguageHeaderTest.java
+++ b/commons/com.b2international.commons.test/src/com/b2international/commons/http/AcceptLanguageHeaderTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.commons.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * @since 8.10.0
+ */
+public class AcceptLanguageHeaderTest {
+
+	@Test(expected = IllegalArgumentException.class)
+	public void unsupportedMixedHeaderValue() throws Exception {
+		AcceptLanguageHeader.parseHeader("de,*");
+	}
+	
+	@Test
+	public void wildcardWithExplicitDefault() throws Exception {
+		List<ExtendedLocale> locales = AcceptLanguageHeader.parseHeader("*", "en");
+		assertThat(locales)
+			.extracting(ExtendedLocale::getLanguageTag)
+			.containsExactly("en");
+	}
+	
+	@Test
+	public void wildcardWithImplicitDefault() throws Exception {
+		List<ExtendedLocale> locales = AcceptLanguageHeader.parseHeader("*");
+		assertThat(locales)
+			.extracting(ExtendedLocale::getLanguageTag)
+			.containsExactly("en-us", "en-gb", "en");
+	}
+	
+	@Test
+	public void acceptLanguageHeaderWithReversePreferenceOrder() throws Exception {
+		List<ExtendedLocale> locales = AcceptLanguageHeader.parseHeader("en;q=0.4,en-GB;q=0.6,en-US;q=0.8");
+		assertThat(locales)
+			.extracting(ExtendedLocale::getLanguageTag)
+			.containsExactly("en-us", "en-gb", "en");
+	}
+	
+}

--- a/commons/com.b2international.commons.test/src/com/b2international/commons/test/AllCommonsTests.java
+++ b/commons/com.b2international.commons.test/src/com/b2international/commons/test/AllCommonsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.b2international.commons.graph.LongTarjanTest;
+import com.b2international.commons.http.AcceptLanguageHeaderTest;
 import com.b2international.commons.test.collect.*;
 import com.b2international.commons.test.config.ConfigurationFactoryTest;
 
@@ -38,6 +40,8 @@ import com.b2international.commons.test.config.ConfigurationFactoryTest;
 	EmptyLongListTest.class,
 	OrderedSetTest.class,
 	LongOrderedSetTest.class,
+	LongTarjanTest.class,
+	AcceptLanguageHeaderTest.class
 })
 public class AllCommonsTests {
 	// Empty class body

--- a/commons/com.b2international.commons/src/com/b2international/commons/http/AcceptHeader.java
+++ b/commons/com.b2international.commons/src/com/b2international/commons/http/AcceptHeader.java
@@ -50,7 +50,7 @@ public class AcceptHeader<T> implements Comparable<AcceptHeader<T>> {
 		return Doubles.compare(quality, other.quality);
 	}
 
-    private static <T> List<T> parse(StringReader input, Function<String, T> converterFunction) throws IOException {
+    /*package*/ static <T> List<T> parse(StringReader input, Function<String, T> converterFunction) throws IOException {
         final ImmutableList.Builder<AcceptHeader<T>> resultBuilder = ImmutableList.builder();
 
         do {
@@ -91,7 +91,4 @@ public class AcceptHeader<T> implements Comparable<AcceptHeader<T>> {
     	return parse(input, Long::valueOf);
     }
     
-    public static List<ExtendedLocale> parseExtendedLocales(StringReader input) throws IOException {
-    	return parse(input, ExtendedLocale::valueOf);
-    }
 }

--- a/commons/com.b2international.commons/src/com/b2international/commons/http/AcceptLanguageHeader.java
+++ b/commons/com.b2international.commons/src/com/b2international/commons/http/AcceptLanguageHeader.java
@@ -24,6 +24,7 @@ import java.util.List;
  */
 public final class AcceptLanguageHeader {
 
+	public static final String WILDCARD = "*";
 	public static final String DEFAULT_ACCEPT_LANGUAGE_HEADER = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4";
 
 	/**
@@ -51,7 +52,7 @@ public final class AcceptLanguageHeader {
 	 */
 	public static final List<ExtendedLocale> parseHeader(final String acceptLanguageHeader, final String defaultAcceptLanguageHeader) {
 		// if the incoming value is a wildcard header value, then fall back to the specified defaultAcceptLanguageHeader parameter
-		try (StringReader reader = new StringReader("*".equals(acceptLanguageHeader) ? defaultAcceptLanguageHeader : acceptLanguageHeader)) {
+		try (StringReader reader = new StringReader(WILDCARD.equals(acceptLanguageHeader) ? defaultAcceptLanguageHeader : acceptLanguageHeader)) {
 			return AcceptHeader.parse(reader, ExtendedLocale::valueOf);
 		} catch (IOException e) {
 			throw new IllegalArgumentException(e.getMessage());

--- a/commons/com.b2international.commons/src/com/b2international/commons/http/AcceptLanguageHeader.java
+++ b/commons/com.b2international.commons/src/com/b2international/commons/http/AcceptLanguageHeader.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.commons.http;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.List;
+
+/**
+ * @since 8.10.0
+ */
+public final class AcceptLanguageHeader {
+
+	public static final String DEFAULT_ACCEPT_LANGUAGE_HEADER = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4";
+
+	/**
+	 * Parses an Accept-Language header into a {@link List} of {@link ExtendedLocale} instances.
+	 * 
+	 * @param acceptLanguageHeader
+	 *            - the desired header value to parse into {@link ExtendedLocale} instances
+	 * @return a {@link List} of {@link ExtendedLocale} instances parsed from the input parameter or if the input parameter is the wildcard header
+	 *         then it falls back to the {@link #DEFAULT_ACCEPT_LANGUAGE_HEADER} as header value.
+	 * @see #parseHeader(String, String)
+	 */
+	public static final List<ExtendedLocale> parseHeader(final String acceptLanguageHeader) {
+		return parseHeader(acceptLanguageHeader, DEFAULT_ACCEPT_LANGUAGE_HEADER);
+	}
+
+	/**
+	 * Parses an Accept-Language header into a {@link List} of {@link ExtendedLocale} instances.
+	 * 
+	 * @param acceptLanguageHeader
+	 *            - the desired header value to parse into {@link ExtendedLocale} instances
+	 * @param defaultAcceptLanguageHeader
+	 *            - a fall back value when clients use the wildcard '*' accept-language header value
+	 * @return a {@link List} of {@link ExtendedLocale} instances parsed from one of the two language header parameters
+	 * @see #parseHeader(String)
+	 */
+	public static final List<ExtendedLocale> parseHeader(final String acceptLanguageHeader, final String defaultAcceptLanguageHeader) {
+		// if the incoming value is a wildcard header value, then fall back to the specified defaultAcceptLanguageHeader parameter
+		try (StringReader reader = new StringReader("*".equals(acceptLanguageHeader) ? defaultAcceptLanguageHeader : acceptLanguageHeader)) {
+			return AcceptHeader.parse(reader, ExtendedLocale::valueOf);
+		} catch (IOException e) {
+			throw new IllegalArgumentException(e.getMessage());
+		}
+	}
+
+}

--- a/commons/com.b2international.commons/src/com/b2international/commons/http/ExtendedLocale.java
+++ b/commons/com.b2international.commons/src/com/b2international/commons/http/ExtendedLocale.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,7 @@
  */
 package com.b2international.commons.http;
 
-import java.io.IOException;
 import java.io.Serializable;
-import java.io.StringReader;
-import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -43,7 +40,7 @@ public final class ExtendedLocale implements Serializable {
 		if (matcher.matches()) {
 			return new ExtendedLocale(matcher.group(1), matcher.group(3), matcher.group(5));
 		} else {
-			throw new IllegalArgumentException("Couldn't convert input " + input + " to an extended locale.");
+			throw new IllegalArgumentException(String.format("Accept-Language header value '%s' is not supported.", input));
 		}
 	}
 	
@@ -101,20 +98,6 @@ public final class ExtendedLocale implements Serializable {
 			return getLanguageTag();
 		} else {
 			return getLanguageTag() + "-x-" + languageRefSetId;
-		}
-	}
-	
-	/**
-	 * Parses an Accept-Language header into a {@link List} of {@link ExtendedLocale} instances.
-	 * 
-	 * @param acceptLanguageHeader
-	 * @return
-	 */
-	public static final List<ExtendedLocale> parseLocales(final String acceptLanguageHeader) {
-		try {
-			return AcceptHeader.parseExtendedLocales(new StringReader(acceptLanguageHeader));
-		} catch (IOException e) {
-			throw new IllegalArgumentException(e.getMessage());
 		}
 	}
 	

--- a/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/codesystem/CodeSystemApiTest.java
+++ b/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/codesystem/CodeSystemApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,8 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.iterableWithSize;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -37,7 +38,7 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 import com.b2international.commons.exceptions.NotFoundException;
-import com.b2international.commons.http.ExtendedLocale;
+import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.commons.json.Json;
 import com.b2international.snowowl.core.Resource;
 import com.b2international.snowowl.core.ResourceURI;
@@ -340,7 +341,7 @@ public class CodeSystemApiTest extends BaseResourceApiTest {
 		assertCodeSystemCreated(Json.assign(
 			prepareCodeSystemCreateRequestBody(codeSystemId), 
 			Json.object("settings", Json.object(
-				CodeSystem.CommonSettings.LOCALES, ExtendedLocale.parseLocales("en-x-123456781000198103,en-x-876543211000198107")
+				CodeSystem.CommonSettings.LOCALES, AcceptLanguageHeader.parseHeader("en-x-123456781000198103,en-x-876543211000198107")
 			))
 		));
 		

--- a/core/com.b2international.snowowl.core.rest/build.properties
+++ b/core/com.b2international.snowowl.core.rest/build.properties
@@ -3,22 +3,4 @@ output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                WEB-INF/,\
-               site/,\
-               WEB-INF/lib/commons-fileupload-1.4.jar,\
-               WEB-INF/lib/commons-logging-1.2.jar,\
-               WEB-INF/lib/spring-aop-5.3.8.jar,\
-               WEB-INF/lib/spring-beans-5.3.8.jar,\
-               WEB-INF/lib/spring-context-5.3.8.jar,\
-               WEB-INF/lib/spring-core-5.3.8.jar,\
-               WEB-INF/lib/springdoc-openapi-common-1.5.9.jar,\
-               WEB-INF/lib/springdoc-openapi-webmvc-core-1.5.9.jar,\
-               WEB-INF/lib/spring-expression-5.3.8.jar,\
-               WEB-INF/lib/spring-security-config-5.5.1.jar,\
-               WEB-INF/lib/spring-security-core-5.5.1.jar,\
-               WEB-INF/lib/spring-security-web-5.5.1.jar,\
-               WEB-INF/lib/spring-web-5.3.8.jar,\
-               WEB-INF/lib/spring-webmvc-5.3.8.jar,\
-               WEB-INF/lib/spring-security-crypto-5.5.1.jar,\
-               WEB-INF/lib/swagger-core-2.1.9.jar,\
-               WEB-INF/lib/spring-boot-autoconfigure-2.5.2.jar,\
-               WEB-INF/lib/spring-boot-2.5.2.jar
+               site/

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/codesystem/ExpressionLabelService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/codesystem/ExpressionLabelService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.b2international.snowowl.core.rest.codesystem;
 
 import org.springframework.web.bind.annotation.*;
 
+import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.snowowl.core.codesystem.CodeSystemRequests;
 import com.b2international.snowowl.core.ecl.LabeledEclExpressions;
 import com.b2international.snowowl.core.events.util.Promise;
@@ -52,8 +53,8 @@ public class ExpressionLabelService extends AbstractRestService {
 			@RequestBody
 			final ExpressionLabelRestInput body,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value="Accept-Language", defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 				return CodeSystemRequests.prepareEclLabeler(body.getCodeSystemUri(), body.getExpressions())
 						.setDescriptionType(body.getDescriptionType())

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/suggest/SuggestRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/suggest/SuggestRestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.*;
 
 import com.b2international.commons.exceptions.BadRequestException;
+import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.snowowl.core.codesystem.CodeSystemRequests;
 import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.request.suggest.ConceptSuggestionBulkRequestBuilder;
@@ -60,8 +61,8 @@ public class SuggestRestService extends AbstractRestService {
 		@ParameterObject
 		final SuggestRestParameters params,
 		
-		@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-		@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+		@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+		@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 		final String acceptLanguage) {
 		
 		return prepareSuggestRequest(params, acceptLanguage)
@@ -81,8 +82,8 @@ public class SuggestRestService extends AbstractRestService {
 		@RequestBody
 		final SuggestRestParameters body,
 		
-		@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-		@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+		@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+		@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 		final String acceptLanguage) {
 		return getSuggest(body, acceptLanguage);
 	}
@@ -107,8 +108,8 @@ public class SuggestRestService extends AbstractRestService {
 		@RequestParam(value = "batchTimeout", defaultValue = "120", required = false)
 		final Integer batchTimeout,
 		
-		@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-		@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+		@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+		@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 		final String acceptLanguage) {
 	
 		if (body == null) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/ResourceRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/ResourceRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.b2international.commons.CompareUtils;
+import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.events.BaseRequestBuilder;
@@ -39,10 +40,11 @@ public abstract class ResourceRequestBuilder<B extends ResourceRequestBuilder<B,
 	 * 
 	 * @param locales - the locale list in Accept-Language header format
 	 * @return ResourceRequestBuilder
+	 * @see AcceptLanguageHeader#parseHeader(String)
 	 */
 	public final B setLocales(String locales) {
 		if (locales != null) {
-			setLocales(ExtendedLocale.parseLocales(locales));
+			setLocales(AcceptLanguageHeader.parseHeader(locales));
 		}
 		return getSelf();
 	}

--- a/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirCodeSystemController.java
+++ b/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirCodeSystemController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBui
 
 import com.b2international.commons.collections.Collections3;
 import com.b2international.commons.exceptions.NotFoundException;
+import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.id.IDs;
 import com.b2international.snowowl.core.rest.domain.ResourceRequest;
@@ -268,8 +269,8 @@ public class FhirCodeSystemController extends AbstractFhirController {
 			@ParameterObject 
 			FhirCodeSystemSearchParameters params,
 
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 			
 		//TODO: replace this with something more general as described in
@@ -322,8 +323,8 @@ public class FhirCodeSystemController extends AbstractFhirController {
 			@ParameterObject
 			final FhirResourceSelectors selectors,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 		
 		return FhirRequests.codeSystems().prepareGet(id)

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptSearchApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptSearchApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2021-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import com.b2international.commons.json.Json;
@@ -392,6 +393,18 @@ public class SnomedConceptSearchApiTest extends AbstractSnomedApiTest {
 			.body("total", equalTo(1))
 			.body("items[0].descriptions.items.module.id", allOf(not(emptyIterable()), everyItem(equalTo(Concepts.MODULE_SCT_CORE))))
 			.body("items[0].relationships.items.module.id", allOf(not(emptyIterable()), everyItem(equalTo(Concepts.MODULE_SCT_CORE))));
+	}
+	
+	@Test
+	public void wildcardAcceptLanguageHeader() throws Exception {
+		givenAuthenticatedRequest(getApiBaseUrl())
+			.accept(JSON_UTF8)
+			.queryParams(Map.of("expand", "pt()"))
+			.get("/{path}/concepts/", branchPath.getPath())
+			.then()
+			.assertThat()
+			.statusCode(200)
+			.body("items[0].pt.term", CoreMatchers.notNullValue());
 	}
 
 	private void assertHierarchyContains(String hierarchyField, String parentOrAncestorRole, Map<String, String> roleToId, Set<String> expectedRoles) {

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptSearchApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptSearchApiTest.java
@@ -400,6 +400,7 @@ public class SnomedConceptSearchApiTest extends AbstractSnomedApiTest {
 		givenAuthenticatedRequest(getApiBaseUrl())
 			.accept(JSON_UTF8)
 			.queryParams(Map.of("expand", "pt()"))
+			.header("Accept-Language", "*")
 			.get("/{path}/concepts/", branchPath.getPath())
 			.then()
 			.assertThat()

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedClassificationRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedClassificationRestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBui
 import org.springframework.web.util.UriComponentsBuilder;
 
 import com.b2international.commons.CompareUtils;
+import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.commons.validation.ApiValidation;
 import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.rest.AbstractRestService;
@@ -177,8 +178,8 @@ public class SnomedClassificationRestService extends AbstractRestService {
 			@RequestParam(value="limit", defaultValue="50", required=false) 
 			final int limit,
 			
-			@Parameter(description ="Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description ="Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value="Accept-Language", defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 
 		return ClassificationRequests.prepareSearchEquivalentConceptSet()
@@ -247,8 +248,8 @@ public class SnomedClassificationRestService extends AbstractRestService {
 //			@PathVariable(value="conceptId")
 //			final String conceptId,
 //
-//			@Parameter(value ="Language codes and reference sets, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-//			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false)
+//			@Parameter(value ="Language codes and reference sets, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+//			@RequestHeader(value="Accept-Language", defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false)
 //			final String languageSetting) {
 //
 //		final List<ExtendedLocale> extendedLocales = getExtendedLocales(languageSetting);

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedConceptRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedConceptRestService.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import com.b2international.commons.StringUtils;
+import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.request.SearchIndexResourceRequest;
 import com.b2international.snowowl.core.request.SearchResourceRequest.Sort;
@@ -85,8 +86,8 @@ public class SnomedConceptRestService extends AbstractRestService {
 			@ParameterObject
 			final SnomedConceptRestSearch params,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue=AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 		
 		List<Sort> sorts = extractSortFields(params.getSort());
@@ -149,8 +150,8 @@ public class SnomedConceptRestService extends AbstractRestService {
 			@RequestBody(required = false)
 			final SnomedConceptRestSearch body,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 		
 		return searchByGet(path, body, acceptLanguage);
@@ -184,8 +185,8 @@ public class SnomedConceptRestService extends AbstractRestService {
 			@ParameterObject
 			final ResourceSelectors selectors,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value="Accept-Language", defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 		return SnomedRequests
 					.prepareGetConcept(conceptId)

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedDescriptionRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedDescriptionRestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.b2international.commons.StringUtils;
+import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.request.SearchIndexResourceRequest;
 import com.b2international.snowowl.core.request.SearchResourceRequest.Sort;
@@ -75,8 +76,8 @@ public class SnomedDescriptionRestService extends AbstractRestService {
 			@ParameterObject
 			final SnomedDescriptionRestSearch params,
 
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value="Accept-Language", defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 		
 		List<Sort> sorts = extractSortFields(params.getSort());
@@ -131,8 +132,8 @@ public class SnomedDescriptionRestService extends AbstractRestService {
 			@RequestBody(required = false)
 			final SnomedDescriptionRestSearch body,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 		
 		return searchByGet(path, body, acceptLanguage);
@@ -198,8 +199,8 @@ public class SnomedDescriptionRestService extends AbstractRestService {
 			@ParameterObject
 			final ResourceSelectors selectors,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value="Accept-Language", defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 		
 		return SnomedRequests.prepareGetDescription(descriptionId)

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedReferenceSetMemberRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedReferenceSetMemberRestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.commons.options.Options;
 import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.core.events.util.Promise;
@@ -78,8 +79,8 @@ public class SnomedReferenceSetMemberRestService extends AbstractRestService {
 			@ParameterObject
 			final SnomedReferenceSetMemberRestSearch params,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value="Accept-Language", defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 
 		final SnomedRefSetMemberSearchRequestBuilder req = SnomedRequests.prepareSearchMember()
@@ -124,8 +125,8 @@ public class SnomedReferenceSetMemberRestService extends AbstractRestService {
 			@RequestBody(required = false)
 			final SnomedReferenceSetMemberRestSearch params,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value="Accept-Language", defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 		return searchByGet(branch, params, acceptLanguage);
 	}
@@ -154,8 +155,8 @@ public class SnomedReferenceSetMemberRestService extends AbstractRestService {
 			@ParameterObject
 			final ResourceSelectors selectors,
 
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value="Accept-Language", defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 		return SnomedRequests
 				.prepareGetMember(memberId)

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedReferenceSetRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedReferenceSetRestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import com.b2international.commons.exceptions.BadRequestException;
+import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.core.events.bulk.BulkRequest;
 import com.b2international.snowowl.core.events.bulk.BulkRequestBuilder;
@@ -88,8 +89,8 @@ public class SnomedReferenceSetRestService extends AbstractRestService {
 			@ParameterObject
 			final SnomedReferenceSetRestSearch params,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 		
 		List<Sort> sorts = extractSortFields(params.getSort());
@@ -131,8 +132,8 @@ public class SnomedReferenceSetRestService extends AbstractRestService {
 			@RequestBody(required = false)
 			final SnomedReferenceSetRestSearch body,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 		
 		return searchByGet(path, body, acceptLanguage);
@@ -187,8 +188,8 @@ public class SnomedReferenceSetRestService extends AbstractRestService {
 			@ParameterObject
 			final ResourceSelectors selectors,
 
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value="Accept-Language", defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 
 		return SnomedRequests

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedRelationshipRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedRelationshipRestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.rest.AbstractRestService;
 import com.b2international.snowowl.core.rest.domain.ResourceSelectors;
@@ -75,8 +76,8 @@ public class SnomedRelationshipRestService extends AbstractRestService {
 			@ParameterObject
 			final SnomedRelationshipRestSearch params,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value="Accept-Language", defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 		return SnomedRequests
 					.prepareSearchRelationship()
@@ -128,8 +129,8 @@ public class SnomedRelationshipRestService extends AbstractRestService {
 			@RequestBody(required = false)
 			final SnomedRelationshipRestSearch params,
 		
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value="Accept-Language", defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 		return searchByGet(path, params, acceptLanguage);
 	}
@@ -201,8 +202,8 @@ public class SnomedRelationshipRestService extends AbstractRestService {
 			@ParameterObject
 			final ResourceSelectors selectors,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value="Accept-Language", defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value="Accept-Language", defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 
 		return SnomedRequests.prepareGetRelationship(relationshipId)

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedRf2ExportRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedRf2ExportRestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2020-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.snowowl.core.attachments.Attachment;
 import com.b2international.snowowl.core.attachments.AttachmentRegistry;
 import com.b2international.snowowl.core.attachments.InternalAttachmentRegistry;
@@ -72,8 +73,8 @@ public class SnomedRf2ExportRestService extends AbstractRestService {
 			@ParameterObject
 			final SnomedRf2ExportConfiguration params,
 			
-			@Parameter(description = "Accepted language tags, in order of preference", example = "en-US;q=0.8,en-GB;q=0.6,en;q=0.4")
-			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue="en-US;q=0.8,en-GB;q=0.6,en;q=0.4", required=false) 
+			@Parameter(description = "Accepted language tags, in order of preference", example = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER)
+			@RequestHeader(value=HttpHeaders.ACCEPT_LANGUAGE, defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required=false) 
 			final String acceptLanguage) {
 		
 		final Attachment exportedFile = SnomedRequests.rf2().prepareExport()

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptSearchRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptSearchRequestBuilder.java
@@ -17,6 +17,7 @@ package com.b2international.snowowl.snomed.datastore.request;
 
 import java.util.List;
 
+import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.request.DescriptionKnnFilterSupport;
@@ -248,9 +249,10 @@ public final class SnomedConceptSearchRequestBuilder extends SnomedComponentSear
 	 * 
 	 * @param acceptLanguage
 	 * @return
+	 * @see AcceptLanguageHeader#parseHeader(String)
 	 */
 	public SnomedConceptSearchRequestBuilder filterByDescriptionLanguageRefSet(String acceptLanguage) {
-		return filterByDescriptionLanguageRefSet(ExtendedLocale.parseLocales(acceptLanguage));
+		return filterByDescriptionLanguageRefSet(AcceptLanguageHeader.parseHeader(acceptLanguage));
 	}
 
 	/**


### PR DESCRIPTION
This PR adds support for the wildcard-only `Accept-Language` header which is being set by most HTTP clients when not explicitly specified when making the HTTP request.
We do not intend to support mixed `Accept-Language` header values where both wildcard and non-wildcard language tags are present (eg. `de,*`). Using such a header value will still result in an HTTP 400 Bad Request response.