### PR TITLE
refactor(snomed.datastore): Improve SnomedDescendantsExpander

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/converter/SnomedDescendantsExpander.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/converter/SnomedDescendantsExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2020-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,35 +20,37 @@ import static com.b2international.snowowl.snomed.datastore.index.entry.SnomedCon
 import static com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument.Expressions.statedAncestors;
 import static com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument.Expressions.statedParents;
 import static com.b2international.snowowl.snomed.datastore.index.entry.SnomedDocument.Expressions.active;
-import static com.google.common.collect.Maps.newHashMap;
-import static com.google.common.collect.Sets.newHashSet;
 
 import java.io.IOException;
-import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
-import com.b2international.commons.collect.LongSets;
+import org.slf4j.Logger;
+
+import com.b2international.collections.longs.LongSortedSet;
 import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.commons.options.Options;
 import com.b2international.index.Hits;
+import com.b2international.index.query.Expression;
 import com.b2international.index.query.Expressions;
 import com.b2international.index.query.Expressions.ExpressionBuilder;
 import com.b2international.index.query.Query;
 import com.b2international.index.revision.RevisionSearcher;
 import com.b2international.snowowl.core.api.SnowowlRuntimeException;
+import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.request.DescendantsExpander;
 import com.b2international.snowowl.snomed.core.domain.SnomedConcept;
 import com.b2international.snowowl.snomed.core.domain.SnomedConcepts;
 import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument;
+import com.b2international.snowowl.snomed.datastore.request.SnomedConceptSearchRequestBuilder;
 import com.b2international.snowowl.snomed.datastore.request.SnomedRequests;
-import com.google.common.base.Functions;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.TreeMultimap;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.*;
+import com.google.common.primitives.Ints;
 
 /**
  * @since 7.7
@@ -56,127 +58,302 @@ import com.google.common.collect.TreeMultimap;
 public final class SnomedDescendantsExpander extends DescendantsExpander<SnomedConcept> {
 
 	private final boolean stated;
+	private final int batchLimit;
 
 	public SnomedDescendantsExpander(BranchContext context, Options expand, List<ExtendedLocale> locales, String descendantExpandKey) {
 		super(context, expand, locales, descendantExpandKey);
 		this.stated = SnomedConcept.Expand.STATED_DESCENDANTS.equals(descendantExpandKey);
+		this.batchLimit = context.service(RepositoryConfiguration.class)
+			.getIndexConfiguration()
+			.getResultWindow();
 	}
 	
 	@Override
-	protected void expand(List<SnomedConcept> results, final Set<String> conceptIds, Options descendantExpandOptions, boolean direct) {
-		try {
-			final int limit = getLimit(descendantExpandOptions);
-			
-			final ExpressionBuilder expression = Expressions.bool();
-			expression.filter(active());
-			final ExpressionBuilder descendantFilter = Expressions.bool();
-			if (stated) {
-				descendantFilter.should(statedParents(conceptIds));
-				if (!direct) {
-					descendantFilter.should(statedAncestors(conceptIds));
-				}
-			} else {
-				descendantFilter.should(parents(conceptIds));
-				if (!direct) {
-					descendantFilter.should(ancestors(conceptIds));
-				}
-			}
-			expression.filter(descendantFilter.build());
-			
-			final Query<SnomedConceptDocument> query = Query.select(SnomedConceptDocument.class)
-					.where(expression.build())
-					.limit((conceptIds.size() == 1 && limit == 0) ? limit : Integer.MAX_VALUE)
-					.build();
-			
-			final RevisionSearcher searcher = context().service(RevisionSearcher.class);
-			final Hits<SnomedConceptDocument> hits = searcher.search(query);
-			
-			if (hits.getTotal() < 1) {
-				final SnomedConcepts descendants = new SnomedConcepts(0, 0);
-				for (SnomedConcept concept : results) {
-					if (stated) {
-						concept.setStatedDescendants(descendants);
-					} else {
-						concept.setDescendants(descendants);
-					}
-				}
-				return;
-			}
-			
-			// in case of only one match and limit zero, use shortcut instead of loading all IDs and components
-			// XXX won't work if number of results is greater than one, either use custom ConceptSearch or figure out how to expand descendants effectively
-			if (conceptIds.size() == 1 && limit == 0) {
-				final SnomedConcepts descendants = new SnomedConcepts(0, hits.getTotal());
-				for (SnomedConcept concept : results) {
-					if (stated) {
-						concept.setStatedDescendants(descendants);
-					} else {
-						concept.setDescendants(descendants);
-					}
-				}
-				return;
-			}
-			
-			final Multimap<String, String> descendantsByAncestor = TreeMultimap.create();
-			for (SnomedConceptDocument hit : hits) {
-				final Set<String> parentsAndAncestors = newHashSet();
-				if (stated) {
-					parentsAndAncestors.addAll(LongSets.toStringSet(hit.getStatedParents()));
-					if (!direct) {
-						parentsAndAncestors.addAll(LongSets.toStringSet(hit.getStatedAncestors()));
-					}
-				} else {
-					parentsAndAncestors.addAll(LongSets.toStringSet(hit.getParents()));
-					if (!direct) {
-						parentsAndAncestors.addAll(LongSets.toStringSet(hit.getAncestors()));
-					}
-				}
-				
-				parentsAndAncestors.retainAll(conceptIds);
-				for (String ancestor : parentsAndAncestors) {
-					descendantsByAncestor.put(ancestor, hit.getId());
-				}
-			}
-			
-			final Collection<String> componentIds = newHashSet(descendantsByAncestor.values());
-			
-			if (limit > 0 && !componentIds.isEmpty()) {
-				// query descendants again
-				final SnomedConcepts descendants = SnomedRequests.prepareSearchConcept()
-						.all()
-						.filterByIds(componentIds)
-						.setLocales(locales())
-						.setExpand(descendantExpandOptions.get("expand", Options.class))
-						.build()
-						.execute(context());
-				
-				final Map<String, SnomedConcept> descendantsById = newHashMap();
-				descendantsById.putAll(Maps.uniqueIndex(descendants, SnomedConcept::getId));
-				for (SnomedConcept concept : results) {
-					final Collection<String> descendantIds = descendantsByAncestor.get(concept.getId());
-					final List<SnomedConcept> currentDescendants = FluentIterable.from(descendantIds).limit(limit).transform(Functions.forMap(descendantsById)).toList();
-					final SnomedConcepts descendantConcepts = new SnomedConcepts(currentDescendants, null, limit, descendantIds.size());
-					if (stated) {
-						concept.setStatedDescendants(descendantConcepts);
-					} else {
-						concept.setDescendants(descendantConcepts);
-					}
-				}
-			} else {
-				for (SnomedConcept concept : results) {
-					final Collection<String> descendantIds = descendantsByAncestor.get(concept.getId());
-					final SnomedConcepts descendants = new SnomedConcepts(limit, descendantIds.size());
-					if (stated) {
-						concept.setStatedDescendants(descendants);
-					} else {
-						concept.setDescendants(descendants);
-					}
-				}
-			}
-			
-		} catch (IOException e) {
-			throw SnowowlRuntimeException.wrap(e);
+	protected void expand(List<SnomedConcept> results, final Set<String> conceptIds, Options descendantOptions, boolean direct) {
+		// Nothing to do if the ancestor ID set is empty
+		if (conceptIds.isEmpty()) {
+			return;
+		}
+		
+		Stopwatch w = null;
+		final Logger log = context().log();
+		if (log.isDebugEnabled()) {
+			w = Stopwatch.createStarted();
+		}
+		
+		final int descendantLimit = getLimit(descendantOptions);
+		final boolean totalOnly = (descendantLimit == 0);
+		
+		if (totalOnly) {
+			expandTotalOnly(results, conceptIds, direct);
+		} else {
+			final Options descendantExpandOptions = descendantOptions.get("expand", Options.class);
+			expandConcepts(results, conceptIds, direct, descendantLimit, descendantExpandOptions);
+		}
+		
+		if (log.isDebugEnabled()) {
+			log.debug("Spent {}ms expanding {}{}{}descendants for {} concept(s)", 
+				w.elapsed(TimeUnit.MILLISECONDS),
+				totalOnly ? "total number of " : "", 
+				stated ? "stated " : "inferred ",
+				direct ? "direct " : "direct and indirect ",		
+				conceptIds.size());
 		}
 	}
+
+	private void expandTotalOnly(final List<SnomedConcept> results, final Set<String> conceptIds, final boolean direct) {
+		final List<String> fieldsToLoad;
+		
+		if (stated) {
+			fieldsToLoad = ImmutableList.of(
+				SnomedConceptDocument.Fields.ID,
+				SnomedConceptDocument.Fields.STATED_PARENTS,
+				SnomedConceptDocument.Fields.STATED_ANCESTORS
+			);
+		} else {
+			fieldsToLoad = ImmutableList.of(
+				SnomedConceptDocument.Fields.ID,
+				SnomedConceptDocument.Fields.PARENTS,
+				SnomedConceptDocument.Fields.ANCESTORS
+			);
+		}		
+
+		final boolean singleConcept = (conceptIds.size() == 1);
+		
+		final int limit;
+		if (singleConcept) {
+			// The "total" count we get from the first query result is the number of descendants on this concept
+			limit = 0;
+		} else {
+			// We need to load all concept documents and distribute the "total" count amongst all ancestors
+			limit = batchLimit;
+		}
+		
+		final RevisionSearcher searcher = context().service(RevisionSearcher.class);
+		final Query<SnomedConceptDocument> query = Query.select(SnomedConceptDocument.class)
+			.fields(fieldsToLoad)
+			.where(Expressions.bool()
+				.filter(active())
+				.filter(createDescendantFilter(conceptIds, direct))
+				.build())
+			.limit(limit)
+			.build();
+
+		
+		if (singleConcept) {
+
+			// The "total" number returned from Hits is equal to the number of descendants on the single concept
+			try {
+				
+				final Hits<SnomedConceptDocument> descendantHits = searcher.search(query);
+				final SnomedConcepts singleConceptDescendants = new SnomedConcepts(0, descendantHits.getTotal());
+				
+				for (final SnomedConcept ancestor : results) {
+					setDescendants(ancestor, singleConceptDescendants);
+				}
+				
+				return;
+				
+			} catch (IOException e) {
+				throw SnowowlRuntimeException.wrap(e);
+			}
+		
+		}
+		
+		// The Multiset keeps track of the number of descendants seen so far (by parent/ancestor concept ID) 
+		Multiset<String> descendantCounts = null;
+		
+		final Stream<Hits<SnomedConceptDocument>> stream = searcher.stream(query);
+		final Iterator<Hits<SnomedConceptDocument>> itr = stream.iterator();
+		
+		while (itr.hasNext()) {
+			final Hits<SnomedConceptDocument> batch = itr.next();
+			
+			if (batch.getTotal() < 1) {
+				// No descendants found whatsoever
+				final SnomedConcepts emptyDescendants = new SnomedConcepts(0, 0);
+				for (SnomedConcept ancestor : results) {
+					setDescendants(ancestor, emptyDescendants);
+				}
+				
+				return;
+			}
+
+			if (descendantCounts == null) {
+				descendantCounts = HashMultiset.create(conceptIds.size());
+			}
+			
+			for (final SnomedConceptDocument descendant : batch) {
+				// Add +1 to the descendant counters for all parent/ancestors that we have seen in this batch
+				registerRelevantAncestors(descendantCounts, descendant, conceptIds, direct);
+			}
+		}
+		
+		// Populate total descendant counts based on the information collected
+		for (final SnomedConcept ancestor : results) {
+			final int total = descendantCounts.count(ancestor.getId());
+			final SnomedConcepts descendants = new SnomedConcepts(0, total);
+			setDescendants(ancestor, descendants);
+		}
+	}
+
+	private Expression createDescendantFilter(final Set<String> conceptIds, boolean direct) {
+		final ExpressionBuilder descendantFilter = Expressions.bool();
+		
+		// Add direct parents filter
+		if (stated) {
+			descendantFilter.should(statedParents(conceptIds));
+		} else {
+			descendantFilter.should(parents(conceptIds));
+		}
+		
+		if (direct) {
+			return descendantFilter.build();
+		}
 	
+		// Add indirect ancestors filter as well if not in direct mode
+		if (stated) {
+			descendantFilter.should(statedAncestors(conceptIds));
+		} else {
+			descendantFilter.should(ancestors(conceptIds));				
+		}
+		
+		return descendantFilter.build();
+	}
+
+	private void registerRelevantAncestors(
+		final Multiset<String> descendantCounts, 
+		final SnomedConceptDocument descendant, 
+		final Set<String> conceptIds, 
+		final boolean direct
+	) {
+		// Always collect direct parent IDs
+		if (stated) {
+			registerRelevantAncestors(descendantCounts, descendant.getStatedParents(), conceptIds);
+		} else {
+			registerRelevantAncestors(descendantCounts, descendant.getParents(), conceptIds);
+		}
+	
+		if (direct) {
+			return;
+		}
+		
+		// Collect indirect ancestor IDs as well if not in direct mode
+		if (stated) {
+			registerRelevantAncestors(descendantCounts, descendant.getStatedAncestors(), conceptIds);
+		} else {
+			registerRelevantAncestors(descendantCounts, descendant.getAncestors(), conceptIds);
+		}
+	}
+
+	private void registerRelevantAncestors(
+		final Multiset<String> descendantCounts, 
+		final LongSortedSet ancestorIdsOfDescendant,
+		final Set<String> conceptIds
+	) {
+		for (var itr = ancestorIdsOfDescendant.iterator(); itr.hasNext(); /* empty */) {
+			final String id = Long.toString(itr.next());
+			if (conceptIds.contains(id)) {
+				descendantCounts.add(id);
+			}
+		}
+	}
+
+	private void expandConcepts(
+		final List<SnomedConcept> results, 
+		final Set<String> conceptIds, 
+		final boolean direct, 
+		final int limit, 
+		final Options descendantExpandOptions
+	) {
+		final SnomedConceptSearchRequestBuilder descendantSearchRequestBuilder = SnomedRequests.prepareSearchConcept();
+		
+		/*
+		 * Contrary to the low-level queries in "createDescendantFilter" below, we only
+		 * need a single filter for the search request ("ancestors" cover both direct
+		 * and indirect parentage).
+		 */
+		if (direct) {
+			if (stated) {
+				descendantSearchRequestBuilder.filterByStatedParents(conceptIds);
+			} else {
+				descendantSearchRequestBuilder.filterByParents(conceptIds);
+			}
+		} else {
+			if (stated) {
+				descendantSearchRequestBuilder.filterByStatedAncestors(conceptIds);
+			} else {
+				descendantSearchRequestBuilder.filterByAncestors(conceptIds);
+			}
+		}
+		
+		final ListMultimap<String, SnomedConcept> descendantsByAncestorId = ArrayListMultimap.create();
+		
+		descendantSearchRequestBuilder.setLimit(batchLimit)
+			.setLocales(locales())
+			.setExpand(descendantExpandOptions)
+			.sortBy(SnomedConceptDocument.Fields.ID)
+			.stream(context())
+			.flatMap(SnomedConcepts::stream)
+			.forEachOrdered(descendant -> registerRelevantAncestors(descendantsByAncestorId, descendant, conceptIds, direct));
+
+		for (SnomedConcept ancestor : results) {
+			final List<SnomedConcept> descendants = descendantsByAncestorId.get(ancestor.getId());
+			final int total = descendants.size();
+			
+			/*
+			 * We can only enforce the requested limit at this point, as a per-ancestor
+			 * total can not be collected from the search request alone, it can only be
+			 * computed after we get to know which concept belongs to which ancestor.
+			 */
+			final List<SnomedConcept> limitedDescendants = ImmutableList.copyOf(descendants.subList(0, Ints.min(limit, descendants.size())));
+			final SnomedConcepts descendantConcepts = new SnomedConcepts(limitedDescendants, null, limit, total);
+			setDescendants(ancestor, descendantConcepts);
+		}
+	}
+
+	private void registerRelevantAncestors(
+		final Multimap<String, SnomedConcept> descendantsByAncestorId, 
+		final SnomedConcept descendant, 
+		final Set<String> conceptIds, 
+		final boolean direct
+	) {
+		final Set<String> parentIds;
+		
+		// Always collect direct parent IDs
+		if (stated) {
+			parentIds = ImmutableSet.copyOf(descendant.getStatedParentIdsAsString());
+		} else {
+			parentIds = ImmutableSet.copyOf(descendant.getParentIdsAsString());
+		}
+		
+		for (final String relevantParentId : Sets.intersection(parentIds, conceptIds)) {
+			descendantsByAncestorId.put(relevantParentId, descendant);
+		}
+
+		if (direct) {
+			return;
+		}
+		
+		final Set<String> ancestorIds;
+		
+		// Collect indirect ancestor IDs as well if not in direct mode
+		if (stated) {
+			ancestorIds = ImmutableSet.copyOf(descendant.getStatedAncestorIdsAsString());
+		} else {
+			ancestorIds = ImmutableSet.copyOf(descendant.getAncestorIdsAsString());
+		}
+
+		for (final String relevantAncestorId : Sets.intersection(ancestorIds, conceptIds)) {
+			descendantsByAncestorId.put(relevantAncestorId, descendant);
+		}
+	}
+
+	private void setDescendants(final SnomedConcept ancestor, final SnomedConcepts descendants) {
+		if (stated) {
+			ancestor.setStatedDescendants(descendants);
+		} else {
+			ancestor.setDescendants(descendants);
+		}
+	}
 }


### PR DESCRIPTION
- Stream large result sets
- Move total descendant count-only cases to a separate method
- Collect descendant concepts with a search request otherwise
- Use configured limit in SnomedDescendantsExpander