### PR TITLE
Short ipv6 format parsing from doc values

### DIFF
--- a/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchPointTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchPointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,20 @@ import org.junit.Test;
 public class RevisionBranchPointTest {
 
 	@Test
+	public void serializeNull() throws Exception {
+		assertNull(RevisionBranchPoint.valueOf(null));
+	}
+	
+	@Test
 	public void serialization() throws Exception {
 		RevisionBranchPoint original = new RevisionBranchPoint(1024, 2048);
 		assertEquals(original, RevisionBranchPoint.valueOf(original.toIpAddress()));
+	}
+	
+	@Test
+	public void deserShortIPv6Address() throws Exception {
+		RevisionBranchPoint addr = RevisionBranchPoint.valueOf("::1:0:187:eb43:177e");
+		assertEquals(1, addr.getBranchId());
 	}
 	
 }

--- a/commons/com.b2international.index/src/com/b2international/index/revision/Commit.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/Commit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public final class Commit implements WithScore {
 		private String branch;
 		private String author;
 		private String comment;
-		private long timestamp;
+		private Long timestamp;
 		private List<CommitDetail> details;
 		private String groupId;
 		private RevisionBranchPoint mergeSource;
@@ -86,7 +86,7 @@ public final class Commit implements WithScore {
 			return this;
 		}
 
-		public Builder timestamp(final long timestamp) {
+		public Builder timestamp(final Long timestamp) {
 			this.timestamp = timestamp;
 			return this;
 		}
@@ -222,7 +222,7 @@ public final class Commit implements WithScore {
 		}
 	)
 	private final String comment;
-	private final long timestamp;
+	private final Long timestamp;
 	private final String groupId;
 	private final List<CommitDetail> details;
 	private final RevisionBranchPoint mergeSource;
@@ -238,7 +238,7 @@ public final class Commit implements WithScore {
 			final String branch,
 			final String author,
 			final String comment,
-			final long timestamp,
+			final Long timestamp,
 			final String groupId,
 			final List<CommitDetail> details, 
 			final RevisionBranchPoint mergeSource,
@@ -281,7 +281,7 @@ public final class Commit implements WithScore {
 		return comment;
 	}
 
-	public long getTimestamp() {
+	public Long getTimestamp() {
 		return timestamp;
 	}
 	


### PR DESCRIPTION
This PR fixes an issue where commit documents could not be parsed when the `mergeSource` field was requested in the request. ES/Lucene stores the short form of the IP field value even if we use the full long form in the `_source`. Added a temporary hack to parse into InetAddress which adds zeros to all `::` short values and then convert that to `RevisionBranchPoint` instances.

Related to https://snowowl.atlassian.net/browse/SO-5774