### PR TITLE
Introduce new generic concept search endpoints

### DIFF
--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/concepts/ConceptRestSearch.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/concepts/ConceptRestSearch.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.rest.concepts;
+
+import java.util.List;
+
+import com.b2international.snowowl.core.rest.domain.ObjectRestSearch;
+
+/**
+ * @since 8.11.0
+ */
+public class ConceptRestSearch extends ObjectRestSearch {
+
+	private Boolean active;
+	private List<String> codeSystem;
+	private String term;
+	private String query;
+	
+	public Boolean getActive() {
+		return active;
+	}
+	
+	public List<String> getCodeSystem() {
+		return codeSystem;
+	}
+	
+	public String getQuery() {
+		return query;
+	}
+	
+	public String getTerm() {
+		return term;
+	}
+	
+	public void setActive(Boolean active) {
+		this.active = active;
+	}
+	
+	public void setCodeSystem(List<String> codeSystem) {
+		this.codeSystem = codeSystem;
+	}
+	
+	public void setQuery(String query) {
+		this.query = query;
+	}
+	
+	public void setTerm(String term) {
+		this.term = term;
+	}
+	
+}

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/concepts/ConceptSearchRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/concepts/ConceptSearchRestService.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.rest.concepts;
+
+import org.elasticsearch.core.Set;
+import org.springdoc.api.annotations.ParameterObject;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.b2international.snowowl.core.codesystem.CodeSystemRequests;
+import com.b2international.snowowl.core.domain.Concepts;
+import com.b2international.snowowl.core.events.util.Promise;
+import com.b2international.snowowl.core.rest.AbstractRestService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * @since 8.11.0
+ */
+@Tag(description = "Concepts", name = "concepts")
+@RestController
+@RequestMapping(value = "/concepts", produces = { AbstractRestService.JSON_MEDIA_TYPE })
+public class ConceptSearchRestService extends AbstractRestService {
+
+	public ConceptSearchRestService() {
+		super(Set.of("id", "active"));
+	}
+	
+	@Operation(
+		summary = "Search concepts",
+		description = "Returns a list of concepts matching the given search criteria."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "OK"),
+		@ApiResponse(responseCode = "400", description = "Invalid search config"), 
+	})
+	@GetMapping
+	public Promise<Concepts> searchConcepts(@ParameterObject ConceptRestSearch params) {
+		return CodeSystemRequests.prepareSearchConcepts()
+				.filterByActive(params.getActive())
+				.filterByTerm(params.getTerm())
+				.filterByCodeSystems(params.getCodeSystem())
+				.filterByQuery(params.getQuery())
+				.setFields(params.getField())
+				.setExpand(params.getExpand())
+				.setLimit(params.getLimit())
+				.setSearchAfter(params.getSearchAfter())
+				.sortBy(extractSortFields(params.getSort()))
+				.buildAsync()
+				.execute(getBus());
+	}
+	
+	@Operation(
+		summary = "Search concepts",
+		description = "Returns a list of concepts matching the given search criteria."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "OK"),
+		@ApiResponse(responseCode = "400", description = "Invalid search config"), 
+	})
+	@PostMapping(value = "/search", consumes = { AbstractRestService.JSON_MEDIA_TYPE })
+	public Promise<Concepts> searchConceptsByPost(@RequestBody ConceptRestSearch params) {
+		return searchConcepts(params);
+	}
+	
+}


### PR DESCRIPTION
This PR introduces two new endpoints: 
* `GET /concepts` 
* `POST /concepts/search`

These endpoints allow generic concept search across all registered CodeSystems (similar to FHIR $lookup, but has many more options, like sorting, paging, term filtering, etc.).