### PR TITLE
SO-5811: fix FHIR publisher field selection

### DIFF
--- a/commons/com.b2international.index/src/com/b2international/index/es/EsDocumentSearcher.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/EsDocumentSearcher.java
@@ -298,7 +298,7 @@ public class EsDocumentSearcher implements Searcher {
 	private boolean requiresDocumentSourceField(DocumentMapping mapping, List<String> fields) {
 		return fields
 			.stream()
-			.filter(mapping::isCollection)
+			.filter(field -> mapping.isCollection(field) || mapping.isMap(field))
 			.findFirst()
 			.isPresent();
 	}

--- a/commons/com.b2international.index/src/com/b2international/index/mapping/DocumentMapping.java
+++ b/commons/com.b2international.index/src/com/b2international/index/mapping/DocumentMapping.java
@@ -309,6 +309,11 @@ public final class DocumentMapping {
 		final Class<?> fieldType = getFieldType(field);
 		return Set.class.isAssignableFrom(fieldType) || PrimitiveSet.class.isAssignableFrom(fieldType);
 	}
+	
+	public boolean isMap(String field) {
+		final Class<?> fieldType = getFieldType(field);
+		return Map.class.isAssignableFrom(fieldType);
+	}
 
 	private static boolean isCollection(Class<?> fieldType) {
 		return Iterable.class.isAssignableFrom(fieldType) || PrimitiveCollection.class.isAssignableFrom(fieldType) || fieldType.isArray();

--- a/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/codesystem/FhirCodeSystemApiTest.java
+++ b/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/codesystem/FhirCodeSystemApiTest.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 
 import org.junit.Test;
 
+import com.b2international.snowowl.fhir.core.model.codesystem.CodeSystem;
 import com.b2international.snowowl.fhir.core.model.dt.Coding;
 import com.b2international.snowowl.fhir.tests.FhirRestTest;
 
@@ -151,8 +152,10 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			.body("meta.tag.code", hasItem(Coding.CODING_SUBSETTED.getCodeValue()))
 			.body("type", equalTo("searchset"))
 			.body("total", equalTo(1))
-			.body("entry.resource.property", notNullValue())
-			.body("entry.resource.filter", notNullValue())
+			.body("entry[0].resource.id", equalTo(getTestCodeSystemId()))
+			.body("entry[0].resource.title", equalTo("Title of " + getTestCodeSystemId()))
+			.body("entry[0].resource.property", notNullValue())
+			.body("entry[0].resource.filter", notNullValue())
 			//no concept definitions are part of the summary
 			.body("entry.resource", not(hasItem("concept")));
 	}
@@ -262,6 +265,31 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			// requested fields
 			.body("entry[0].resource.name", equalTo(getTestCodeSystemId()))
 			.body("entry[0].resource.url", equalTo(getTestCodeSystemUrl()));
+	}
+	
+	@Test
+	public void GET_CodeSystem_ElementsMixedWithSummaryFields() throws Exception {
+		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
+			.queryParam("_id", getTestCodeSystemId())
+			.queryParam("_elements", CodeSystem.Fields.ID, CodeSystem.Fields.META, CodeSystem.Fields.URL, CodeSystem.Fields.VERSION, CodeSystem.Fields.NAME, CodeSystem.Fields.TITLE, CodeSystem.Fields.DATE, CodeSystem.Fields.PUBLISHER)
+			.when().get(CODESYSTEM)
+			.then().assertThat()
+			.statusCode(200)
+			.body("resourceType", equalTo("Bundle"))
+			.body("meta.tag.code", hasItem(Coding.CODING_SUBSETTED.getCodeValue()))
+			.body("total", equalTo(1))
+			.body("type", equalTo("searchset"))
+			// mandatory fields
+			.body("entry[0].resource.id", equalTo(getTestCodeSystemId()))
+			.body("entry[0].resource.status", equalTo("draft"))
+			.body("entry[0].resource.content", equalTo("not-present"))
+			// requested fields
+			.body("entry[0].resource.url", equalTo(getTestCodeSystemUrl()))
+			.body("entry[0].resource.version", nullValue())
+			.body("entry[0].resource.name", equalTo(getTestCodeSystemId()))
+			.body("entry[0].resource.title", equalTo("Title of " + getTestCodeSystemId()))
+			.body("entry[0].resource.date", nullValue())
+			.body("entry[0].resource.publisher", equalTo("SNOMED International"));
 	}
 	
 	@Test

--- a/tests/com.b2international.snowowl.test.commons/src/com/b2international/snowowl/test/commons/codesystem/CodeSystemRestRequests.java
+++ b/tests/com.b2international.snowowl.test.commons/src/com/b2international/snowowl/test/commons/codesystem/CodeSystemRestRequests.java
@@ -91,7 +91,7 @@ public abstract class CodeSystemRestRequests {
 	public static Json createCodeSystemBody(ResourceURI extensionOf, String branchPath, String codeSystemId,  Map<String, Object> settings) {
 		Json requestBody = Json.object(
 				"id", codeSystemId,
-				"title", codeSystemId,
+				"title", "Title of " + codeSystemId,
 				"url", getCodeSystemUrl(codeSystemId),
 				"description", "<div>Markdown supported</div>",
 				"toolingId", SnomedTerminologyComponentConstants.TOOLING_ID,


### PR DESCRIPTION
This PR resolves a bug when trying to load resource documents with the field selection of the settings field, which is a Map type field. Previously the system was unable to detect that this field cannot be loaded from doc_values, and unfortunately Elasticsearch does not throw an error when trying to load unindexed/unsupported/dynamic fields from doc_values.