### PR TITLE
SO-4901: identical component conflict

### DIFF
--- a/commons/com.b2international.commons/src/com/b2international/commons/json/Json.java
+++ b/commons/com.b2international.commons/src/com/b2international/commons/json/Json.java
@@ -50,19 +50,19 @@ public final class Json extends ForwardingMap<String, Object> {
 	}
 	
 	public Json with(String property, Object value) {
-		final Map<String, Object> newJson = Maps.newHashMap(source);
+		final Map<String, Object> newJson = Maps.newLinkedHashMap(source);
 		newJson.put(property, value);
 		return new Json(newJson);
 	}
 	
 	public Json without(String property) {
-		final Map<String, Object> newJson = Maps.newHashMap(source);
+		final Map<String, Object> newJson = Maps.newLinkedHashMap(source);
 		newJson.remove(property);
 		return new Json(newJson);
 	}
 	
 	public Json with(Map<String, Object> object) {
-		final Map<String, Object> newJson = Maps.newHashMap(source);
+		final Map<String, Object> newJson = Maps.newLinkedHashMap(source);
 		newJson.putAll(object);
 		return new Json(newJson);
 	}
@@ -76,7 +76,7 @@ public final class Json extends ForwardingMap<String, Object> {
 	}
 	
 	private static <K, V> Map<K, V> deepMerge(Map<K, V> target, Map<K, V> source) {
-		final Map<K, V> updatedTarget = Maps.newHashMap(target);
+		final Map<K, V> updatedTarget = Maps.newLinkedHashMap(target);
 		source.forEach((key, value) -> {
 			updatedTarget.merge(key, value, (oldValue, newValue) -> {
 				if (oldValue instanceof Map<?, ?> && newValue instanceof Map<?, ?>) {

--- a/commons/com.b2international.index/src/com/b2international/index/revision/AddedInSourceAndDetachedInTargetConflict.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/AddedInSourceAndDetachedInTargetConflict.java
@@ -15,6 +15,8 @@
  */
 package com.b2international.index.revision;
 
+import java.util.Objects;
+
 /**
  * @since 7.0
  */
@@ -50,5 +52,17 @@ public final class AddedInSourceAndDetachedInTargetConflict extends Conflict {
 		this.featureName = featureName;
 		return this;
 	}
-
+	
+	@Override
+	public int hashCode() {
+		return Objects.hash(getObjectId(), getMessage(), getFeatureName(), getDetachedOnTarget());
+	}
+	
+	@Override
+	protected boolean doEquals(Conflict obj) {
+		AddedInSourceAndDetachedInTargetConflict other = (AddedInSourceAndDetachedInTargetConflict) obj;
+		return Objects.equals(featureName, other.featureName)
+				&& Objects.equals(detachedOnTarget, other.detachedOnTarget);
+	}
+	
 }

--- a/commons/com.b2international.index/src/com/b2international/index/revision/AddedInTargetAndDetachedInSourceConflict.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/AddedInTargetAndDetachedInSourceConflict.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package com.b2international.index.revision;
+
+import java.util.Objects;
 
 /**
  * @since 7.0
@@ -49,6 +51,18 @@ public final class AddedInTargetAndDetachedInSourceConflict extends Conflict {
 	public AddedInTargetAndDetachedInSourceConflict withFeatureName(String featureName) {
 		this.featureName = featureName;
 		return this;
+	}
+	
+	@Override
+	public int hashCode() {
+		return Objects.hash(getObjectId(), getMessage(), getFeatureName(), getAddedOnTarget());
+	}
+	
+	@Override
+	protected boolean doEquals(Conflict obj) {
+		AddedInTargetAndDetachedInSourceConflict other = (AddedInTargetAndDetachedInSourceConflict) obj;
+		return Objects.equals(featureName, other.featureName)
+				&& Objects.equals(addedOnTarget, other.addedOnTarget);
 	}
 
 }

--- a/commons/com.b2international.index/src/com/b2international/index/revision/BaseRevisionBranching.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/BaseRevisionBranching.java
@@ -430,7 +430,7 @@ public abstract class BaseRevisionBranching {
 		return new BranchMergeOperation(this, fromPath, toPath);
 	}
 	
-	Commit doMerge(BranchMergeOperation operation) {
+	Commit doMerge(BranchMergeOperation operation) throws BranchMergeConflictException {
 		String source = operation.fromPath;
 		String target = operation.toPath;
 		if (target.equals(source)) {

--- a/commons/com.b2international.index/src/com/b2international/index/revision/BranchMergeOperation.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/BranchMergeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2019-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,11 @@ public final class BranchMergeOperation {
 		return this;
 	}
 	
-	public Commit merge() {
+	/**
+	 * @return the commit associated with the merge
+	 * @throws BranchMergeConflictException - if there is a conflict which client can optionally handle if they would like to
+	 */
+	public Commit merge() throws BranchMergeConflictException {
 		return branching.doMerge(this);
 	}
 

--- a/commons/com.b2international.index/src/com/b2international/index/revision/ChangedInSourceAndDetachedInTargetConflict.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/ChangedInSourceAndDetachedInTargetConflict.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 package com.b2international.index.revision;
 
 import java.util.List;
+import java.util.Objects;
 
+import com.b2international.commons.collections.Collections3;
 import com.b2international.index.revision.StagingArea.RevisionPropertyDiff;
 
 /**
@@ -28,11 +30,22 @@ public final class ChangedInSourceAndDetachedInTargetConflict extends Conflict {
 
 	public ChangedInSourceAndDetachedInTargetConflict(ObjectId objectId, List<RevisionPropertyDiff> changes) {
 		super(objectId, "");
-		this.changes = changes;
+		this.changes = Collections3.toImmutableList(changes);
 	}
 	
 	public List<RevisionPropertyDiff> getChanges() {
 		return changes;
+	}
+	
+	@Override
+	public int hashCode() {
+		return Objects.hash(getObjectId(), getMessage(), getChanges());
+	}
+	
+	@Override
+	protected boolean doEquals(Conflict obj) {
+		ChangedInSourceAndDetachedInTargetConflict other = (ChangedInSourceAndDetachedInTargetConflict) obj;
+		return Objects.equals(changes, other.changes);
 	}
 
 }

--- a/commons/com.b2international.index/src/com/b2international/index/revision/ChangedInSourceAndTargetConflict.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/ChangedInSourceAndTargetConflict.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package com.b2international.index.revision;
+
+import java.util.Objects;
 
 import com.b2international.index.revision.StagingArea.RevisionPropertyDiff;
 
@@ -39,4 +41,16 @@ public final class ChangedInSourceAndTargetConflict extends Conflict {
 		return targetChange;
 	}
 
+	@Override
+	public int hashCode() {
+		return Objects.hash(getObjectId(), getMessage(), getSourceChange(), getTargetChange());
+	}
+	
+	@Override
+	protected boolean doEquals(Conflict obj) {
+		ChangedInSourceAndTargetConflict other = (ChangedInSourceAndTargetConflict) obj;
+		return Objects.equals(sourceChange, other.sourceChange)
+				&& Objects.equals(targetChange, other.targetChange);
+	}
+	
 }

--- a/commons/com.b2international.index/src/com/b2international/index/revision/Conflict.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/Conflict.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package com.b2international.index.revision;
+
+import java.util.Objects;
 
 /**
  * @since 7.0
@@ -41,4 +43,31 @@ public abstract class Conflict {
 		return getMessage();
 	}
 	
+	@Override
+	public int hashCode() {
+		return Objects.hash(objectId, message);
+	}
+	
+	@Override
+	public final boolean equals(Object obj) {
+		if (obj == null) return false;
+		if (this == obj) return true;
+		if (getClass() != obj.getClass()) return false;
+		Conflict other = (Conflict) obj;
+		return Objects.equals(objectId, other.objectId) 
+				&& Objects.equals(message, other.message)
+				&& doEquals(other);
+	}
+
+	/**
+	 * Subclasses optionally override this method to provide additional equals checks when they have additional registered conflict properties.
+	 * <p><i>Please note if you override this method make sure you override the {@link #hashCode()} method as well to properly compute the hash value of the subclass.</i></p> 
+	 *  
+	 * @param obj
+	 * @return
+	 */
+	protected boolean doEquals(Conflict obj) {
+		return true;
+	}
+
 }

--- a/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
@@ -822,7 +822,7 @@ public final class StagingArea {
 		externalRevisionsToReviseOnMergeSource.put(type, id);
 	}
 	
-	/*package*/ void merge(RevisionBranchRef fromRef, RevisionBranchRef toRef, boolean squash, RevisionConflictProcessor conflictProcessor, Set<String> exclusions) {
+	/*package*/ void merge(RevisionBranchRef fromRef, RevisionBranchRef toRef, boolean squash, RevisionConflictProcessor conflictProcessor, Set<String> exclusions) throws BranchMergeConflictException {
 		checkArgument(this.mergeSources == null, "Already merged another ref to this StagingArea. Commit staged changes to apply them.");
 		this.mergeFromBranchRef = fromRef.difference(toRef);
 		this.mergeSources = this.mergeFromBranchRef


### PR DESCRIPTION
This PR improves the automatic conflict resolution to allow identical objects to be added to both sides of the merge. This earlier resulted in a conflict now it passes through.