### PR TITLE
SO-3933: published vs unpublished snapshot export

### DIFF
--- a/cis/com.b2international.snowowl.snomed.cis/src/com/b2international/snowowl/snomed/cis/gen/SequentialItemIdGenerationStrategy.java
+++ b/cis/com.b2international.snowowl.snomed.cis/src/com/b2international/snowowl/snomed/cis/gen/SequentialItemIdGenerationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2017-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,7 +136,7 @@ public final class SequentialItemIdGenerationStrategy implements ItemIdGeneratio
 	}
 	
 	public ItemIdCounter getOrCreateCounter(String namespace, ComponentCategory category) {
-		return lastItemIds.getUnchecked(Pair.identicalPairOf(Strings.nullToEmpty(namespace), category));
+		return lastItemIds.getUnchecked(Pair.of(Strings.nullToEmpty(namespace), category));
 	}
 	
 	@Override

--- a/commons/com.b2international.commons/src/com/b2international/commons/Pair.java
+++ b/commons/com.b2international.commons/src/com/b2international/commons/Pair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,10 @@ package com.b2international.commons;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.Objects;
 
-import com.google.common.base.Objects;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.base.Joiner;
 
 /**
  * Represents a pair of values of the specified type.
@@ -30,35 +31,57 @@ import com.google.common.base.Objects;
  * {@link #identicalPairOf(Object, Object)}; for serialization purposes {@link #serializablePairOf(Serializable, Serializable)} 
  * should be used.
  */
-public class Pair<A, B> {
+public class Pair<A, B> implements Serializable {
 
-	private A a;
-	private B b;
+	private static final long serialVersionUID = 1L;
 
-	public Pair() {
-	}
+	@JsonIgnore
+	private static final Joiner ARROW_JOINER = Joiner.on("->");
+	
+	private final A a;
+	private final B b;
 
 	public Pair(final A a, final B b) {
 		this.a = a;
 		this.b = b;
 	}
 
-	public A getA() {
+	public final A getA() {
 		return a;
 	}
 
-	public void setA(final A a) {
-		this.a = a;
-	}
-
-	public B getB() {
+	public final B getB() {
 		return b;
 	}
-
-	public void setB(final B b) {
-		this.b = b;
+	
+	@Override
+	public final int hashCode() {
+		return Objects.hash(a, b);
 	}
 
+	@Override
+	public final boolean equals(final Object obj) {
+		if (this == obj) return true;
+		if (obj == null) return false;
+		if (getClass() != obj.getClass()) return false;
+		final Pair<?, ?> other = (Pair<?, ?>) obj;
+		return Objects.equals(getA(), other.getA()) && Objects.equals(getB(), other.getB());
+	}
+
+	/**
+	 * Returns as a singleton immutable map.
+	 * <br>This method eagerly creates a new map instance each time this method is accessed.
+	 * @return a map of the pair.
+	 */
+	public final Map<A, B> asMap() {
+		return Collections.singletonMap(a, b);
+	}
+	
+	@Override
+	public final String toString() {
+		return ARROW_JOINER.join(a, b);
+	}
+	
 	/**
 	 * Creates a {@link Pair} instance from the specified A and B arguments.
 	 * 
@@ -69,72 +92,5 @@ public class Pair<A, B> {
 	public static final <A, B> Pair<A, B> of(final A a, final B b) {
 		return new Pair<A, B>(a, b);
 	}
-	
-	/**Creates a new pair from the given entry.*/
-	public static final <A, B> Pair<A, B> of (final Entry<A, B> entry) {
-		return of(entry.getKey(), entry.getValue());
-	}
-	
-	/**Creates a new identical pair instance with the given values.*/
-	public static <A, B> IdenticalPair<A, B> identicalPairOf(final A a, final B b) {
-		return new IdenticalPair<A, B>(a, b);
-	}
 
-	/**Creates a new serializable pair instance for the given values.*/
-	public static <A extends Serializable, B extends Serializable> SerializablePair<A, B> serializablePairOf(final A a, final B b) {
-		return new SerializablePair<A, B>(a, b);
-	}
-
-	/**
-	 * Returns as a singleton immutable map.
-	 * <br>This method eagerly creates a new map instance each time this method is accessed.
-	 * @return a map of the pair.
-	 */
-	public Map<A, B> asMap() {
-		return Collections.singletonMap(a, b);
-	}
-	
-	@Override
-	public String toString() {
-		return a + "->" + b;
-	}
-
-	/**
-	 * A serializable pair of values.
-	 * @see Pair
-	 * @see Serializable
-	 */
-	public static class SerializablePair<A extends Serializable, B extends Serializable> extends Pair<A, B> implements Serializable {
-		private static final long serialVersionUID = 6569609379343461859L;
-		private SerializablePair(final A a, final B b) { super(a, b); }
-	}
-	
-	/**
-	 * A pair of values. Each instance of the class are equal if {@link #getA() A} and {@link #getB() B} values are equal.
-	 */
-	public static class IdenticalPair<A, B> extends Pair<A, B> {
-		
-		private IdenticalPair(final A a, final B b) { super(a, b); }
-
-		@Override
-		public int hashCode() {
-			final int prime = 31;
-			int result = 1;
-			result = prime * result + ((getA() == null) ? 0 : getA().hashCode());
-			result = prime * result + ((getB() == null) ? 0 : getB().hashCode());
-			return result;
-		}
-
-		@Override
-		public boolean equals(final Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
-				return false;
-			final IdenticalPair<?, ?> other = (IdenticalPair<?, ?>) obj;
-			return Objects.equal(getA(), other.getA()) && Objects.equal(getB(), other.getB());
-		}
-	}
 }

--- a/commons/com.b2international.commons/src/com/b2international/commons/ReflectionUtils.java
+++ b/commons/com.b2international.commons/src/com/b2international/commons/ReflectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,8 @@ public class ReflectionUtils {
 
 	public static class Parameter<T> extends Pair<Class<T>, T> {
 		
-		public Parameter() {
-		}
-		
+		private static final long serialVersionUID = 1L;
+
 		public Parameter(Class<T> clazz, T value) {
 			super(clazz, value);
 		}

--- a/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2018-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -503,7 +503,7 @@ public final class StagingArea {
 						Multimap<String, String> componentsByType = HashMultimap.create();
 						components.forEach(c -> componentsByType.put(c.type(), c.id()));
 						componentsByType.asMap().forEach((componentType, componentIds) -> {
-							final Pair<String, String> typeKey = Pair.identicalPairOf(container.type(), componentType);
+							final Pair<String, String> typeKey = Pair.of(container.type(), componentType);
 							if (!buildersByRelationship.containsKey(typeKey)) {
 								buildersByRelationship.put(typeKey, builderFactory.apply(typeKey.getA(), typeKey.getB()));
 							}

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/SnomedExportRestRequests.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/SnomedExportRestRequests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,8 +60,8 @@ public abstract class SnomedExportRestRequests {
 				@Override
 				public InputStream openStream() throws IOException {
 					return export(branchPath, exportConfiguration)
-							.thenReturn()
-							.asInputStream();
+							.then().assertThat().statusCode(200)
+							.extract().asInputStream();
 				}
 			}.copyTo(Files.asByteSink(exportArchive));
 

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/SnomedRestFixtures.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/SnomedRestFixtures.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.b2international.commons.Pair;
-import com.b2international.commons.Pair.IdenticalPair;
 import com.b2international.commons.json.Json;
 import com.b2international.snowowl.core.ApplicationContext;
 import com.b2international.snowowl.core.api.IBranchPath;
@@ -59,7 +58,7 @@ public abstract class SnomedRestFixtures {
 	public static final String DEFAULT_TERM = "Description term";
 	public static final String DEFAULT_LANGUAGE_CODE = "en";
 
-	private static final Map<IdenticalPair<String, String>, String> REFERENCED_COMPONENT_CACHE = newHashMap();
+	private static final Map<Pair<String, String>, String> REFERENCED_COMPONENT_CACHE = newHashMap();
 	
 	public static String createNewConcept(IBranchPath conceptPath) {
 		return createNewConcept(conceptPath, Concepts.ROOT_CONCEPT);
@@ -619,7 +618,7 @@ public abstract class SnomedRestFixtures {
 	}
 	
 	public static String getFirstMatchingComponent(IBranchPath branchPath, String referencedComponentType) {
-		IdenticalPair<String, String> key = Pair.identicalPairOf(branchPath.getPath(), referencedComponentType);
+		Pair<String, String> key = Pair.of(branchPath.getPath(), referencedComponentType);
 		if (!REFERENCED_COMPONENT_CACHE.containsKey(key)) {
 			final String referencedComponentId = Iterables.getFirst(searchComponent(branchPath, getSnomedComponentType(referencedComponentType), Json.object("limit", 1))
 					.extract()


### PR DESCRIPTION
This PR fixes an RF2 Snapshot export issue when the RF2 export was missing some of the published content when the configuration was not to include pre-release content but the reference branch contained some.