### PR TITLE
SO-5905: wild matches should be case insensitive (8.x)

### DIFF
--- a/commons/com.b2international.index/src/com/b2international/index/es/query/Es8QueryBuilder.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/query/Es8QueryBuilder.java
@@ -475,7 +475,7 @@ public class Es8QueryBuilder {
 	}
 	
 	private void visit(RegexpPredicate regexp) {
-		deque.push(QueryBuilders.regexp(r -> r.boost(this.boost).field(toFieldPath(regexp)).value(regexp.getArgument())));
+		deque.push(QueryBuilders.regexp(r -> r.boost(this.boost).field(toFieldPath(regexp)).value(regexp.getArgument()).caseInsensitive(regexp.isCaseInsensitive())));
 	}
 	
 	private void visit(RangePredicate<?> range) {

--- a/commons/com.b2international.index/src/com/b2international/index/es/query/EsQueryBuilder.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/query/EsQueryBuilder.java
@@ -392,7 +392,7 @@ public final class EsQueryBuilder {
 	}
 	
 	private void visit(RegexpPredicate regexp) {
-		deque.push(QueryBuilders.regexpQuery(toFieldPath(regexp), regexp.getArgument()));
+		deque.push(QueryBuilders.regexpQuery(toFieldPath(regexp), regexp.getArgument()).caseInsensitive(regexp.isCaseInsensitive()));
 	}
 	
 	private void visit(RangePredicate<?> range) {

--- a/commons/com.b2international.index/src/com/b2international/index/query/Expressions.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/Expressions.java
@@ -239,7 +239,11 @@ public class Expressions {
 	}
 	
 	public static RegexpPredicate regexp(String field, String regexp) {
-		return new RegexpPredicate(field, regexp);
+		return regexp(field, regexp, false);
+	}
+	
+	public static RegexpPredicate regexp(String field, String regexp, boolean caseInsensitive) {
+		return new RegexpPredicate(field, regexp, caseInsensitive);
 	}
 	
 	public static Expression dismaxWithScoreCategories(Expression...disjuncts) {

--- a/commons/com.b2international.index/src/com/b2international/index/query/RegexpPredicate.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/RegexpPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2020-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,20 @@ package com.b2international.index.query;
  */
 public final class RegexpPredicate extends SingleArgumentPredicate<String> {
 
-	RegexpPredicate(String field, String regexp) {
+	private final boolean caseInsensitive;
+	
+	RegexpPredicate(String field, String regexp, boolean caseInsensitive) {
 		super(field, regexp);
+		this.caseInsensitive = caseInsensitive;
+	}
+	
+	public boolean isCaseInsensitive() {
+		return caseInsensitive;
 	}
 	
 	@Override
 	public String toString() {
-		return String.format("%s = regexp(%s)", getField(), getArgument());
+		return String.format("%s = regexp(%s)%s", getField(), getArgument(), isCaseInsensitive() ? "[ci]" : "[cs]");
 	}
 
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/ecl/EclEvaluationRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/ecl/EclEvaluationRequest.java
@@ -507,9 +507,9 @@ public abstract class EclEvaluationRequest<C extends ServiceProvider> implements
 						.build());
 			case WILD:
 				final String regex = term.replace("*", ".*");
-				return termRegexExpression(regex);
+				return termRegexExpression(regex, true);
 			case REGEX:
-				return termRegexExpression(term);
+				return termRegexExpression(term, false);
 			case EXACT:
 				return termCaseInsensitiveExpression(term);
 			default:
@@ -545,7 +545,7 @@ public abstract class EclEvaluationRequest<C extends ServiceProvider> implements
 		return throwUnsupported("Unable to provide case insensitive term expression for term filter: " + term);		
 	}
 
-	protected Expression termRegexExpression(String regex) {
+	protected Expression termRegexExpression(String regex, boolean caseInsensitive) {
 		return throwUnsupported("Unable to provide regex term expression for term filter: " + regex);
 	}
 

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/ecl/EclEvaluationRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/ecl/EclEvaluationRequest.java
@@ -501,8 +501,7 @@ public abstract class EclEvaluationRequest<C extends ServiceProvider> implements
 		switch (lexicalSearchType) {
 			case MATCH:
 				return termMatchExpression(com.b2international.snowowl.core.request.search.TermFilter.match().term(term)
-						// make sure we disable case sensitivity and synonyms
-						.caseSensitive(false)
+						// make sure we disable synonyms when performing an ECL search
 						.synonyms(false)
 						.build());
 			case WILD:

--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequestPropertyFilterTest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequestPropertyFilterTest.java
@@ -16,7 +16,7 @@
 package com.b2international.snowowl.snomed.core.ecl;
 
 import static com.b2international.snowowl.test.commons.snomed.RandomSnomedIdentiferGenerator.generateDescriptionId;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.util.*;
 
@@ -233,6 +233,31 @@ public class SnomedEclEvaluationRequestPropertyFilterTest extends BaseSnomedEclE
 			
 		final Expression actual = eval("* {{ term = \"history\" }}");
 		final Expression expected = SnomedDocument.Expressions.ids(List.of(Concepts.ROOT_CONCEPT));
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void termWildCaseInsensitive() throws Exception {
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+				.id(generateDescriptionId())
+				.active(true)
+				.moduleId(Concepts.MODULE_SCT_CORE)
+				.term("History related concept")
+				.conceptId(Concepts.ROOT_CONCEPT)
+				.typeId(Concepts.SYNONYM)
+				.build());
+		
+		indexRevision(MAIN, SnomedDescriptionIndexEntry.builder()
+				.id(generateDescriptionId())
+				.active(true)
+				.moduleId(Concepts.MODULE_SCT_CORE)
+				.term("Concept with history")
+				.conceptId(Concepts.MODULE_SCT_CORE)
+				.typeId(Concepts.SYNONYM)
+				.build());
+			
+		final Expression actual = eval("* {{ term = wild:\"*history*\" }}");
+		final Expression expected = SnomedDocument.Expressions.ids(List.of(Concepts.ROOT_CONCEPT, Concepts.MODULE_SCT_CORE));
 		assertEquals(expected, actual);
 	}
 	

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequest.java
@@ -628,8 +628,8 @@ final class SnomedEclEvaluationRequest extends EclEvaluationRequest<BranchContex
 	}
 	
 	@Override
-	protected Expression termRegexExpression(String regex) {
-		return SnomedDescriptionIndexEntry.Expressions.matchTermRegex(regex);
+	protected Expression termRegexExpression(String regex, boolean caseInsensitive) {
+		return Expressions.regexp(SnomedDescriptionIndexEntry.Fields.TERM, regex, caseInsensitive);
 	}
 	
 	@Override


### PR DESCRIPTION
This is the backport of PR #1206 