### PR TITLE
fix(index): support loading unindexed fields from documents

### DIFF
--- a/commons/com.b2international.index.tests/src/com/b2international/index/Fixtures.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/Fixtures.java
@@ -68,6 +68,9 @@ public class Fixtures {
 		private short shortField;
 		private Short shortWrapper;
 		
+		@Field(index = false)
+		private String unindexedValue;
+		
 		private LongSortedSet longSortedSet;
 
 		@JsonCreator
@@ -181,6 +184,14 @@ public class Fixtures {
 		
 		public void setLongSortedSet(LongSortedSet longSortedSet) {
 			this.longSortedSet = longSortedSet;
+		}
+		
+		public String getUnindexedValue() {
+			return unindexedValue;
+		}
+		
+		public void setUnindexedValue(String unindexedValue) {
+			this.unindexedValue = unindexedValue;
 		}
 
 		@Override

--- a/commons/com.b2international.index.tests/src/com/b2international/index/PartialDocumentLoadingTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/PartialDocumentLoadingTest.java
@@ -426,4 +426,26 @@ public class PartialDocumentLoadingTest extends BaseIndexTest {
 		assertEquals("field2_1", hit.get("field2").asText());
 	}
 	
+	@Test
+	public void selectNotIndexedFieldViaStringArray() {
+		final Data data1 = new Data(KEY1);
+		data1.setUnindexedValue("test");
+		final Data data2 = new Data(KEY2);
+		// second value is unset to test null value loading
+		data2.setUnindexedValue(null);
+		indexDocuments(data1, data2);
+		
+		final Query<String[]> query = Query.select(String[].class)
+				.from(Data.class)
+				.fields("id", "unindexedValue")
+				.where(Expressions.matchAll())
+				.build();
+
+		final Hits<String[]> hits = search(query);
+		
+		checkHits(hits, DEFAULT_LIMIT, 2, 2);
+		assertEquals("test", hits.getHits().get(0)[1]);
+		assertEquals(null, hits.getHits().get(1)[1]);
+	}
+	
 }

--- a/commons/com.b2international.index/src/com/b2international/index/es/EsDocumentSearcher.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/EsDocumentSearcher.java
@@ -298,7 +298,7 @@ public class EsDocumentSearcher implements Searcher {
 	private boolean requiresDocumentSourceField(DocumentMapping mapping, List<String> fields) {
 		return fields
 			.stream()
-			.filter(field -> mapping.isCollection(field) || mapping.isMap(field))
+			.filter(field -> mapping.isCollection(field) || mapping.isMap(field) || !mapping.isDocValuesEnabled(field))
 			.findFirst()
 			.isPresent();
 	}

--- a/commons/com.b2international.index/src/com/b2international/index/mapping/DocumentMapping.java
+++ b/commons/com.b2international.index/src/com/b2international/index/mapping/DocumentMapping.java
@@ -314,6 +314,12 @@ public final class DocumentMapping {
 		final Class<?> fieldType = getFieldType(field);
 		return Map.class.isAssignableFrom(fieldType);
 	}
+	
+	public boolean isDocValuesEnabled(String field) {
+		Field f = getField(field);
+		com.b2international.index.mapping.Field fieldAnnotation = f.getAnnotation(com.b2international.index.mapping.Field.class);
+		return fieldAnnotation == null || fieldAnnotation.index() == true;
+	}
 
 	private static boolean isCollection(Class<?> fieldType) {
 		return Iterable.class.isAssignableFrom(fieldType) || PrimitiveCollection.class.isAssignableFrom(fieldType) || fieldType.isArray();


### PR DESCRIPTION
This resolves problems around exporting query type reference set to RF2.