### PR TITLE
Broken oss win pkg

### DIFF
--- a/releng/com.b2international.snowowl.server.update/assembly/oss-win.xml
+++ b/releng/com.b2international.snowowl.server.update/assembly/oss-win.xml
@@ -32,8 +32,7 @@
 			<directory>${project.basedir}/assembly/common</directory>
 			<outputDirectory></outputDirectory>
 			<excludes>
-				<!-- Exclude all *.sh file, as we will add 755 permission later during 
-					copy -->
+				<!-- Exclude all *.sh file from win package -->
 				<exclude>**/*.sh</exclude>
 			</excludes>
 		</fileSet>

--- a/releng/com.b2international.snowowl.server.update/assembly/oss-win.xml
+++ b/releng/com.b2international.snowowl.server.update/assembly/oss-win.xml
@@ -4,21 +4,28 @@
 	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
 	<id>oss</id>
 	<formats>
-		<format>tar.gz</format>
-		<format>dir</format> <!-- Required for packaging to RPM -->
+		<format>zip</format>
 	</formats>
 	<fileSets>
 		<!-- Equinox server base content -->
 		<fileSet>
-			<directory>${linux.product.path}/configuration</directory>
+			<directory>${win.product.path}/configuration</directory>
 			<outputDirectory>configuration</outputDirectory>
 		</fileSet>
 		<fileSet>
-			<directory>${linux.product.path}/plugins</directory>
+			<directory>${win.product.path}/plugins</directory>
 			<outputDirectory>plugins</outputDirectory>
 			<excludes>
 				<exclude>org.eclipse.equinox.launcher.*</exclude>
 			</excludes>
+		</fileSet>
+		<fileSet>
+			<directory>${win.product.path}/plugins</directory>
+			<outputDirectory>plugins</outputDirectory>
+			<includes>
+				<include>org.eclipse.justj.openjdk.hotspot.jre.full.win32.x86_64_*</include>
+				<include>org.eclipse.justj.openjdk.hotspot.jre.full.win32.x86_64_*/**/*</include>
+			</includes>
 		</fileSet>
 		<!-- Common files -->		
 		<fileSet>
@@ -29,15 +36,6 @@
 					copy -->
 				<exclude>**/*.sh</exclude>
 			</excludes>
-		</fileSet>
-		<!-- Copy *.sh from common folder -->
-		<fileSet>
-			<directory>${project.basedir}/assembly/common</directory>
-			<outputDirectory></outputDirectory>
-			<fileMode>0755</fileMode>
-			<includes>
-				<include>**/*.sh</include>
-			</includes>
 		</fileSet>
 		<!-- Copy release files from the ROOT of the repository -->
 		<fileSet>

--- a/releng/com.b2international.snowowl.server.update/assembly/oss.xml
+++ b/releng/com.b2international.snowowl.server.update/assembly/oss.xml
@@ -28,6 +28,8 @@
 				<!-- Exclude all *.sh file, as we will add 755 permission later during 
 					copy -->
 				<exclude>**/*.sh</exclude>
+				<!-- Exclude all *.bat files from linux packages -->
+				<exclude>**/*.bat</exclude>
 			</excludes>
 		</fileSet>
 		<!-- Copy *.sh from common folder -->

--- a/releng/com.b2international.snowowl.server.update/pom.xml
+++ b/releng/com.b2international.snowowl.server.update/pom.xml
@@ -18,6 +18,7 @@
 		<product.id>com.b2international.snowowl.server</product.id>
 		<so.products.directory>${products.directory}/${product.id}</so.products.directory>
 		<linux.product.path>${so.products.directory}/linux/gtk/x86_64/${product.rootFolder}</linux.product.path>
+		<win.product.path>${so.products.directory}/win32/win32/x86_64/${product.rootFolder}</win.product.path>
 	</properties>
 
 	<dependencies>
@@ -56,7 +57,7 @@
 				<artifactId>maven-assembly-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>package-oss</id>
+						<id>package-oss-unix</id>
 						<phase>package</phase>
 						<goals>
 							<goal>single</goal>
@@ -65,6 +66,17 @@
 							<workDirectory>${project.build.directory}/assembly/oss</workDirectory>
 							<descriptor>${basedir}/assembly/oss.xml</descriptor>
 							<tarLongFileMode>gnu</tarLongFileMode>
+						</configuration>
+					</execution>
+					<execution>
+						<id>package-oss-win</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<workDirectory>${project.build.directory}/assembly/oss</workDirectory>
+							<descriptor>${basedir}/assembly/oss-win.xml</descriptor>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
This PR fixes the broken Windows package to include the proper win32 JRE instead of the Linux one.