### PR TITLE
SO-5918: special tilde resource character support

### DIFF
--- a/commons/com.b2international.index/src/com/b2international/index/revision/Commit.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/Commit.java
@@ -150,6 +150,10 @@ public final class Commit implements WithScore {
 			return matchAny(Fields.BRANCH, branchPaths);
 		}
 		
+		public static Expression subjects(final Iterable<String> subjects) {
+			return matchAny(Fields.SUBJECTS, subjects);
+		}
+		
 		public static Expression author(final String author) {
 			return exactMatch(Fields.AUTHOR, author);
 		}

--- a/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/codesystem/CodeSystemApiTest.java
+++ b/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/codesystem/CodeSystemApiTest.java
@@ -25,8 +25,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.iterableWithSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -579,6 +578,13 @@ public class CodeSystemApiTest extends BaseResourceApiTest {
 			.buildAsync()
 			.execute(Services.bus())
 			.getSync();
+	}
+	
+	@Test
+	public void codesystem34_DisallowUsingSpecialTildeCharacterInResourceIds() throws Exception {
+		assertCodeSystemCreate(prepareCodeSystemCreateRequestBody("cs~34"))
+			.statusCode(400)
+			.body("message", equalTo("CodeSystem.id 'cs~34' uses an illegal character. Allowed characters are 'A-Za-z0-9-_'."));
 	}
 	
 	private long getCodeSystemCreatedAt(final String id) {

--- a/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/uri/ResourceURITest.java
+++ b/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/uri/ResourceURITest.java
@@ -15,7 +15,7 @@
  */
 package com.b2international.snowowl.core.uri;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 
@@ -75,4 +75,31 @@ public class ResourceURITest {
 	public void timestampPartValidation() throws Exception {
 		CodeSystem.uri("SNOMEDCT-EXT/a/b@yesterday");
 	}
+	
+	@Test
+	public void specialIdPart() throws Exception {
+		ResourceURI uri = CodeSystem.uri("SNOMEDCT-EXT~2022-01-31");
+		assertEquals("SNOMEDCT-EXT~2022-01-31", uri.getResourceId());
+		assertEquals(ResourceURI.HEAD, uri.getPath());
+	}
+	
+	@Test(expected = BadRequestException.class)
+	public void specialIdPartAndPath() throws Exception {
+		CodeSystem.uri("SNOMEDCT-EXT~2022-01-31/child");
+	}
+	
+	@Test
+	public void removeSpecialIdPart() throws Exception {
+		ResourceURI uri = CodeSystem.uri("SNOMEDCT-EXT~2022-01-31").withoutSpecialResourceIdPart();
+		assertEquals("SNOMEDCT-EXT", uri.getResourceId());
+		assertEquals(ResourceURI.HEAD, uri.getPath());
+	}
+	
+	@Test
+	public void appendSpecialIdPart() throws Exception {
+		ResourceURI uri = CodeSystem.uri("SNOMEDCT-EXT").withSpecialResourceIdPart("2022-01-31");
+		assertEquals("SNOMEDCT-EXT~2022-01-31", uri.getResourceId());
+		assertEquals(ResourceURI.HEAD, uri.getPath());
+	}
+	
 }

--- a/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/uri/ResourceURITest.java
+++ b/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/uri/ResourceURITest.java
@@ -15,7 +15,8 @@
  */
 package com.b2international.snowowl.core.uri;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
@@ -80,7 +81,7 @@ public class ResourceURITest {
 	public void specialIdPart() throws Exception {
 		ResourceURI uri = CodeSystem.uri("SNOMEDCT-EXT~2022-01-31");
 		assertEquals("SNOMEDCT-EXT~2022-01-31", uri.getResourceId());
-		assertEquals(ResourceURI.HEAD, uri.getPath());
+		assertThat(uri.getPath()).isNull();
 	}
 	
 	@Test(expected = BadRequestException.class)
@@ -88,18 +89,41 @@ public class ResourceURITest {
 		CodeSystem.uri("SNOMEDCT-EXT~2022-01-31/child");
 	}
 	
+	@Test(expected = BadRequestException.class)
+	public void specialIdPartAndEmptyPath() throws Exception {
+		CodeSystem.uri("SNOMEDCT-EXT~2022-01-31/");
+	}
+	
 	@Test
 	public void removeSpecialIdPart() throws Exception {
 		ResourceURI uri = CodeSystem.uri("SNOMEDCT-EXT~2022-01-31").withoutSpecialResourceIdPart();
-		assertEquals("SNOMEDCT-EXT", uri.getResourceId());
-		assertEquals(ResourceURI.HEAD, uri.getPath());
+		assertThat(uri.toString()).isEqualTo("codesystems/SNOMEDCT-EXT");
+		assertThat(uri.getResourceId()).isEqualTo("SNOMEDCT-EXT");
+		assertThat(uri.getPath()).isEqualTo(ResourceURI.HEAD);
 	}
 	
 	@Test
 	public void appendSpecialIdPart() throws Exception {
 		ResourceURI uri = CodeSystem.uri("SNOMEDCT-EXT").withSpecialResourceIdPart("2022-01-31");
-		assertEquals("SNOMEDCT-EXT~2022-01-31", uri.getResourceId());
-		assertEquals(ResourceURI.HEAD, uri.getPath());
+		assertThat(uri.toString()).isEqualTo("codesystems/SNOMEDCT-EXT~2022-01-31");
+		assertThat(uri.getResourceId()).isEqualTo("SNOMEDCT-EXT~2022-01-31");
+		assertThat(uri.getPath()).isNull();
+	}
+	
+	@Test
+	public void convertTimestampedSpecialURIToRegular() throws Exception {
+		ResourceURI uri = CodeSystem.uri("SNOMEDCT-EXT").withSpecialResourceIdPart("2022-01-31").withTimestampPart("@123123123");
+		ResourceURI regularForm = uri.toRegularURI();
+		
+		assertThat(uri.toString()).isEqualTo("codesystems/SNOMEDCT-EXT~2022-01-31@123123123");
+		assertThat(uri.getResourceId()).isEqualTo("SNOMEDCT-EXT~2022-01-31");
+		assertThat(uri.getPath()).isNull();
+		assertThat(uri.getTimestampPart()).isEqualTo("@123123123");
+		
+		assertThat(regularForm.toString()).isEqualTo("codesystems/SNOMEDCT-EXT/2022-01-31@123123123");
+		assertThat(regularForm.getResourceId()).isEqualTo("SNOMEDCT-EXT");
+		assertThat(regularForm.getPath()).isEqualTo("2022-01-31");
+		assertThat(regularForm.getTimestampPart()).isEqualTo("@123123123");
 	}
 	
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ResourceURI.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ResourceURI.java
@@ -22,8 +22,6 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.elasticsearch.common.Strings;
-
 import com.b2international.commons.CompareUtils;
 import com.b2international.commons.exceptions.BadRequestException;
 import com.b2international.snowowl.core.branch.Branch;
@@ -31,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 
 /**
  * @since 8.0
@@ -93,20 +92,20 @@ public final class ResourceURI implements Serializable, Comparable<ResourceURI> 
 			throw new BadRequestException("Malformed Resource URI value: '%s' must be in format '<resourceType>/<resourceId>/<path>'.", uri);
 		}
 		// ignore HEAD in path part by automatically removing it from the uri
-		this.uri = uri.replaceFirst("/HEAD", ""); 
+		this.uri = uri.replaceFirst("/HEAD", "").replaceFirst("~HEAD", ""); 
 		this.resourceType = matcher.group(1);
 		this.resourceId = matcher.group(2);
 		
 		
-		if (CompareUtils.isEmpty(matcher.group(3))) {
-			this.path = HEAD;			
-		} else {
-			// remove leading slash from match
-			this.path = matcher.group(3).substring(1);
-			if (hasSpecialResourceIdPart()) {
-				throw new BadRequestException("Resource URIs cannot use both the special tilde ('~') character and a branch path.")
+		if (hasSpecialResourceIdPart()) {
+			if (!CompareUtils.isEmpty(matcher.group(3))) {
+				throw new BadRequestException("Resource URIs cannot use both the special tilde ('~') character and a branch path. Got: %s", uri)
 					.withDeveloperMessage("For child paths use either the '~' or the '/path' alternatives. For nested deeper branch paths always use the forward slash separator.");
 			}
+			this.path = null; // when using special ID part paths cannot get any value
+		} else {
+			// remove leading slash from match
+			this.path = CompareUtils.isEmpty(matcher.group(3)) ? HEAD : matcher.group(3).substring(1);
 		}
 		
 		
@@ -146,15 +145,15 @@ public final class ResourceURI implements Serializable, Comparable<ResourceURI> 
 	}
 	
 	public boolean isLatest() {
-		return hasPath(LATEST);
+		return hasPath(LATEST) || LATEST.equals(getSpecialIdPart());
 	}
 	
 	public boolean isHead() {
-		return hasPath(HEAD);
+		return hasPath(HEAD) || HEAD.equals(getSpecialIdPart());
 	}
 	
 	public boolean isNext() {
-		return hasPath(NEXT);
+		return hasPath(NEXT) || NEXT.equals(getSpecialIdPart());
 	}
 	
 	public boolean hasPath(String path) {
@@ -166,7 +165,11 @@ public final class ResourceURI implements Serializable, Comparable<ResourceURI> 
 		if (Objects.equals(getPath(), path)) {
 			return this;
 		}
-		return Strings.isNullOrEmpty(path) ? ResourceURI.of(resourceType, resourceId) : ResourceURI.branch(resourceType, resourceId, path);
+		if (Strings.isNullOrEmpty(path)) {
+			return ResourceURI.of(resourceType, resourceId.concat(Strings.nullToEmpty(getTimestampPart())));
+		} else {
+			return ResourceURI.branch(resourceType, resourceId, path.concat(Strings.nullToEmpty(getTimestampPart())));
+		}
 	}
 
 	@JsonIgnore
@@ -174,25 +177,34 @@ public final class ResourceURI implements Serializable, Comparable<ResourceURI> 
 		if (Objects.equals(getTimestampPart(), timestampPart)) {
 			return this;
 		}
-		return withPath(getPath() + timestampPart);
+		// depending on whether we have a path segment or not append the new timestamp part
+		if (path == null) {
+			return ResourceURI.of(resourceType, resourceId.concat(timestampPart));
+		} else {
+			return ResourceURI.branch(resourceType, resourceId, Strings.nullToEmpty(path).concat(timestampPart));
+		}
 	}
 	
 	@JsonIgnore
 	public ResourceURIWithQuery withQueryPart(String query) {
-		return ResourceURIWithQuery.of(resourceType, String.join(Branch.SEPARATOR, resourceId, path), query);
+		return ResourceURIWithQuery.of(resourceType, Branch.BRANCH_PATH_JOINER.join(resourceId, path), query);
 	}
 
 	@JsonIgnore
 	public ResourceURI withoutPath() {
-		return new ResourceURI(String.join(Branch.SEPARATOR, resourceType, resourceId));
+		return new ResourceURI(Branch.BRANCH_PATH_JOINER.join(resourceType, resourceId));
 	}
 	
 	@JsonIgnore
 	public String withoutResourceType() {
-		return isHead() ? resourceId : String.join(Branch.SEPARATOR, resourceId, path);
+		return isHead() ? resourceId : Branch.BRANCH_PATH_JOINER.join(resourceId, path);
 	}
 	
 	// SPECIAL TILDE ID handling
+	
+	public String getSpecialIdPart() {
+		return hasSpecialResourceIdPart() ? extractSpecialResourceIdPart(resourceId) : null;
+	}
 	
 	@JsonIgnore
 	public boolean hasSpecialResourceIdPart() {
@@ -205,14 +217,23 @@ public final class ResourceURI implements Serializable, Comparable<ResourceURI> 
 		final int separatorIdx = resourceId.lastIndexOf(TILDE);
 		
 		if (separatorIdx > 0) {
-			return ResourceURI.of(getResourceType(), resourceId.substring(0, separatorIdx));
+			return ResourceURI.of(getResourceType(), resourceId.substring(0, separatorIdx).concat(Strings.nullToEmpty(getTimestampPart())));
 		} else {
 			return this;
 		}
 	}
 	
 	public ResourceURI withSpecialResourceIdPart(String specialResourceIdPart) {
-		return new ResourceURI(String.join(Branch.SEPARATOR, resourceType, String.join(TILDE, withoutSpecialResourceIdPart(this.resourceId), specialResourceIdPart)));
+		return specialResourceIdPart == null ? this : new ResourceURI(String.join(Branch.SEPARATOR, resourceType, String.join(TILDE, withoutSpecialResourceIdPart(this.resourceId), specialResourceIdPart)));
+	}
+	
+	@JsonIgnore
+	public ResourceURI toRegularURI() {
+		if (hasSpecialResourceIdPart()) {
+			return withoutSpecialResourceIdPart().withPath(getSpecialIdPart());
+		} else {
+			return this;
+		}
 	}
 
 	@JsonIgnore
@@ -252,23 +273,23 @@ public final class ResourceURI implements Serializable, Comparable<ResourceURI> 
 
 	public static ResourceURI branch(String resourceType, String resourceId, String path) {
 		Preconditions.checkArgument(!resourceId.contains(Branch.SEPARATOR), "Resource ID should not be an URI already. Got: %s", resourceId);
-		return new ResourceURI(String.join(Branch.SEPARATOR, resourceType, resourceId, path));
+		return new ResourceURI(Branch.BRANCH_PATH_JOINER.join(resourceType, resourceId, path));
 	}
 
 	public static ResourceURI latest(String resourceType, String resourceId) {
 		Preconditions.checkArgument(!resourceId.contains(Branch.SEPARATOR), "Resource ID should not be an URI already. Got: %s", resourceId);
-		return new ResourceURI(String.join(Branch.SEPARATOR, resourceType, resourceId, LATEST));
+		return new ResourceURI(Branch.BRANCH_PATH_JOINER.join(resourceType, resourceId, LATEST));
 	}
 	
 	public static ResourceURI next(String resourceType, String resourceId) {
 		Preconditions.checkArgument(!resourceId.contains(Branch.SEPARATOR), "Resource ID should not be an URI already. Got: %s", resourceId);
-		return new ResourceURI(String.join(Branch.SEPARATOR, resourceType, resourceId, NEXT));
+		return new ResourceURI(Branch.BRANCH_PATH_JOINER.join(resourceType, resourceId, NEXT));
 	}
 
 	public static ResourceURI of(String resourceType, String resourceId) {
 		checkNotNull(resourceType, "'resourceType' must be specified");
 		checkNotNull(resourceId, "'resourceId' must be specified");
-		return new ResourceURI(String.join(Branch.SEPARATOR, resourceType, resourceId));
+		return new ResourceURI(Branch.BRANCH_PATH_JOINER.join(resourceType, resourceId));
 	}
 
 	public ResourceURIWithQuery withQuery(String query) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/authorization/AccessControl.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/authorization/AccessControl.java
@@ -75,18 +75,16 @@ public interface AccessControl {
 		if (terminologyResourceRequest != null) {
 			TerminologyResource resource = terminologyResourceRequest.getResource(context);
 			// fetch the currently accessed (versioned, branch or base resource URI) and the base resource URI
-			ResourceURI accessedResourceURI = terminologyResourceRequest.getResourceURI(context);
-			ResourceURI resourceURI = resource.getResourceURI();
+			ResourceURI accessedResourceUri = terminologyResourceRequest.getResourceURI(context);
+			ResourceURI resourceUri = resource.getResourceURI().withoutSpecialResourceIdPart(); // always remove the special ID parts when checking entire collection access
 
 			// if the user is accessing a version branch or subbranch of the resource always check for authorization of the entire resource and then check for direct version/branch access only
-			if (!accessedResourceURI.equals(resourceURI)) {
+			if (!accessedResourceUri.equals(resourceUri)) {
 				// accept both full resourceURI as resource and without resource type (as ID/path is often enough), but always check the typeless ID first, then the full one
-				accessedResources.add(Permission.asResource(resourceURI.withoutResourceType()));
-				accessedResources.add(Permission.asResource(resourceURI.toString()));
+				registerAccessedResourceUri(accessedResources, resourceUri);
 			}
 			// accept both full resourceURI as resource and without resource type (as ID/path is often enough), but always check the typeless ID first, then the full one
-			accessedResources.add(Permission.asResource(accessedResourceURI.withoutResourceType()));
-			accessedResources.add(Permission.asResource(accessedResourceURI.toString()));
+			registerAccessedResourceUri(accessedResources, accessedResourceUri);
 			
 			
 			// if a resource that is being accessed is part of a bundle and the user has access to that bundle then it has access to the resource as well
@@ -95,6 +93,11 @@ public interface AccessControl {
 			// ensure Root bundle is not present when checking access
 			accessedResources.remove(IComponent.ROOT_ID);
 		}
+	}
+	
+	static void registerAccessedResourceUri(List<String> accessedResources, ResourceURI resourceUri) {
+		accessedResources.add(Permission.asResource(resourceUri.withoutResourceType()));
+		accessedResources.add(Permission.asResource(resourceUri.toString()));		
 	}
 
 	/**

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/Branch.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/Branch.java
@@ -57,7 +57,7 @@ public final class Branch implements MetadataHolder, Serializable {
 	 * A singleton {@link Joiner} that can be used to concatenate branch path segments into a fully usable branch path.
 	 * @see #get(String...)
 	 */
-	public static final Joiner BRANCH_PATH_JOINER = Joiner.on(SEPARATOR);
+	public static final Joiner BRANCH_PATH_JOINER = Joiner.on(SEPARATOR).skipNulls();
 	
 	/**
 	 * A singleton {@link Splitter} that can be used to break an existing branch path into its constituent segments.

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/commit/CommitInfo.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/commit/CommitInfo.java
@@ -17,6 +17,7 @@ package com.b2international.snowowl.core.commit;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.SortedSet;
 
 import com.b2international.index.revision.Commit;
 import com.b2international.index.revision.RevisionBranchPoint;
@@ -39,7 +40,7 @@ public final class CommitInfo implements Serializable {
 	}
 	
 	public static final class Fields {
-		public static final List<String> DEFAULT_FIELD_SELECTION = List.of(Commit.Fields.ID, Commit.Fields.AUTHOR, Commit.Fields.BRANCH, Commit.Fields.COMMENT, Commit.Fields.TIMESTAMP, Commit.Fields.GROUP_ID);
+		public static final List<String> DEFAULT_FIELD_SELECTION = List.of(Commit.Fields.ID, Commit.Fields.AUTHOR, Commit.Fields.BRANCH, Commit.Fields.COMMENT, Commit.Fields.TIMESTAMP, Commit.Fields.GROUP_ID, Commit.Fields.SUBJECTS);
 	}
 	
 	public static Builder builder() {
@@ -54,7 +55,8 @@ public final class CommitInfo implements Serializable {
 			.comment(doc.getComment())
 			.timestamp(doc.getTimestamp())
 			.groupId(doc.getGroupId())
-			.mergeSource(doc.getMergeSource());
+			.mergeSource(doc.getMergeSource())
+			.subjects(doc.getSubjects());
 	}
 	
 	public static Builder builder(final CommitInfo commitInfo) {
@@ -90,7 +92,7 @@ public final class CommitInfo implements Serializable {
 		private Long timestamp;
 		private String groupId;
 		private RevisionBranchPoint mergeSource;
-		private List<String> subjects;
+		private SortedSet<String> subjects;
 		private CommitInfoDetails details;
 		
 		public Builder id(final String id) {
@@ -128,7 +130,7 @@ public final class CommitInfo implements Serializable {
 			return this;
 		}
 		
-		public Builder subjects(List<String> subjects) {
+		public Builder subjects(SortedSet<String> subjects) {
 			this.subjects = subjects;
 			return this;
 		}
@@ -155,7 +157,7 @@ public final class CommitInfo implements Serializable {
 	private final Long timestamp;
 	private final String groupId;
 	private final RevisionBranchPoint mergeSource;
-	private final List<String> subjects;
+	private final SortedSet<String> subjects;
 	private final CommitInfoDetails details;
 	
 	///////////////////////
@@ -172,7 +174,7 @@ public final class CommitInfo implements Serializable {
 			final Long timestamp, 
 			final String groupId,
 			final RevisionBranchPoint mergeSource,
-			final List<String> subjects,
+			final SortedSet<String> subjects,
 			final CommitInfoDetails details) {
 		this.id = id;
 		this.branch = branch;
@@ -217,7 +219,7 @@ public final class CommitInfo implements Serializable {
 		return mergeSource;
 	}
 	
-	public List<String> getSubjects() {
+	public SortedSet<String> getSubjects() {
 		return subjects;
 	}
 	

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/commit/CommitInfoSearchRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/commit/CommitInfoSearchRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2022 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,8 @@ final class CommitInfoSearchRequest extends SearchIndexResourceRequest<Repositor
 		TIME_STAMP_FROM,
 		TIME_STAMP_TO,
 		TIME_STAMP,
-		AFFECTED_COMPONENT_ID
+		AFFECTED_COMPONENT_ID,
+		SUBJECT,
 		
 	}
 	
@@ -79,6 +80,7 @@ final class CommitInfoSearchRequest extends SearchIndexResourceRequest<Repositor
 		addSecurityFilter(context, queryBuilder);
 		addBranchClause(queryBuilder, context);
 		addBranchPrefixClause(queryBuilder);
+		addSubjectClause(queryBuilder);
 		addUserIdClause(queryBuilder);
 		addCommentClause(queryBuilder);
 		addTimeStampClause(queryBuilder);
@@ -196,6 +198,13 @@ final class CommitInfoSearchRequest extends SearchIndexResourceRequest<Repositor
 		if (containsKey(OptionKey.BRANCH)) {
 			final Collection<String> branchPaths = getCollection(OptionKey.BRANCH, String.class);
 			builder.filter(branches(branchPaths));
+		}
+	}
+	
+	private void addSubjectClause(final ExpressionBuilder builder) {
+		if (containsKey(OptionKey.SUBJECT)) {
+			final Collection<String> subjects = getCollection(OptionKey.SUBJECT, String.class);
+			builder.filter(subjects(subjects));
 		}
 	}
 	

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/commit/CommitInfoSearchRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/commit/CommitInfoSearchRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2023 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,14 @@ public final class CommitInfoSearchRequestBuilder
 	
 	public CommitInfoSearchRequestBuilder filterByBranchPrefix(final String branchPathPrefix) {
 		return addOption(BRANCH_PREFIX, branchPathPrefix);
+	}
+	
+	public CommitInfoSearchRequestBuilder filterBySubject(String subject) {
+		return addOption(SUBJECT, subject);
+	}
+	
+	public CommitInfoSearchRequestBuilder filterBySubjects(Iterable<String> subjects) {
+		return addOption(SUBJECT, subjects);
 	}
 
 	public CommitInfoSearchRequestBuilder filterByAuthor(final String author) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryTransactionContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryTransactionContext.java
@@ -90,7 +90,7 @@ public final class RepositoryTransactionContext extends DelegatingBranchContext 
 	
 	@Override
 	public Set<String> getSubjectIds() {
-		return optionalService(ResourceURI.class).map(ResourceURI::toString).map(Set::of).orElse(Set.of());
+		return optionalService(ResourceURI.class).map(ResourceURI::withoutResourceType).map(Set::of).orElse(Set.of());
 	}
 	
 	@Override

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/resource/BaseResourceSearchRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/resource/BaseResourceSearchRequest.java
@@ -33,6 +33,7 @@ import com.b2international.index.query.SortBy;
 import com.b2international.index.query.SortBy.Builder;
 import com.b2international.index.query.SortBy.Order;
 import com.b2international.snowowl.core.Resource;
+import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.authorization.AuthorizationService;
 import com.b2international.snowowl.core.domain.RepositoryContext;
@@ -196,7 +197,7 @@ public abstract class BaseResourceSearchRequest<R> extends SearchIndexResourceRe
 		
 		final AuthorizationService authz = context.optionalService(AuthorizationService.class).orElse(AuthorizationService.DEFAULT);
 		// TODO make this configurable via plugins
-		final Set<String> specialResourceIdCharacters = Set.of("~");
+		final Set<String> specialResourceIdCharacters = Set.of(ResourceURI.TILDE);
 		
 		// special check for a single resource content access request to not lookup all the visible resources for the user but to check only the one needed for faster execution
 		if (!CompareUtils.isEmpty(componentIds()) && componentIds().size() == 1) {
@@ -207,7 +208,7 @@ public abstract class BaseResourceSearchRequest<R> extends SearchIndexResourceRe
 				final String componentIdToCheck = specialResourceIdCharacters.stream()
 						.filter(componentIdValue::contains)
 						.findFirst()
-						.map(specialResourceIdCharacter -> componentIdValue.split(specialResourceIdCharacter)[0])
+						.map(ResourceURI::withoutSpecialResourceIdPart)
 						.orElse(componentIdValue);
 				
 				

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/resource/ResourceContentCompareRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/resource/ResourceContentCompareRequest.java
@@ -38,8 +38,6 @@ final class ResourceContentCompareRequest extends ResourceRequest<RepositoryCont
 
 	private static final long serialVersionUID = 1L;
 
-	private static final String SPECIAL_ID_SEPARATOR = "~";
-
 	@NotNull
 	private final ResourceURIWithQuery fromUri;
 	
@@ -66,8 +64,8 @@ final class ResourceContentCompareRequest extends ResourceRequest<RepositoryCont
 	@Override
 	public AnalysisCompareResult execute(final RepositoryContext resourceContext) {
 
-		final ResourceURI fromWithoutPath = removeSpecialIdSuffix(fromUri.getResourceUri().withoutPath());
-		final ResourceURI toWithoutPath = removeSpecialIdSuffix(toUri.getResourceUri().withoutPath());
+		final ResourceURI fromWithoutPath = fromUri.getResourceUri().withoutPath().withoutSpecialResourceIdPart();
+		final ResourceURI toWithoutPath = toUri.getResourceUri().withoutPath().withoutSpecialResourceIdPart();
 
 		if (!fromWithoutPath.equals(toWithoutPath)) {
 			throw new BadRequestException("Resource URIs should have a common root, got '%s' and '%s'", fromWithoutPath, toWithoutPath);
@@ -91,14 +89,4 @@ final class ResourceContentCompareRequest extends ResourceRequest<RepositoryCont
 		return contentRequest.execute(resourceContext);
 	}
 
-	private static ResourceURI removeSpecialIdSuffix(final ResourceURI resourceUri) {
-		final String resourceId = resourceUri.getResourceId();
-		final int separatorIdx = resourceId.lastIndexOf(SPECIAL_ID_SEPARATOR);
-		
-		if (separatorIdx > 0) {
-			return ResourceURI.of(resourceUri.getResourceType(), resourceId.substring(0, separatorIdx));
-		} else {
-			return resourceUri;
-		}
-	}
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/version/VersionCreateRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/version/VersionCreateRequest.java
@@ -99,7 +99,7 @@ public final class VersionCreateRequest implements Request<RepositoryContext, Bo
 			author = submitter;			
 		}
 		
-		if (!resource.isHead()) {
+		if (resource.getPath() != null && !resource.isHead()) {
 			throw new BadRequestException("Version '%s' cannot be created on unassigned branch '%s'", version, resource)
 				.withDeveloperMessage("Did you mean to version '%s'?", resource.withoutPath());
 		}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/uri/DefaultResourceURIPathResolver.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/uri/DefaultResourceURIPathResolver.java
@@ -71,12 +71,15 @@ public final class DefaultResourceURIPathResolver implements ResourceURIPathReso
 	}
 
 	@Override
-	public PathWithVersion resolveWithVersion(ServiceProvider context, ResourceURI uriToResolve, Resource resource) {
+	public PathWithVersion resolveWithVersion(ServiceProvider context, ResourceURI uri, Resource resource) {
 		if (resource instanceof TerminologyResource) {
 			TerminologyResource terminologyResource = (TerminologyResource) resource;
 			
+			// convert special URIs to regular ones if the terminology resource ID does not equal with the current URI's resource ID
+			final ResourceURI uriToResolve = !terminologyResource.getId().equals(uri.getResourceId()) ? uri.toRegularURI() : uri;
+			
 			// use code system working branch directly when HEAD is specified
-			if (uriToResolve.isHead()) {
+			if (uriToResolve.isHead() || uriToResolve.getPath() == null) {
 				return getResourceHeadBranch(uriToResolve, terminologyResource);
 			}
 			

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/version/VersionDocument.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/version/VersionDocument.java
@@ -565,7 +565,7 @@ public final class VersionDocument implements CommitSubject, Serializable {
 	 */
 	@JsonIgnore
 	public LocalDate getEffectiveTimeAsLocalDate() {
-		return EffectiveTimes.toDate(effectiveTime);
+		return effectiveTime == null ? null : EffectiveTimes.toDate(effectiveTime);
 	}
 	
 	/**

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/AllSnomedApiTests.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/AllSnomedApiTests.java
@@ -55,6 +55,8 @@ import com.b2international.snowowl.test.commons.SnowOwlAppRule;
  */
 @RunWith(Suite.class)
 @SuiteClasses({ 
+	// Core API test cases requiring actual terminology data, make sure it is the first test class to run
+	ResourceURITildeSupportTest.class,
 	// RF2 release handling, imported content verification
 	SnomedRf2NextReleaseImportTest.class,
 	SnomedRf2ContentImportTest.class,

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/ResourceURITildeSupportTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/ResourceURITildeSupportTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.snomed.core.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.elasticsearch.core.Map;
+import org.junit.Test;
+
+import com.b2international.snowowl.core.branch.BranchPathUtils;
+import com.b2international.snowowl.snomed.core.domain.SnomedConcepts;
+import com.b2international.snowowl.test.commons.SnomedContentRule;
+import com.b2international.snowowl.test.commons.rest.BranchBase;
+
+/**
+ * @since 9.0
+ */
+@BranchBase(isolateTests = false)
+public class ResourceURITildeSupportTest extends AbstractSnomedApiTest {
+
+	@Test
+	public void accessVersionViaTilde() throws Exception {
+		SnomedConcepts conceptsFromPath = searchConcepts(SnomedContentRule.SNOMEDCT.withPath("2002-01-31"), Map.of(), 0);
+		SnomedConcepts conceptsFromTilde = searchConcepts(SnomedContentRule.SNOMEDCT.withSpecialResourceIdPart("2002-01-31"), Map.of(), 0);
+		assertThat(conceptsFromPath.getTotal()).isEqualTo(1331);
+		assertThat(conceptsFromTilde.getTotal()).isEqualTo(1331);
+	}
+	
+	@Test
+	public void accessBranchViaTilde() throws Exception {
+		String childBranchName = "accessBranchViaTilde";
+		branching.createBranch(BranchPathUtils.createMainPath().child(childBranchName)).statusCode(201);
+		// search concepts using the same branch and 
+		SnomedConcepts conceptsFromPath = searchConcepts(SnomedContentRule.SNOMEDCT.withPath(childBranchName), Map.of(), 0);
+		SnomedConcepts conceptsFromTilde = searchConcepts(SnomedContentRule.SNOMEDCT.withSpecialResourceIdPart(childBranchName), Map.of(), 0);
+		assertThat(conceptsFromPath.getTotal()).isEqualTo(1999);
+		assertThat(conceptsFromTilde.getTotal()).isEqualTo(1999);
+	}
+	
+}


### PR DESCRIPTION
This PR adds support for `resourceId~secondaryId` URI values where the secondary ID can be either a special derivative resource ID or a direct branch ID. The system will always prefer fetching a resource with a matching ID first then and only then falls back to direct child branch access.