### PR TITLE
feat(index): support branch name and path aliases

### DIFF
--- a/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchPathAliasTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchPathAliasTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2023 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.index.revision;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.Assert.*;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.b2international.commons.exceptions.BadRequestException;
+import com.b2international.commons.exceptions.NotFoundException;
+import com.b2international.index.revision.RevisionFixtures.RevisionData;
+import com.google.common.collect.ImmutableSortedSet;
+
+/**
+ * @since 9.0
+ */
+public class RevisionBranchPathAliasTest extends BaseRevisionIndexTest {
+
+	@Override
+	protected Collection<Class<?>> getTypes() {
+		return List.of(RevisionData.class);
+	}
+	
+	@Test
+	public void createBranchWithAlias() throws Exception {
+		String branchA = createBranch(MAIN, "a");
+		
+		assertTrue(branching().updateNameAliases(branchA, ImmutableSortedSet.of("b")));
+		
+		// using the path alias the system should be able to get the branch
+		RevisionBranch doc = getBranch("MAIN/b");
+		assertThat(doc.getName()).isEqualTo("a");
+		assertThat(doc.getPath()).isEqualTo("MAIN/a");
+		assertThat(doc.getNameAliases()).isEqualTo(ImmutableSortedSet.of("b"));
+		assertThat(doc.getPathAliases()).isEqualTo(ImmutableSortedSet.of("MAIN/b"));
+	}
+	
+	@Test
+	public void conflictsWithPath() throws Exception {
+		String branchA = createBranch(MAIN, "a");
+		String branchB = createBranch(MAIN, "b");
+	
+		assertThatExceptionOfType(BadRequestException.class)
+			.isThrownBy(() -> branching().updateNameAliases(branchA, ImmutableSortedSet.of("b")))
+			.withMessage("Conflicting path aliases when trying to update nameAliases of 'MAIN/a' to '[b]'");
+	}
+	
+	@Test
+	public void conflictsWithPathAlias() throws Exception {
+		String branchA = createBranch(MAIN, "a");
+		String branchB = createBranch(MAIN, "b");
+		
+		assertTrue(branching().updateNameAliases(branchA, ImmutableSortedSet.of("c")));
+	
+		assertThatExceptionOfType(BadRequestException.class)
+			.isThrownBy(() -> branching().updateNameAliases(branchB, ImmutableSortedSet.of("c")))
+			.withMessage("Conflicting path aliases when trying to update nameAliases of 'MAIN/b' to '[c]'");
+	}
+	
+	@Test
+	public void nullValue() throws Exception {
+		String branchA = createBranch(MAIN, "a");
+		assertFalse(branching().updateNameAliases(branchA, null));
+	}
+	
+	@Test
+	public void clearNameAliases() throws Exception {
+		String branchA = createBranch(MAIN, "a");
+		
+		// set two alias
+		assertTrue(branching().updateNameAliases(branchA, ImmutableSortedSet.of("b", "c")));
+		
+		// clear alias array
+		assertTrue(branching().updateNameAliases(branchA, ImmutableSortedSet.of()));
+		
+		// b alias should not return the branch
+		assertThatExceptionOfType(NotFoundException.class)
+			.isThrownBy(() -> getBranch("MAIN/b"));
+		assertThatExceptionOfType(NotFoundException.class)
+			.isThrownBy(() -> getBranch("MAIN/c"));
+	}
+	
+	@Test
+	public void removeNameAlias() throws Exception {
+		String branchA = createBranch(MAIN, "a");
+		
+		assertTrue(branching().updateNameAliases(branchA, ImmutableSortedSet.of("b", "c")));
+		
+		assertTrue(branching().updateNameAliases(branchA, ImmutableSortedSet.of("c")));
+		
+		// b alias should not return the branch
+		assertThatExceptionOfType(NotFoundException.class)
+			.isThrownBy(() -> getBranch("MAIN/b"));
+
+		// c alias is still functional
+		getBranch("MAIN/c");
+	}
+
+}

--- a/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchingTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchingTest.java
@@ -286,7 +286,7 @@ public class RevisionBranchingTest extends BaseRevisionIndexTest {
 	
 	private ObjectAssert<RevisionBranch> assertBranchCreate(String branchName) {
 		final String branchPath = branching().createBranch(MAIN, branchName, null, false);
-		return assertThat(branching().get(branchPath));
+		return assertThat(branching().getBranch(branchPath));
 	}
 	
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/BranchUpdateRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/BranchUpdateRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,14 @@
  */
 package com.b2international.snowowl.core.branch;
 
+import java.util.SortedSet;
+
 import com.b2international.commons.options.Metadata;
 import com.b2international.snowowl.core.domain.RepositoryContext;
 import com.b2international.snowowl.core.events.BaseRequestBuilder;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.request.RepositoryRequestBuilder;
+import com.google.common.collect.ImmutableSortedSet;
 
 /**
  * @since 5.0
@@ -28,13 +31,14 @@ public final class BranchUpdateRequestBuilder extends BaseRequestBuilder<BranchU
 
 	private final String branchPath;
 	private Metadata metadata;
+	private SortedSet<String> nameAliases;
 
 	BranchUpdateRequestBuilder(String branchPath) {
 		this.branchPath = branchPath;
 	}
 	
 	/**
-	 * Update (override) the current {@link Metadata} with the specified {@link Metadata}.  
+	 * Update (override) the current {@link Metadata} with the specified {@link Metadata}. To clear metadata, specify an empty {@link Metadata} object.
 	 * @param metadata
 	 * @return
 	 */
@@ -43,10 +47,21 @@ public final class BranchUpdateRequestBuilder extends BaseRequestBuilder<BranchU
 		return getSelf();
 	}
 	
+	/**
+	 * Update (override) the current set of name aliases assigned to the selected branch. To clear name aliases, specify an empty collection.
+	 * @param nameAliases
+	 * @return
+	 */
+	public BranchUpdateRequestBuilder setNameAliases(Iterable<String> nameAliases) {
+		this.nameAliases = nameAliases == null ? null : ImmutableSortedSet.copyOf(nameAliases);
+		return getSelf();
+	}
+	
 	@Override
 	protected Request<RepositoryContext, Boolean> doBuild() {
 		final BranchUpdateRequest req = new BranchUpdateRequest(branchPath);
 		req.setMetadata(metadata);
+		req.setNameAliases(nameAliases);
 		return req;
 	}
 


### PR DESCRIPTION
A set of name aliases can be specified for a given, existing branch. This works just like the primary path of the branch and can be used to access the branch. Only a single path alias can exist at a given time which points to a single branch document.