### PR TITLE
SO-5904: ECL search disable synonym token filter

### DIFF
--- a/commons/com.b2international.index/src/com/b2international/index/query/TextPredicate.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/TextPredicate.java
@@ -101,15 +101,19 @@ public final class TextPredicate extends Predicate {
 		if (ignoreStopwords) {
 			return withAnalyzer((analyzer == Analyzers.TOKENIZED_SYNONYMS || analyzer == Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS) ? Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS : Analyzers.TOKENIZED_IGNORE_STOPWORDS);
 		} else {
-			return withAnalyzer(analyzer == Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS ? Analyzers.TOKENIZED_SYNONYMS : null);
+			return withAnalyzer(analyzer == Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS ? Analyzers.TOKENIZED_SYNONYMS : Analyzers.TOKENIZED);
 		}
 	}
 	
-	public TextPredicate withSynonyms(boolean enableSynonyms) {
+	public TextPredicate withSynonyms(Boolean enableSynonyms) {
+		// if enableSynonyms is not a valid boolean value keep it unchanged, use the default set in the mapping
+		if (enableSynonyms == null) {
+			return this;
+		}
 		if (enableSynonyms) {
 			return withAnalyzer((analyzer == Analyzers.TOKENIZED_IGNORE_STOPWORDS || analyzer == Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS) ? Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS : Analyzers.TOKENIZED_SYNONYMS);
 		} else {
-			return withAnalyzer(analyzer == Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS ? Analyzers.TOKENIZED_IGNORE_STOPWORDS : null);
+			return withAnalyzer(analyzer == Analyzers.TOKENIZED_SYNONYMS_IGNORE_STOPWORDS ? Analyzers.TOKENIZED_IGNORE_STOPWORDS : Analyzers.TOKENIZED);
 		}
 	}
 

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/ecl/EclEvaluationRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/ecl/EclEvaluationRequest.java
@@ -500,7 +500,11 @@ public abstract class EclEvaluationRequest<C extends ServiceProvider> implements
 
 		switch (lexicalSearchType) {
 			case MATCH:
-				return termMatchExpression(com.b2international.snowowl.core.request.search.TermFilter.match().term(term).build());
+				return termMatchExpression(com.b2international.snowowl.core.request.search.TermFilter.match().term(term)
+						// make sure we disable case sensitivity and synonyms
+						.caseSensitive(false)
+						.synonyms(false)
+						.build());
 			case WILD:
 				final String regex = term.replace("*", ".*");
 				return termRegexExpression(regex);

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/search/TermFilter.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/search/TermFilter.java
@@ -47,7 +47,7 @@ public abstract class TermFilter implements Serializable {
 	 * 
 	 * <li>All terms present match on a case insensitive, ASCII folded, possessive removed, split text type field (usually the <b>term</b> field) with fuzziness enabled with hardcoded 10 expansions of 1 character difference (Levenshtein distance).
 	 * 
-	 * Additionally stopwords can be ignored and case sensitivity can be enabled/disabled.
+	 * Additionally stopwords can be ignored, case sensitivity can be enabled/disabled and synonyms can be included if needed.
 	 * 
 	 * @return {@link MatchTermFilter.Builder}
 	 */


### PR DESCRIPTION
This PR fixes a minor lexical search issue in ECL filtering related to using a search analyzer that includes synonyms of the search string. While this is okay for user interfaces, during ECL evaluation this should be disabled by default when using the `match` lexical search type.

https://snowowl.atlassian.net/browse/SO-5904