### PR TITLE
fix(fhir): add a separate `X-Owner` header to configure ownership...

### DIFF
--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemUpdateRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemUpdateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2022-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ final class FhirCodeSystemUpdateRequest extends FhirResourceUpdateRequest {
 	@NotNull
 	private final CodeSystem fhirCodeSystem;
 	
+	private final String author;
 	private final String owner;
 	private final String ownerProfileName;
 	private final LocalDate defaultEffectiveDate;
@@ -53,13 +54,15 @@ final class FhirCodeSystemUpdateRequest extends FhirResourceUpdateRequest {
 	private final String bundleId;
 
 	public FhirCodeSystemUpdateRequest(
-		final CodeSystem fhirCodeSystem, 
+		final CodeSystem fhirCodeSystem,
+		final String author,
 		final String owner, 
 		final String ownerProfileName,
 		final LocalDate defaultEffectiveDate, 
 		final String bundleId) {
 		
 		this.fhirCodeSystem = fhirCodeSystem;
+		this.author = author;
 		this.owner = owner;
 		this.ownerProfileName = ownerProfileName;
 		this.defaultEffectiveDate = defaultEffectiveDate;
@@ -81,6 +84,6 @@ final class FhirCodeSystemUpdateRequest extends FhirResourceUpdateRequest {
 
 		return codeSystemOperations
 			.orElseThrow(() -> new NotImplementedException("FHIR CodeSystem resource creation is not configured."))
-			.update(context, fhirCodeSystem, owner, ownerProfileName, defaultEffectiveDate, bundleId);
+			.update(context, fhirCodeSystem, author, owner, ownerProfileName, defaultEffectiveDate, bundleId);
 	}
 }

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemUpdateRequestBuilder.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemUpdateRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2022-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import com.b2international.snowowl.fhir.core.request.FhirResourceUpdateResult;
 public final class FhirCodeSystemUpdateRequestBuilder implements ResourceRepositoryRequestBuilder<FhirResourceUpdateResult> {
 
 	private CodeSystem fhirCodeSystem;
+	private String author;
 	private String owner;
 	private String ownerProfileName;
 	private LocalDate defaultEffectiveDate;
@@ -41,6 +42,11 @@ public final class FhirCodeSystemUpdateRequestBuilder implements ResourceReposit
 		return this;
 	}
 
+	public FhirCodeSystemUpdateRequestBuilder setAuthor(String author) {
+		this.author = author;
+		return this;
+	}
+	
 	public FhirCodeSystemUpdateRequestBuilder setOwner(final String owner) {
 		this.owner = owner;
 		return this;
@@ -67,6 +73,6 @@ public final class FhirCodeSystemUpdateRequestBuilder implements ResourceReposit
 
 	@Override
 	public Request<RepositoryContext, FhirResourceUpdateResult> build() {
-		return new FhirCodeSystemUpdateRequest(fhirCodeSystem, owner, ownerProfileName, defaultEffectiveDate, bundleId);
+		return new FhirCodeSystemUpdateRequest(fhirCodeSystem, author, owner, ownerProfileName, defaultEffectiveDate, bundleId);
 	}
 }

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemWriteSupport.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemWriteSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2022-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,7 @@ import com.b2international.snowowl.fhir.core.request.FhirResourceUpdateResult;
 import com.b2international.snowowl.fhir.core.request.conceptmap.FhirWriteSupport;
 
 /**
- * Implementing classes provide support for code system interactions and named
- * operations which can not be achieved using tooling-independent building
+ * Implementing classes provide support for code system interactions and named operations which can not be achieved using tooling-independent building
  * blocks.
  * 
  * @since 8.2.0
@@ -32,28 +31,26 @@ import com.b2international.snowowl.fhir.core.request.conceptmap.FhirWriteSupport
 public interface FhirCodeSystemWriteSupport extends FhirWriteSupport {
 
 	/**
-	 * Creates a new code system based on the specified input, or updates an
-	 * existing one if it can be retrieved by ID.
+	 * Creates a new code system based on the specified input, or updates an existing one if it can be retrieved by ID.
 	 * 
-	 * @param context - the request context to use for creation/update
-	 * @param fhirCodeSystem - the input FHIR representation of the code system
-	 * @param owner - the commit author and resource owner, usually provided via 
-	 * a request header (can be different from the user associated with the service
-	 * provider)
-	 * @param ownerProfileName - the owner's display name, stored in resource settings
-	 * @param defaultEffectiveDate - the default effective date to use if no date
-	 * information is present on the resource (when not given and a version is present, 
-	 * but no effective time is recorded on the code system, an exception will be thrown)
-	 * @param bundleId - the parent bundle identifier
+	 * @param context
+	 *            - the request context to use for creation/update
+	 * @param fhirCodeSystem
+	 *            - the input FHIR representation of the code system
+	 * @param author
+	 *            - the commit author
+	 * @param owner
+	 *            - the resource owner, usually provided via a request header (can be different from the user associated with the service provider)
+	 * @param ownerProfileName
+	 *            - the owner's display name, stored in resource settings
+	 * @param defaultEffectiveDate
+	 *            - the default effective date to use if no date information is present on the resource (when not given and a version is present, but
+	 *            no effective time is recorded on the code system, an exception will be thrown)
+	 * @param bundleId
+	 *            - the parent bundle identifier
 	 * 
-	 * @return indicates whether a new resource has been created or if an existing
-	 * resource has been updated as part of this interaction
+	 * @return indicates whether a new resource has been created or if an existing resource has been updated as part of this interaction
 	 */
-	public FhirResourceUpdateResult update(
-		ServiceProvider context, 
-		CodeSystem fhirCodeSystem, 
-		String owner, 
-		String ownerProfileName,
-		LocalDate defaultEffectiveDate,
-		String bundleId);	
+	public FhirResourceUpdateResult update(ServiceProvider context, CodeSystem fhirCodeSystem, String author, String owner, String ownerProfileName,
+			LocalDate defaultEffectiveDate, String bundleId);
 }

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/conceptmap/FhirConceptMapUpdateRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/conceptmap/FhirConceptMapUpdateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2022-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ final class FhirConceptMapUpdateRequest extends FhirResourceUpdateRequest {
 	@NotNull
 	private final Map<String, ResourceURI> systemUriOverrides;
 	
+	private final String author;
 	private final String owner;
 	private final String ownerProfileName;
 	private final LocalDate defaultEffectiveDate;
@@ -56,6 +57,7 @@ final class FhirConceptMapUpdateRequest extends FhirResourceUpdateRequest {
 	public FhirConceptMapUpdateRequest(
 		final ConceptMap fhirConceptMap,
 		final Map<String, ResourceURI> systemUriOverrides,
+		final String author,
 		final String owner, 
 		final String ownerProfileName,
 		final LocalDate defaultEffectiveDate, 
@@ -63,6 +65,7 @@ final class FhirConceptMapUpdateRequest extends FhirResourceUpdateRequest {
 		
 		this.fhirConceptMap = fhirConceptMap;
 		this.systemUriOverrides = systemUriOverrides;
+		this.author = author;
 		this.owner = owner;
 		this.ownerProfileName = ownerProfileName;
 		this.defaultEffectiveDate = defaultEffectiveDate;
@@ -76,6 +79,6 @@ final class FhirConceptMapUpdateRequest extends FhirResourceUpdateRequest {
 		
 		return conceptMapWriteSupport
 			.orElseThrow(() -> new NotImplementedException("FHIR ConceptMap resource creation is not configured."))
-			.update(context, fhirConceptMap, systemUriOverrides, owner, ownerProfileName, defaultEffectiveDate, bundleId);
+			.update(context, fhirConceptMap, systemUriOverrides, author, owner, ownerProfileName, defaultEffectiveDate, bundleId);
 	}
 }

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/conceptmap/FhirConceptMapUpdateRequestBuilder.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/conceptmap/FhirConceptMapUpdateRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2022-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ public final class FhirConceptMapUpdateRequestBuilder implements ResourceReposit
 
 	private ConceptMap fhirConceptMap;
 	private Map<String, ResourceURI> systemUriOverrides = Map.of();
+	private String author;
 	private String owner;
 	private String ownerProfileName;
 	private LocalDate defaultEffectiveDate;
@@ -50,6 +51,11 @@ public final class FhirConceptMapUpdateRequestBuilder implements ResourceReposit
 		} else {
 			this.systemUriOverrides = systemUriOverrides;
 		}
+		return this;
+	}
+	
+	public FhirConceptMapUpdateRequestBuilder setAuthor(String author) {
+		this.author = author;
 		return this;
 	}
 	
@@ -82,6 +88,7 @@ public final class FhirConceptMapUpdateRequestBuilder implements ResourceReposit
 		return new FhirConceptMapUpdateRequest(
 			fhirConceptMap, 
 			systemUriOverrides, 
+			author,
 			owner, 
 			ownerProfileName, 
 			defaultEffectiveDate, 

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/conceptmap/FhirConceptMapWriteSupport.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/conceptmap/FhirConceptMapWriteSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2022-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,7 @@ import com.b2international.snowowl.fhir.core.model.conceptmap.ConceptMap;
 import com.b2international.snowowl.fhir.core.request.FhirResourceUpdateResult;
 
 /**
- * Implementing classes provide support for concept map interactions and named
- * operations which can not be achieved using tooling-independent building
+ * Implementing classes provide support for concept map interactions and named operations which can not be achieved using tooling-independent building
  * blocks.
  * 
  * @since 8.2.0
@@ -33,32 +32,29 @@ import com.b2international.snowowl.fhir.core.request.FhirResourceUpdateResult;
 public interface FhirConceptMapWriteSupport extends FhirWriteSupport {
 
 	/**
-	 * Creates a new concept map based on the specified input, or updates an
-	 * existing one if it can be retrieved by ID.
+	 * Creates a new concept map based on the specified input, or updates an existing one if it can be retrieved by ID.
 	 * 
-	 * @param context - the request context to use for creation/update
-	 * @param fhirConceptMap - the input FHIR representation of the concept map
-	 * @param systemUriOverrides - code system resource URIs are taken from this map 
-	 * directly instead of going through a lookup step when the concept map refers
-	 * to a system URI (stored in map keys) as its source or target
-	 * @param owner - the commit author and resource owner, usually provided via 
-	 * a request header (can be different from the user associated with the service
-	 * provider)
-	 * @param ownerProfileName - the owner's display name, stored in resource settings
-	 * @param defaultEffectiveDate - the default effective date to use if no date
-	 * information is present on the resource (when not given and a version is present, 
-	 * but no effective time is recorded on the concept map, an exception will be thrown)
-	 * @param bundleId - the parent bundle identifier
+	 * @param context
+	 *            - the request context to use for creation/update
+	 * @param fhirConceptMap
+	 *            - the input FHIR representation of the concept map
+	 * @param systemUriOverrides
+	 *            - code system resource URIs are taken from this map directly instead of going through a lookup step when the concept map refers to a
+	 *            system URI (stored in map keys) as its source or target
+	 * @param author
+	 *            - the commit author
+	 * @param owner
+	 *            - the resource owner, usually provided via a request header (can be different from the user associated with the service provider)
+	 * @param ownerProfileName
+	 *            - the owner's display name, stored in resource settings
+	 * @param defaultEffectiveDate
+	 *            - the default effective date to use if no date information is present on the resource (when not given and a version is present, but
+	 *            no effective time is recorded on the concept map, an exception will be thrown)
+	 * @param bundleId
+	 *            - the parent bundle identifier
 	 * 
-	 * @return indicates whether a new resource has been created or if an existing
-	 * resource has been updated as part of this interaction
+	 * @return indicates whether a new resource has been created or if an existing resource has been updated as part of this interaction
 	 */
-	public FhirResourceUpdateResult update(
-		ServiceProvider context, 
-		ConceptMap fhirConceptMap, 
-		Map<String, ResourceURI> systemUriOverrides,
-		String owner, 
-		String ownerProfileName,
-		LocalDate defaultEffectiveDate,
-		String bundleId);	
+	public FhirResourceUpdateResult update(ServiceProvider context, ConceptMap fhirConceptMap, Map<String, ResourceURI> systemUriOverrides,
+			String author, String owner, String ownerProfileName, LocalDate defaultEffectiveDate, String bundleId);
 }

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/valueset/FhirValueSetUpdateRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/valueset/FhirValueSetUpdateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2022-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ final class FhirValueSetUpdateRequest extends FhirResourceUpdateRequest {
 	@NotNull
 	private final Map<String, ResourceURI> systemUriOverrides;
 	
+	private final String author;
 	private final String owner;
 	private final String ownerProfileName;
 	private final LocalDate defaultEffectiveDate;
@@ -56,6 +57,7 @@ final class FhirValueSetUpdateRequest extends FhirResourceUpdateRequest {
 	public FhirValueSetUpdateRequest(
 		final ValueSet fhirValueSet,
 		final Map<String, ResourceURI> systemUriOverrides,
+		final String author,
 		final String owner, 
 		final String ownerProfileName,
 		final LocalDate defaultEffectiveDate, 
@@ -63,6 +65,7 @@ final class FhirValueSetUpdateRequest extends FhirResourceUpdateRequest {
 		
 		this.fhirValueSet = fhirValueSet;
 		this.systemUriOverrides = systemUriOverrides;
+		this.author = author;
 		this.owner = owner;
 		this.ownerProfileName = ownerProfileName;
 		this.defaultEffectiveDate = defaultEffectiveDate;
@@ -76,6 +79,6 @@ final class FhirValueSetUpdateRequest extends FhirResourceUpdateRequest {
 		
 		return valueSetWriteSupport
 			.orElseThrow(() -> new NotImplementedException("FHIR ValueSet resource creation is not configured."))
-			.update(context, fhirValueSet, systemUriOverrides, owner, ownerProfileName, defaultEffectiveDate, bundleId);
+			.update(context, fhirValueSet, systemUriOverrides, author, owner, ownerProfileName, defaultEffectiveDate, bundleId);
 	}
 }

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/valueset/FhirValueSetUpdateRequestBuilder.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/valueset/FhirValueSetUpdateRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2022-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ public final class FhirValueSetUpdateRequestBuilder implements ResourceRepositor
 
 	private ValueSet fhirValueSet;
 	private Map<String, ResourceURI> systemUriOverrides = Map.of();
+	private String author;
 	private String owner;
 	private String ownerProfileName;
 	private LocalDate defaultEffectiveDate;
@@ -50,6 +51,11 @@ public final class FhirValueSetUpdateRequestBuilder implements ResourceRepositor
 		} else {
 			this.systemUriOverrides = systemUriOverrides;
 		}
+		return this;
+	}
+	
+	public FhirValueSetUpdateRequestBuilder setAuthor(String author) {
+		this.author = author;
 		return this;
 	}
 	
@@ -82,6 +88,7 @@ public final class FhirValueSetUpdateRequestBuilder implements ResourceRepositor
 		return new FhirValueSetUpdateRequest(
 			fhirValueSet, 
 			systemUriOverrides, 
+			author,
 			owner, 
 			ownerProfileName, 
 			defaultEffectiveDate, 

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/valueset/FhirValueSetWriteSupport.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/valueset/FhirValueSetWriteSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2022-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,7 @@ import com.b2international.snowowl.fhir.core.request.FhirResourceUpdateResult;
 import com.b2international.snowowl.fhir.core.request.conceptmap.FhirWriteSupport;
 
 /**
- * Implementing classes provide support for value set interactions and named
- * operations which can not be achieved using tooling-independent building
+ * Implementing classes provide support for value set interactions and named operations which can not be achieved using tooling-independent building
  * blocks.
  * 
  * @since 8.2.0
@@ -34,32 +33,29 @@ import com.b2international.snowowl.fhir.core.request.conceptmap.FhirWriteSupport
 public interface FhirValueSetWriteSupport extends FhirWriteSupport {
 
 	/**
-	 * Creates a new value set based on the specified input, or updates an
-	 * existing one if it can be retrieved by ID.
+	 * Creates a new value set based on the specified input, or updates an existing one if it can be retrieved by ID.
 	 * 
-	 * @param context - the request context to use for creation/update
-	 * @param fhirValueSet - the input FHIR representation of the value set
-	 * @param systemUriOverrides - code system resource URIs are taken from this map 
-	 * directly instead of going through a lookup step when the value set refers
-	 * to a system URI (stored in map keys) in any inclusion/exclusion
-	 * @param owner - the commit author and resource owner, usually provided via 
-	 * a request header (can be different from the user associated with the service
-	 * provider)
-	 * @param ownerProfileName - the owner's display name, stored in resource settings
-	 * @param defaultEffectiveDate - the default effective date to use if no date
-	 * information is present on the resource (when not given and a version is present, 
-	 * but no effective time is recorded on the value set, an exception will be thrown)
-	 * @param bundleId - the parent bundle identifier
+	 * @param context
+	 *            - the request context to use for creation/update
+	 * @param fhirValueSet
+	 *            - the input FHIR representation of the value set
+	 * @param systemUriOverrides
+	 *            - code system resource URIs are taken from this map directly instead of going through a lookup step when the value set refers to a
+	 *            system URI (stored in map keys) in any inclusion/exclusion
+	 * @param author
+	 *            - the commit author
+	 * @param owner
+	 *            - the resource owner, usually provided via a request header (can be different from the user associated with the service provider)
+	 * @param ownerProfileName
+	 *            - the owner's display name, stored in resource settings
+	 * @param defaultEffectiveDate
+	 *            - the default effective date to use if no date information is present on the resource (when not given and a version is present, but
+	 *            no effective time is recorded on the value set, an exception will be thrown)
+	 * @param bundleId
+	 *            - the parent bundle identifier
 	 * 
-	 * @return indicates whether a new resource has been created or if an existing
-	 * resource has been updated as part of this interaction
+	 * @return indicates whether a new resource has been created or if an existing resource has been updated as part of this interaction
 	 */
-	public FhirResourceUpdateResult update(
-		ServiceProvider context, 
-		ValueSet fhirValueSet, 
-		Map<String, ResourceURI> systemUriOverrides,
-		String owner, 
-		String ownerProfileName,
-		LocalDate defaultEffectiveDate,
-		String bundleId);	
+	public FhirResourceUpdateResult update(ServiceProvider context, ValueSet fhirValueSet, Map<String, ResourceURI> systemUriOverrides, String author,
+			String owner, String ownerProfileName, LocalDate defaultEffectiveDate, String bundleId);
 }

--- a/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/AbstractFhirController.java
+++ b/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/AbstractFhirController.java
@@ -56,7 +56,8 @@ public abstract class AbstractFhirController extends AbstractRestService {
 
 	// Headers used in resource creation/udpate requests 
 	protected static final String X_EFFECTIVE_DATE = "X-Effective-Date";
-	protected static final String X_AUTHOR_PROFILE_NAME = "X-Author-Profile-Name";
+	protected static final String X_OWNER = "X-Owner";
+	protected static final String X_OWNER_PROFILE_NAME = "X-Owner-Profile-Name";
 	protected static final String X_BUNDLE_ID = "X-Bundle-Id";
 	
 	@Autowired

--- a/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirCodeSystemController.java
+++ b/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirCodeSystemController.java
@@ -104,7 +104,7 @@ public class FhirCodeSystemController extends AbstractFhirController {
 		@RequestHeader(value = X_AUTHOR, required = false)
 		final String author,
 		
-		@Parameter(description = "The resource owner (if not set it will fall back to the current authenticated user id)")
+		@Parameter(description = "The resource owner (if not set it will fall back to the X-Author header then to the current authenticated user id)")
 		@RequestHeader(value = X_OWNER, required = false)
 		final String owner,
 		
@@ -206,7 +206,7 @@ public class FhirCodeSystemController extends AbstractFhirController {
 		@RequestHeader(value = X_AUTHOR, required = false)
 		final String author,
 		
-		@Parameter(description = "The resource owner (if not set it will fall back to the current authenticated user id)")
+		@Parameter(description = "The resource owner (if not set it will fall back to the X-Author header then to the current authenticated user id)")
 		@RequestHeader(value = X_OWNER, required = false)
 		final String owner,
 		

--- a/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirCodeSystemController.java
+++ b/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirCodeSystemController.java
@@ -100,13 +100,17 @@ public class FhirCodeSystemController extends AbstractFhirController {
 		@DateTimeFormat(iso = ISO.DATE)
 		final LocalDate defaultEffectiveDate,
 		
-		@Parameter(description = "The user identifier used for commits and set as the resource owner")
+		@Parameter(description = "The user identifier used for committing the change")
 		@RequestHeader(value = X_AUTHOR, required = false)
 		final String author,
 		
-		@Parameter(description = "The user profile name to add to resource settings")
-		@RequestHeader(value = X_AUTHOR_PROFILE_NAME, required = false)
-		final String authorProfileName,
+		@Parameter(description = "The resource owner (if not set it will fall back to the current authenticated user id)")
+		@RequestHeader(value = X_OWNER, required = false)
+		final String owner,
+		
+		@Parameter(description = "The user profile name to add to resource settings for client purposes")
+		@RequestHeader(value = X_OWNER_PROFILE_NAME, required = false)
+		final String ownerProfileName,
 		
 		@Parameter(description = "The parent bundle's identifier (defaults to root if not present)")
 		@RequestHeader(value = X_BUNDLE_ID, required = false)
@@ -154,7 +158,7 @@ public class FhirCodeSystemController extends AbstractFhirController {
 			.build();
 		
 		codeSystem.setChange(fhirCodeSystemWithId);
-		return update(generatedId, codeSystem, defaultEffectiveDate, author, authorProfileName, bundleId);
+		return update(generatedId, codeSystem, defaultEffectiveDate, author, owner, ownerProfileName, bundleId);
 		
 	}
 	
@@ -198,13 +202,17 @@ public class FhirCodeSystemController extends AbstractFhirController {
 		@DateTimeFormat(iso = ISO.DATE)
 		final LocalDate defaultEffectiveDate,
 		
-		@Parameter(description = "The user identifier used for commits and set as the resource owner")
+		@Parameter(description = "The user identifier used for committing the change")
 		@RequestHeader(value = X_AUTHOR, required = false)
 		final String author,
 		
-		@Parameter(description = "The user profile name to add to resource settings")
-		@RequestHeader(value = X_AUTHOR_PROFILE_NAME, required = false)
-		final String authorProfileName,
+		@Parameter(description = "The resource owner (if not set it will fall back to the current authenticated user id)")
+		@RequestHeader(value = X_OWNER, required = false)
+		final String owner,
+		
+		@Parameter(description = "The user profile name to add to resource settings for client purposes")
+		@RequestHeader(value = X_OWNER_PROFILE_NAME, required = false)
+		final String ownerProfileName,
 		
 		@Parameter(description = "The parent bundle's identifier (defaults to root if not present)")
 		@RequestHeader(value = X_BUNDLE_ID, required = false)
@@ -224,8 +232,9 @@ public class FhirCodeSystemController extends AbstractFhirController {
 		final FhirResourceUpdateResult updateResult = FhirRequests.codeSystems()
 			.prepareUpdate()
 			.setFhirCodeSystem(fhirCodeSystem)
-			.setOwner(author)
-			.setOwnerProfileName(authorProfileName)
+			.setAuthor(author)
+			.setOwner(owner)
+			.setOwnerProfileName(ownerProfileName)
 			.setBundleId(bundleId)
 			.setDefaultEffectiveDate(defaultEffectiveDate)
 			.buildAsync()

--- a/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirConceptMapController.java
+++ b/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirConceptMapController.java
@@ -100,7 +100,7 @@ public class FhirConceptMapController extends AbstractFhirController {
 		@RequestHeader(value = X_AUTHOR, required = false)
 		final String author,
 		
-		@Parameter(description = "The resource owner (if not set it will fall back to the current authenticated user id)")
+		@Parameter(description = "The resource owner (if not set it will fall back to the X-Author header then to the current authenticated user id)")
 		@RequestHeader(value = X_OWNER, required = false)
 		final String owner,
 		
@@ -197,7 +197,7 @@ public class FhirConceptMapController extends AbstractFhirController {
 		@RequestHeader(value = X_AUTHOR, required = false)
 		final String author,
 		
-		@Parameter(description = "The resource owner (if not set it will fall back to the current authenticated user id)")
+		@Parameter(description = "The resource owner (if not set it will fall back to the X-Author header then to the current authenticated user id)")
 		@RequestHeader(value = X_OWNER, required = false)
 		final String owner,
 		

--- a/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirConceptMapController.java
+++ b/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirConceptMapController.java
@@ -96,13 +96,17 @@ public class FhirConceptMapController extends AbstractFhirController {
 		@DateTimeFormat(iso = ISO.DATE)
 		final LocalDate defaultEffectiveDate,
 		
-		@Parameter(description = "The user identifier used for commits and set as the resource owner")
+		@Parameter(description = "The user identifier used for committing the change")
 		@RequestHeader(value = X_AUTHOR, required = false)
 		final String author,
 		
-		@Parameter(description = "The user profile name to add to resource settings")
-		@RequestHeader(value = X_AUTHOR_PROFILE_NAME, required = false)
-		final String authorProfileName,
+		@Parameter(description = "The resource owner (if not set it will fall back to the current authenticated user id)")
+		@RequestHeader(value = X_OWNER, required = false)
+		final String owner,
+		
+		@Parameter(description = "The user profile name to add to resource settings for client purposes")
+		@RequestHeader(value = X_OWNER_PROFILE_NAME, required = false)
+		final String ownerProfileName,
 		
 		@Parameter(description = "The parent bundle's identifier (defaults to root if not present)")
 		@RequestHeader(value = X_BUNDLE_ID, required = false)
@@ -145,7 +149,7 @@ public class FhirConceptMapController extends AbstractFhirController {
 			.build();
 		
 		fhirConceptMapWithUriMapping.setConceptMap(fhirConceptMapWithId);
-		return update(generatedId, conceptMap, defaultEffectiveDate, author, authorProfileName, bundleId);
+		return update(generatedId, conceptMap, defaultEffectiveDate, author, owner, ownerProfileName, bundleId);
 		
 	}
 	
@@ -189,13 +193,17 @@ public class FhirConceptMapController extends AbstractFhirController {
 		@DateTimeFormat(iso = ISO.DATE)
 		final LocalDate defaultEffectiveDate,
 		
-		@Parameter(description = "The user identifier used for commits and set as the resource owner")
+		@Parameter(description = "The user identifier used for committing the change")
 		@RequestHeader(value = X_AUTHOR, required = false)
 		final String author,
 		
-		@Parameter(description = "The user profile name to add to resource settings")
-		@RequestHeader(value = X_AUTHOR_PROFILE_NAME, required = false)
-		final String authorProfileName,
+		@Parameter(description = "The resource owner (if not set it will fall back to the current authenticated user id)")
+		@RequestHeader(value = X_OWNER, required = false)
+		final String owner,
+		
+		@Parameter(description = "The user profile name to add to resource settings for client purposes")
+		@RequestHeader(value = X_OWNER_PROFILE_NAME, required = false)
+		final String ownerProfileName,
 		
 		@Parameter(description = "The parent bundle's identifier (defaults to root if not present)")
 		@RequestHeader(value = X_BUNDLE_ID, required = false)
@@ -218,8 +226,9 @@ public class FhirConceptMapController extends AbstractFhirController {
 			.prepareUpdate()
 			.setFhirConceptMap(fhirConceptMap)
 			.setSystemUriOverrides(systemUriOverrides)
-			.setOwner(author)
-			.setOwnerProfileName(authorProfileName)
+			.setAuthor(author)
+			.setOwner(owner)
+			.setOwnerProfileName(ownerProfileName)
 			.setBundleId(bundleId)
 			.setDefaultEffectiveDate(defaultEffectiveDate)
 			.buildAsync()

--- a/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirValueSetController.java
+++ b/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirValueSetController.java
@@ -95,13 +95,17 @@ public class FhirValueSetController extends AbstractFhirController {
 		@DateTimeFormat(iso = ISO.DATE)
 		final LocalDate defaultEffectiveDate,
 		
-		@Parameter(description = "The user identifier used for commits and set as the resource owner")
+		@Parameter(description = "The user identifier used for committing the change")
 		@RequestHeader(value = X_AUTHOR, required = false)
 		final String author,
 		
-		@Parameter(description = "The user profile name to add to resource settings")
-		@RequestHeader(value = X_AUTHOR_PROFILE_NAME, required = false)
-		final String authorProfileName,
+		@Parameter(description = "The resource owner (if not set it will fall back to the current authenticated user id)")
+		@RequestHeader(value = X_OWNER, required = false)
+		final String owner,
+		
+		@Parameter(description = "The user profile name to add to resource settings for client purposes")
+		@RequestHeader(value = X_OWNER_PROFILE_NAME, required = false)
+		final String ownerProfileName,
 		
 		@Parameter(description = "The parent bundle's identifier (defaults to root if not present)")
 		@RequestHeader(value = X_BUNDLE_ID, required = false)
@@ -142,7 +146,7 @@ public class FhirValueSetController extends AbstractFhirController {
 			.build();
 		
 		fhirValueSetWithUriMapping.setValueSet(fhirValueSetWithId);
-		return update(generatedId, valueSet, defaultEffectiveDate, author, authorProfileName, bundleId);
+		return update(generatedId, valueSet, defaultEffectiveDate, author, owner, ownerProfileName, bundleId);
 		
 	}
 	
@@ -186,13 +190,17 @@ public class FhirValueSetController extends AbstractFhirController {
 		@DateTimeFormat(iso = ISO.DATE)
 		final LocalDate defaultEffectiveDate,
 		
-		@Parameter(description = "The user identifier used for commits and set as the resource owner")
+		@Parameter(description = "The user identifier used for committing the change")
 		@RequestHeader(value = X_AUTHOR, required = false)
 		final String author,
 		
-		@Parameter(description = "The user profile name to add to resource settings")
-		@RequestHeader(value = X_AUTHOR_PROFILE_NAME, required = false)
-		final String authorProfileName,
+		@Parameter(description = "The resource owner (if not set it will fall back to the current authenticated user id)")
+		@RequestHeader(value = X_OWNER, required = false)
+		final String owner,
+		
+		@Parameter(description = "The user profile name to add to resource settings for client purposes")
+		@RequestHeader(value = X_OWNER_PROFILE_NAME, required = false)
+		final String ownerProfileName,
 		
 		@Parameter(description = "The parent bundle's identifier (defaults to root if not present)")
 		@RequestHeader(value = X_BUNDLE_ID, required = false)
@@ -215,8 +223,9 @@ public class FhirValueSetController extends AbstractFhirController {
 			.prepareUpdate()
 			.setFhirValueSet(fhirValueSet)
 			.setSystemUriOverrides(systemUriOverrides)
-			.setOwner(author)
-			.setOwnerProfileName(authorProfileName)
+			.setAuthor(author)
+			.setOwner(owner)
+			.setOwnerProfileName(ownerProfileName)
 			.setBundleId(bundleId)
 			.setDefaultEffectiveDate(defaultEffectiveDate)
 			.buildAsync()

--- a/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirValueSetController.java
+++ b/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirValueSetController.java
@@ -99,7 +99,7 @@ public class FhirValueSetController extends AbstractFhirController {
 		@RequestHeader(value = X_AUTHOR, required = false)
 		final String author,
 		
-		@Parameter(description = "The resource owner (if not set it will fall back to the current authenticated user id)")
+		@Parameter(description = "The resource owner (if not set it will fall back to the X-Author header then to the current authenticated user id)")
 		@RequestHeader(value = X_OWNER, required = false)
 		final String owner,
 		
@@ -194,7 +194,7 @@ public class FhirValueSetController extends AbstractFhirController {
 		@RequestHeader(value = X_AUTHOR, required = false)
 		final String author,
 		
-		@Parameter(description = "The resource owner (if not set it will fall back to the current authenticated user id)")
+		@Parameter(description = "The resource owner (if not set it will fall back to the X-Author header then to the current authenticated user id)")
 		@RequestHeader(value = X_OWNER, required = false)
 		final String owner,
 		


### PR DESCRIPTION
...of a FHIR resource when creating it via FHIR API

Rename `X-Author-Profile-Name` to `X-Owner-Profile-Name`.