### PR TITLE
feat(fhir): Add permission check to FHIR resource update requests

### DIFF
--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/model/Issue.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/model/Issue.java
@@ -145,7 +145,7 @@ public class Issue {
 			
 			String outcomeCodeString = operationOutcomeCode.getDisplayName();
 			if (outcomeCodeString.contains("%s")) {
-				String.format(outcomeCodeString, Arrays.toString(locations.toArray()));
+				outcomeCodeString = String.format(outcomeCodeString, Arrays.toString(locations.toArray()));
 			}
 			
 			Coding coding = Coding.builder()

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/FhirResourceUpdateRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/FhirResourceUpdateRequest.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2023 B2i Healthcare. All rights reserved.
+ *******************************************************************************/
+package com.b2international.snowowl.fhir.core.request;
+
+import static com.google.common.collect.Sets.newHashSet;
+
+import java.util.List;
+import java.util.Set;
+
+import com.b2international.snowowl.core.authorization.AuthorizationService;
+import com.b2international.snowowl.core.bundle.Bundle;
+import com.b2international.snowowl.core.domain.IComponent;
+import com.b2international.snowowl.core.domain.RepositoryContext;
+import com.b2international.snowowl.core.events.Request;
+import com.b2international.snowowl.core.identity.Permission;
+import com.b2international.snowowl.core.identity.User;
+import com.b2international.snowowl.core.request.ResourceRequests;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * @since 8.11.0
+ */
+public abstract class FhirResourceUpdateRequest implements Request<RepositoryContext, FhirResourceUpdateResult> {
+
+	protected final void checkAuthorization(RepositoryContext context, String bundleId) {
+		final User user = context.service(User.class);
+		final AuthorizationService service = context.optionalService(AuthorizationService.class).orElse(AuthorizationService.DEFAULT);
+		
+		// We require edit access to the bundle mentioned in the request OR any of its ancestors OR the "*" wildcard.
+		final Set<String> resourceIds;
+		
+		if (!IComponent.ROOT_ID.equals(bundleId)) {
+		
+			// XXX: This request throws a NotFoundException if the user has no browsing permission for the bundle
+			final Bundle bundle = ResourceRequests.bundles()
+				.prepareGet(bundleId)
+				.buildAsync()
+				.execute(context);
+		
+			resourceIds = newHashSet(bundle.getId(), bundle.getBundleId(), Permission.ALL);
+			resourceIds.addAll(bundle.getBundleAncestorIds());
+			resourceIds.remove(IComponent.ROOT_ID);
+			
+		} else {
+			resourceIds = ImmutableSet.of(Permission.ALL);
+		}
+		
+		final Permission requiredPermission = Permission.requireAny(Permission.OPERATION_EDIT, resourceIds);
+		service.checkPermission(context, user, List.of(requiredPermission));
+	}
+}

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/FhirResourceUpdateRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/FhirResourceUpdateRequest.java
@@ -3,20 +3,12 @@
  *******************************************************************************/
 package com.b2international.snowowl.fhir.core.request;
 
-import static com.google.common.collect.Sets.newHashSet;
-
-import java.util.List;
-import java.util.Set;
-
-import com.b2international.snowowl.core.authorization.AuthorizationService;
-import com.b2international.snowowl.core.bundle.Bundle;
-import com.b2international.snowowl.core.domain.IComponent;
+import com.b2international.commons.CompareUtils;
+import com.b2international.commons.exceptions.ForbiddenException;
 import com.b2international.snowowl.core.domain.RepositoryContext;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.identity.Permission;
 import com.b2international.snowowl.core.identity.User;
-import com.b2international.snowowl.core.request.ResourceRequests;
-import com.google.common.collect.ImmutableSet;
 
 /**
  * @since 8.11.0
@@ -25,28 +17,12 @@ public abstract class FhirResourceUpdateRequest implements Request<RepositoryCon
 
 	protected final void checkAuthorization(RepositoryContext context, String bundleId) {
 		final User user = context.service(User.class);
-		final AuthorizationService service = context.optionalService(AuthorizationService.class).orElse(AuthorizationService.DEFAULT);
-		
-		// We require edit access to the bundle mentioned in the request OR any of its ancestors OR the "*" wildcard.
-		final Set<String> resourceIds;
-		
-		if (!IComponent.ROOT_ID.equals(bundleId)) {
-		
-			// XXX: This request throws a NotFoundException if the user has no browsing permission for the bundle
-			final Bundle bundle = ResourceRequests.bundles()
-				.prepareGet(bundleId)
-				.buildAsync()
-				.execute(context);
-		
-			resourceIds = newHashSet(bundle.getId(), bundle.getBundleId(), Permission.ALL);
-			resourceIds.addAll(bundle.getBundleAncestorIds());
-			resourceIds.remove(IComponent.ROOT_ID);
+
+		if (!CompareUtils.isEmpty(user.getPermissions()) 
+			&& !user.isAdministrator() 
+			&& !user.hasPermission(Permission.requireAny(Permission.OPERATION_EDIT, Permission.ALL))) {
 			
-		} else {
-			resourceIds = ImmutableSet.of(Permission.ALL);
+			throw new ForbiddenException("Operation not permitted for users without editing access.");
 		}
-		
-		final Permission requiredPermission = Permission.requireAny(Permission.OPERATION_EDIT, resourceIds);
-		service.checkPermission(context, user, List.of(requiredPermission));
 	}
 }

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemUpdateRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemUpdateRequest.java
@@ -26,8 +26,8 @@ import org.hibernate.validator.constraints.NotEmpty;
 
 import com.b2international.commons.exceptions.NotImplementedException;
 import com.b2international.snowowl.core.domain.RepositoryContext;
-import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.fhir.core.model.codesystem.CodeSystem;
+import com.b2international.snowowl.fhir.core.request.FhirResourceUpdateRequest;
 import com.b2international.snowowl.fhir.core.request.FhirResourceUpdateResult;
 
 /**
@@ -36,7 +36,7 @@ import com.b2international.snowowl.fhir.core.request.FhirResourceUpdateResult;
  * @see <a href="https://hl7.org/fhir/http.html#update">Update interaction</a>
  * @since 8.2.0
  */
-final class FhirCodeSystemUpdateRequest implements Request<RepositoryContext, FhirResourceUpdateResult> {
+final class FhirCodeSystemUpdateRequest extends FhirResourceUpdateRequest {
 
 	private static final long serialVersionUID = 1L;
 	
@@ -74,7 +74,9 @@ final class FhirCodeSystemUpdateRequest implements Request<RepositoryContext, Fh
 	
 	@Override
 	public FhirResourceUpdateResult execute(final RepositoryContext context) {
+		checkAuthorization(context, bundleId);
 		checkArgument(conceptCountUnderLimit(), "Maintenance of code systems with more than %s codes is not supported.", CONCEPT_LIMIT);
+		
 		final Optional<FhirCodeSystemWriteSupport> codeSystemOperations = context.optionalService(FhirCodeSystemWriteSupport.class);
 
 		return codeSystemOperations

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/conceptmap/FhirConceptMapUpdateRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/conceptmap/FhirConceptMapUpdateRequest.java
@@ -26,8 +26,8 @@ import org.hibernate.validator.constraints.NotEmpty;
 import com.b2international.commons.exceptions.NotImplementedException;
 import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.domain.RepositoryContext;
-import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.fhir.core.model.conceptmap.ConceptMap;
+import com.b2international.snowowl.fhir.core.request.FhirResourceUpdateRequest;
 import com.b2international.snowowl.fhir.core.request.FhirResourceUpdateResult;
 
 /**
@@ -36,7 +36,7 @@ import com.b2international.snowowl.fhir.core.request.FhirResourceUpdateResult;
  * @see <a href="https://hl7.org/fhir/http.html#update">Update interaction</a>
  * @since 8.2.0
  */
-final class FhirConceptMapUpdateRequest implements Request<RepositoryContext, FhirResourceUpdateResult> {
+final class FhirConceptMapUpdateRequest extends FhirResourceUpdateRequest {
 
 	private static final long serialVersionUID = 1L;
 	
@@ -71,6 +71,7 @@ final class FhirConceptMapUpdateRequest implements Request<RepositoryContext, Fh
 	
 	@Override
 	public FhirResourceUpdateResult execute(final RepositoryContext context) {
+		checkAuthorization(context, bundleId);
 		final Optional<FhirConceptMapWriteSupport> conceptMapWriteSupport = context.optionalService(FhirConceptMapWriteSupport.class);
 		
 		return conceptMapWriteSupport

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/valueset/FhirValueSetUpdateRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/valueset/FhirValueSetUpdateRequest.java
@@ -26,8 +26,8 @@ import org.hibernate.validator.constraints.NotEmpty;
 import com.b2international.commons.exceptions.NotImplementedException;
 import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.domain.RepositoryContext;
-import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.fhir.core.model.valueset.ValueSet;
+import com.b2international.snowowl.fhir.core.request.FhirResourceUpdateRequest;
 import com.b2international.snowowl.fhir.core.request.FhirResourceUpdateResult;
 
 /**
@@ -36,7 +36,7 @@ import com.b2international.snowowl.fhir.core.request.FhirResourceUpdateResult;
  * @see <a href="https://hl7.org/fhir/http.html#update">Update interaction</a>
  * @since 8.2.0
  */
-final class FhirValueSetUpdateRequest implements Request<RepositoryContext, FhirResourceUpdateResult> {
+final class FhirValueSetUpdateRequest extends FhirResourceUpdateRequest {
 
 	private static final long serialVersionUID = 1L;
 	
@@ -71,6 +71,7 @@ final class FhirValueSetUpdateRequest implements Request<RepositoryContext, Fhir
 	
 	@Override
 	public FhirResourceUpdateResult execute(final RepositoryContext context) {
+		checkAuthorization(context, bundleId);
 		final Optional<FhirValueSetWriteSupport> valueSetWriteSupport = context.optionalService(FhirValueSetWriteSupport.class);
 		
 		return valueSetWriteSupport

--- a/fhir/com.b2international.snowowl.fhir.rest.tests/.launch/fhir-api-tests.launch
+++ b/fhir/com.b2international.snowowl.fhir.rest.tests/.launch/fhir-api-tests.launch
@@ -43,6 +43,7 @@
         <setEntry value="ch.qos.logback.classic@default:default"/>
         <setEntry value="ch.qos.logback.core@default:default"/>
         <setEntry value="com.b2international.snomed.ecl@default:default"/>
+        <setEntry value="com.diffplug.osgi.extension.sun.misc@default:default"/>
         <setEntry value="com.fasterxml.classmate@default:default"/>
         <setEntry value="com.fasterxml.jackson.core.jackson-annotations@default:default"/>
         <setEntry value="com.fasterxml.jackson.core.jackson-core@default:default"/>

--- a/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/AbstractFhirController.java
+++ b/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/AbstractFhirController.java
@@ -113,6 +113,18 @@ public abstract class AbstractFhirController extends AbstractRestService {
 		return ex.toOperationOutcome();
 	}
 	
+	@ExceptionHandler
+	@ResponseStatus(HttpStatus.FORBIDDEN)
+	public @ResponseBody OperationOutcome handle(final ForbiddenException ex) {
+		return OperationOutcome.builder()
+			.addIssue(Issue.builder()
+				.severity(IssueSeverity.ERROR)
+				.code(IssueType.FORBIDDEN)
+				.diagnostics(ex.getMessage())
+				.build())
+			.build();
+	}
+	
 	/**
 	 * Exception handler converting any {@link JsonMappingException} to an <em>HTTP 400</em>.
 	 * 


### PR DESCRIPTION
Updating a resource requires `*:*` or `edit:*` permissions if the user has an associated permissions list (applicable to file, LDAP and JWT token authentication sources).