### PR TITLE
fix(index): Revise merged revisions to avoid duplication

### DIFF
--- a/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
@@ -425,11 +425,7 @@ public final class StagingArea {
 				if (object instanceof Revision) {
 					RevisionDiff revisionDiff = value.getDiff();
 					final Revision rev = revisionDiff.newRevision;
-					
-					if (!revisionDiff.hasChanges()) {
-						return;
-					}
-					
+
 					if (isMerge()) {
 						revisionsToReviseOnMergeSource.put(rev.getClass(), rev.getId());
 					}
@@ -439,7 +435,11 @@ public final class StagingArea {
 					}
 					
 					writer.put(rev);
-					
+
+					if (!revisionDiff.hasChanges()) {
+						return;
+					}
+
 					// register component as changed in commit doc
 					ObjectId containerId = checkNotNull(rev.getContainerId(), "Missing containerId for revision: %s", rev);
 					ObjectId objectId = rev.getObjectId();


### PR DESCRIPTION
This PR adds two test cases and a proposed fix to the issue where two revisions on separate branches end up in the same state, but neither receives a `revised` entry when one of the branches is merged to the other. Subject to further discussions. 😄  

Related ticket: https://snowowl.atlassian.net/browse/SO-5672