### PR TITLE
Collect nested requests for permission checking recursively in TransactionalRequest and SnomedBulkRequest

### DIFF
--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/TransactionalRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/TransactionalRequest.java
@@ -105,7 +105,10 @@ public final class TransactionalRequest implements Request<BranchContext, Commit
 	@JsonIgnore
 	@Override
 	public Collection<Request<?, ?>> getNestedRequests() {
-		return ImmutableList.of(this, getNext());
+		return ImmutableList.<Request<?, ?>>builder()
+			.add(this)
+			.addAll(next.getNestedRequests())
+			.build();
 	}
 	
 	/**

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedBulkRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedBulkRequest.java
@@ -128,5 +128,14 @@ public final class SnomedBulkRequest<R> extends DelegatingRequest<TransactionCon
 			});
 		}
 	}
-	
+
+	@Override
+	public Collection<Request<?, ?>> getNestedRequests() {
+		// XXX: this method is primarily used for permission checking and so does not dig deeper into the nested request hierarchy
+		return ImmutableList.<Request<?, ?>>builder()
+			.add(this)
+			.addAll(super.getNestedRequests())
+			.build();
+
+	}
 }


### PR DESCRIPTION
These usually appear with one packed into the other; if `TransactionRequest` stops at `SnomedBulkRequest`, there might not be enough information collected for permission checks.