### PR TITLE
Introduce shortcuts to frequently used index settings

### DIFF
--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ServiceProvider.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ServiceProvider.java
@@ -25,8 +25,10 @@ import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.config.SnowOwlConfiguration;
 import com.b2international.snowowl.core.domain.DelegatingContext;
+import com.b2international.snowowl.core.domain.PagingSettingsProvider;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.jobs.JobRequests;
 import com.b2international.snowowl.core.jobs.RemoteJob;
@@ -37,7 +39,7 @@ import com.google.inject.Provider;
 /**
  * @since 4.5
  */
-public interface ServiceProvider {
+public interface ServiceProvider extends PagingSettingsProvider {
 
 	/**
 	 * @return the application-level configuration object.
@@ -139,7 +141,26 @@ public interface ServiceProvider {
 				.filter(parametersPredicate)
 				.isPresent();
 	}
+	
+	private PagingSettingsProvider pagingSettings() {
+		return service(RepositoryConfiguration.class);
+	}
 
+	@Override
+	default int getPageSize() {
+		return pagingSettings().getPageSize();
+	}
+
+	@Override
+	default int getTermPartitionSize() {
+		return pagingSettings().getTermPartitionSize();
+	}
+	
+	@Override
+	default int getCommitLimit() {
+		return pagingSettings().getCommitLimit();
+	}
+	
 	/**
 	 * Empty {@link ServiceProvider} implementation that throws {@link UnsupportedOperationException}s when trying to provide services. Useful when
 	 * testing {@link Request} implementations.
@@ -157,5 +178,4 @@ public interface ServiceProvider {
 			throw new UnsupportedOperationException("Empty service provider can't provide services. Requested: " + type);
 		}
 	};
-
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/bundle/BundleDeleteRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/bundle/BundleDeleteRequest.java
@@ -18,7 +18,6 @@ package com.b2international.snowowl.core.bundle;
 import javax.validation.constraints.NotNull;
 
 import com.b2international.snowowl.core.Resources;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.exceptions.ComponentNotFoundException;
@@ -77,13 +76,9 @@ final class BundleDeleteRequest implements Request<TransactionContext, Boolean> 
 	 * @param context 
 	 */
 	private void updateResourceBundles(TransactionContext context, ResourceDocument bundleToDelete) {
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
-		
 		ResourceRequests.prepareSearch()
 			.filterByBundleId(bundleToDelete.getId())
-			.setLimit(pageSize)
+			.setLimit(context.getPageSize())
 			.stream(context)
 			.flatMap(Resources::stream)
 			.forEach(resource -> {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/conceptmap/ConceptMapCompareRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/conceptmap/ConceptMapCompareRequest.java
@@ -27,7 +27,6 @@ import org.hibernate.validator.constraints.NotEmpty;
 import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.compare.*;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.ConceptMapMapping;
 import com.b2international.snowowl.core.domain.ConceptMapMappings;
 import com.b2international.snowowl.core.domain.RepositoryContext;
@@ -79,16 +78,12 @@ final class ConceptMapCompareRequest extends ResourceRequest<RepositoryContext, 
 	}
 
 	private List<ConceptMapMapping> fetchConceptMapMappings(ServiceProvider context, ResourceURI conceptMapUri) {
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
-
 		return ConceptMapRequests.prepareSearchConceptMapMappings()
 			.filterByActive(true)
 			.filterByConceptMap(conceptMapUri.toString())
 			.setLocales(locales())
 			.setPreferredDisplay(preferredDisplay)
-			.setLimit(pageSize)
+			.setLimit(context.getPageSize())
 			.streamAsync(context.service(IEventBus.class), req -> req.buildAsync())
 			.flatMap(ConceptMapMappings::stream)
 			.collect(Collectors.toList());

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/config/IndexConfiguration.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/config/IndexConfiguration.java
@@ -24,6 +24,7 @@ import javax.validation.constraints.Min;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import com.b2international.index.IndexClientFactory;
+import com.b2international.snowowl.core.domain.PagingSettingsProvider;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -35,7 +36,7 @@ import com.google.common.collect.Maps;
 /**
  * @since 5.0
  */
-public class IndexConfiguration {
+public class IndexConfiguration implements PagingSettingsProvider {
 
 	public static final int DEFAULT_CLUSTER_HEALTH_TIMEOUT = 300_000; // Snow Owl defaults to 5m cluster health timeout
 	public static final int DEFAULT_RESULT_WINDOW = 100_099; // Snow Owl defaults to slightly more than 100k max result window
@@ -294,16 +295,19 @@ public class IndexConfiguration {
 	}
 	
 	@JsonIgnore
+	@Override
 	public int getPageSize() {
 		return Math.min(IndexClientFactory.MAX_PAGE_SIZE, getResultWindow());
 	}
 	
 	@JsonIgnore
+	@Override
 	public int getTermPartitionSize() {
 		return Math.min(getMaxTermsCount(), getResultWindow());
 	}
 
 	@JsonIgnore
+	@Override
 	public int getCommitLimit() {
 		return Math.min(getCommitWatermarkLow(), getResultWindow());
 	}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/config/RepositoryConfiguration.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/config/RepositoryConfiguration.java
@@ -22,6 +22,8 @@ import javax.validation.constraints.Pattern;
 
 import org.hibernate.validator.constraints.NotEmpty;
 
+import com.b2international.snowowl.core.domain.PagingSettingsProvider;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.net.HostAndPort;
 
@@ -31,7 +33,7 @@ import com.google.common.net.HostAndPort;
  * 
  * @since 3.4
  */
-public class RepositoryConfiguration {
+public class RepositoryConfiguration implements PagingSettingsProvider {
 	
 	@NotEmpty
 	private String host = "0.0.0.0";
@@ -169,5 +171,23 @@ public class RepositoryConfiguration {
 	@JsonProperty
 	public void setDeploymentId(String deploymentId) {
 		this.deploymentId = deploymentId;
+	}
+
+	@JsonIgnore
+	@Override
+	public int getPageSize() {
+		return indexConfiguration.getPageSize();
+	}
+
+	@JsonIgnore
+	@Override
+	public int getTermPartitionSize() {
+		return indexConfiguration.getTermPartitionSize();
+	}
+
+	@JsonIgnore
+	@Override
+	public int getCommitLimit() {
+		return indexConfiguration.getCommitLimit();
 	}
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/PagingSettingsProvider.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/PagingSettingsProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.domain;
+
+/**
+ * @since 9.0
+ */
+public interface PagingSettingsProvider {
+
+	/**
+	 * @return the recommended page/batch size for streaming queries
+	 */
+	public int getPageSize();
+	
+	/**
+	 * @return the recommended (maximum) number of terms that should appear in a single "terms" query
+	 */
+	public int getTermPartitionSize();
+
+	/**
+	 * @return the recommended number of changes in a single commit (soft limit)
+	 */
+	public int getCommitLimit();
+}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/ResourceRepository.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/ResourceRepository.java
@@ -23,7 +23,6 @@ import com.b2international.index.revision.*;
 import com.b2international.snowowl.core.RepositoryManager;
 import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.branch.Branch;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.RepositoryContext;
 import com.b2international.snowowl.core.request.ResourceRequests;
 import com.b2international.snowowl.core.version.VersionDocument;
@@ -131,10 +130,6 @@ public final class ResourceRepository implements RevisionIndex {
 		public void run(StagingArea staging) {
 			RepositoryContext context = (RepositoryContext) staging.getContext();
 
-			final int pageSize = context.service(RepositoryConfiguration.class)
-				.getIndexConfiguration()
-				.getPageSize();
-			
 			// stage deletion of all version documents as well when deleting a resource
 			final Multimap<String, ResourceDocument> resourceUrisByTooling = HashMultimap.create();
 			staging.getRemovedObjects(ResourceDocument.class).forEach(deletedResource -> {
@@ -150,7 +145,7 @@ public final class ResourceRepository implements RevisionIndex {
 				final Set<String> resources = resourceUrisByTooling.get(toolingId).stream().map(ResourceDocument::getResourceURI).map(ResourceURI::toString).collect(Collectors.toSet());
 				
 				ResourceRequests.prepareSearchVersion()
-					.setLimit(pageSize)
+					.setLimit(context.getPageSize())
 					.filterByResources(resources)
 					.stream(context)
 					.flatMap(Versions::stream)

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/suggest/ConceptSuggestionContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/suggest/ConceptSuggestionContext.java
@@ -30,7 +30,6 @@ import com.b2international.snowowl.core.ResourceURIWithQuery;
 import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.codesystem.CodeSystem;
 import com.b2international.snowowl.core.codesystem.CodeSystemRequests;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.Concept;
 import com.b2international.snowowl.core.domain.Concepts;
 import com.b2international.snowowl.core.domain.DelegatingContext;
@@ -88,10 +87,6 @@ public final class ConceptSuggestionContext extends DelegatingContext {
 			}
 		});
 		
-		final int pageSize = service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
-		
 		// TODO optimize multiple likes specifying the same source system
 		return likes
 			.stream()
@@ -117,7 +112,7 @@ public final class ConceptSuggestionContext extends DelegatingContext {
 							.filterByCodeSystemUri(uri.getResourceUri())
 							.filterByQuery(Ecl.or(eclQueries))
 							.filterByExclusion(exclusionQuery)
-							.setLimit(pageSize)
+							.setLimit(getPageSize())
 							.setLocales(locales)
 							.stream(this)
 							.flatMap(Concepts::stream)

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/version/VersioningRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/version/VersioningRequest.java
@@ -21,7 +21,6 @@ import com.b2international.commons.exceptions.ApiException;
 import com.b2international.index.revision.Commit;
 import com.b2international.snowowl.core.api.SnowowlRuntimeException;
 import com.b2international.snowowl.core.authorization.AccessControl;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.CappedTransactionContext;
 import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.core.events.Request;
@@ -54,7 +53,7 @@ public class VersioningRequest implements Request<TransactionContext, Boolean>, 
 		log.info("Versioning components of '{}' resource...", config.getResource());
 		try {
 			// capped context to commit versioned components in the configured low watermark bulks
-			try (CappedTransactionContext versioningContext = CappedTransactionContext.create(context, getCommitLimit(context)).onCommit(this::onCommit)) {
+			try (CappedTransactionContext versioningContext = CappedTransactionContext.create(context, context.getCommitLimit()).onCommit(this::onCommit)) {
 				doVersionComponents(versioningContext);
 			}
 		} catch (Exception e) {
@@ -66,12 +65,6 @@ public class VersioningRequest implements Request<TransactionContext, Boolean>, 
 		return Boolean.TRUE;
 	}
 
-	protected final int getCommitLimit(TransactionContext context) {
-		return context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getCommitLimit();
-	}
-	
 	/**
 	 * Subclasses may override this method to update versioning properties on terminology components before creating the version. 
 	 * @param context

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/validation/ValidateRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/validation/ValidateRequest.java
@@ -35,8 +35,6 @@ import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.TerminologyResource;
 import com.b2international.snowowl.core.api.SnowowlRuntimeException;
 import com.b2international.snowowl.core.authorization.AccessControl;
-import com.b2international.snowowl.core.config.IndexConfiguration;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.events.util.Promise;
@@ -113,9 +111,6 @@ final class ValidateRequest implements Request<BranchContext, ValidationResult>,
 	}
 
 	private ValidationResult doValidate(final BranchContext context, final Writer index) throws IOException {
-		final IndexConfiguration indexConfiguration = context.service(RepositoryConfiguration.class).getIndexConfiguration();
-		final int pageSize = indexConfiguration.getPageSize();
-
 		final String branchPath = context.path();
 		final TerminologyResource resource = context.service(TerminologyResource.class);
 		final ResourceURI resourceURI = resource.getResourceURI(branchPath);
@@ -123,7 +118,7 @@ final class ValidateRequest implements Request<BranchContext, ValidationResult>,
 		final ValidationRuleSearchRequestBuilder req = ValidationRequests.rules()
 			.prepareSearch()
 			.filterByTooling(resource.getToolingId())
-			.setLimit(pageSize);
+			.setLimit(context.getPageSize());
 		
 		if (!CompareUtils.isEmpty(ruleIds)) {
 			req.filterByIds(ruleIds);
@@ -198,7 +193,7 @@ final class ValidateRequest implements Request<BranchContext, ValidationResult>,
 						final String ruleId = newIssues.ruleId;
 						final List<ValidationIssue> existingIssues = ValidationRequests.issues()
 							.prepareSearch()
-							.setLimit(pageSize)
+							.setLimit(context.getPageSize())
 							.filterByResultId(resultId)
 							.filterByResourceUri(resourceURI)
 							.filterByRule(ruleId)
@@ -290,13 +285,10 @@ final class ValidateRequest implements Request<BranchContext, ValidationResult>,
 	}
 
 	private Multimap<String, ComponentIdentifier> fetchWhiteListEntries(final BranchContext context, final Set<String> ruleIds) {
-		final IndexConfiguration indexConfiguration = context.service(RepositoryConfiguration.class).getIndexConfiguration();
-		final int pageSize = indexConfiguration.getPageSize();
-		
 		// Fetch all whitelist entries to determine whether an issue is whitelisted already or not
 		final ValidationWhiteListSearchRequestBuilder whiteListReq = ValidationRequests.whiteList()
 			.prepareSearch()
-			.setLimit(pageSize);
+			.setLimit(context.getPageSize());
 
 		// Fetch whitelist entries associated with the defined rules
 		if (!CompareUtils.isEmpty(ruleIds)) {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclRefinementEvaluator.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclRefinementEvaluator.java
@@ -42,7 +42,6 @@ import com.b2international.index.revision.RevisionSearcher;
 import com.b2international.snomed.ecl.ecl.*;
 import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.api.SnowowlRuntimeException;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.request.SearchResourceRequest;
@@ -415,17 +414,13 @@ final class SnomedEclRefinementEvaluator {
 
 		// TODO: does this request need to support filtering by group?
 		
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
-		
 		return SnomedRequests.prepareSearchMember()
 				.filterByActive(true)
 				.filterByRefSetType(SnomedRefSetType.CONCRETE_DATA_TYPE)
 				.filterByReferencedComponent(focusConceptIds)
 				.filterByProps(propFilter)
 				.setEclExpressionForm(expressionForm)
-				.setLimit(pageSize)
+				.setLimit(context.getPageSize())
 				.<Property>transformAsync(context, req -> req.build(context.path()), members -> members.stream().map(input -> {
 					return new Property(
 							input.getReferencedComponent().getId(), 
@@ -482,9 +477,6 @@ final class SnomedEclRefinementEvaluator {
 		}
 		
 		// TODO: does this request need to support filtering by group?
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
 		
 		Promise<Collection<Property>> statementsWithValue = SnomedRequests.prepareSearchRelationship()
 				.filterByActive(true)
@@ -495,7 +487,7 @@ final class SnomedEclRefinementEvaluator {
 				.filterByValues(operator, values)
 				.setEclExpressionForm(expressionForm)
 				.setFields(ID, SOURCE_ID, TYPE_ID, RELATIONSHIP_GROUP, VALUE_TYPE, NUMERIC_VALUE, STRING_VALUE)
-				.setLimit(pageSize)
+				.setLimit(context.getPageSize())
 				.transformAsync(context, req -> req.build(context.path()), relationships -> relationships.stream().map(relationship -> {
 					return new Property(
 							relationship.getSourceId(), 
@@ -549,13 +541,9 @@ final class SnomedEclRefinementEvaluator {
 			activeOwlAxiomMemberQuery.filter(SnomedRefSetMemberIndexEntry.Expressions.referencedComponentIds(focusConceptIds));
 		}
 		
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
-		
 		final Query<SnomedRefSetMemberIndexEntry> activeAxiomStatementsQuery = Query.select(SnomedRefSetMemberIndexEntry.class)
 			.where(activeOwlAxiomMemberQuery.build())
-			.limit(pageSize)
+			.limit(context.getPageSize())
 			.build();
 		
 		final Set<Property> axiomProperties = newHashSet();
@@ -678,10 +666,6 @@ final class SnomedEclRefinementEvaluator {
 			fieldsToLoad.add(RELATIONSHIP_GROUP);
 		}
 		
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
-		
 		SnomedRelationshipSearchRequestBuilder searchRelationships = SnomedRequests.prepareSearchRelationship()
 				.filterByActive(true) 
 				.filterBySources(sourceFilter)
@@ -690,7 +674,7 @@ final class SnomedEclRefinementEvaluator {
 				.filterByCharacteristicTypes(getCharacteristicTypes(expressionForm))
 				.setEclExpressionForm(expressionForm)
 				.setFields(fieldsToLoad.build())
-				.setLimit(pageSize);
+				.setLimit(context.getPageSize());
 		
 		// if a grouping refinement, then filter relationships with group >= 1
 		if (groupedRelationshipsOnly) {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/request/SnomedQueryOptimizerFactory.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/request/SnomedQueryOptimizerFactory.java
@@ -16,7 +16,6 @@
 package com.b2international.snowowl.snomed.core.request;
 
 import com.b2international.commons.options.Options;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.domain.QueryExpressionDiffs;
 import com.b2international.snowowl.core.request.QueryOptimizer;
@@ -28,11 +27,7 @@ public final class SnomedQueryOptimizerFactory implements QueryOptimizer {
 
 	@Override
 	public QueryExpressionDiffs optimize(final BranchContext context, final Options params) {
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
-
-		final SnomedQueryOptimizer delegate = new SnomedQueryOptimizer(pageSize);
+		final SnomedQueryOptimizer delegate = new SnomedQueryOptimizer(context.getPageSize());
 		return delegate.optimize(context, params);
 	}
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/version/SnomedVersioningRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/version/SnomedVersioningRequest.java
@@ -28,7 +28,6 @@ import com.b2international.index.Hits;
 import com.b2international.index.query.Query;
 import com.b2international.index.revision.Commit;
 import com.b2international.index.revision.RevisionSearcher;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.date.EffectiveTimes;
 import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.core.request.version.VersioningConfiguration;
@@ -83,25 +82,25 @@ public final class SnomedVersioningRequest extends VersioningRequest {
 		final Stream<Hits<? extends SnomedDocument>> documentsToVersion = Streams.concat(
 			Query.select(SnomedConceptDocument.class)
 				.where(SnomedDocument.Expressions.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME))
-				.limit(getCommitLimit(context))
+				.limit(context.getCommitLimit())
 				.build()
 				.stream(searcher),
 			
 			Query.select(SnomedDescriptionIndexEntry.class)
 				.where(SnomedDocument.Expressions.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME))
-				.limit(getCommitLimit(context))
+				.limit(context.getCommitLimit())
 				.build()
 				.stream(searcher),
 		
 			Query.select(SnomedRelationshipIndexEntry.class)
 				.where(SnomedDocument.Expressions.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME))
-				.limit(getCommitLimit(context))
+				.limit(context.getCommitLimit())
 				.build()
 				.stream(searcher),
 				
 			Query.select(SnomedRefSetMemberIndexEntry.class)
 				.where(SnomedDocument.Expressions.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME))
-				.limit(getCommitLimit(context))
+				.limit(context.getCommitLimit())
 				.build()
 				.stream(searcher));
 		

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/version/SnomedVersioningRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/version/SnomedVersioningRequest.java
@@ -112,9 +112,6 @@ public final class SnomedVersioningRequest extends VersioningRequest {
 		log.info("Collecting module dependencies of changed components...");
 		final Multimap<String, String> moduleDependencies = HashMultimap.create();
 		final Map<String, Long> moduleToLatestEffectiveTime = newHashMap();
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
 		
 		for (String module : ImmutableSet.copyOf(componentIdsByReferringModule.keySet())) {
 			final Collection<String> dependencies = componentIdsByReferringModule.removeAll(module);
@@ -123,7 +120,7 @@ public final class SnomedVersioningRequest extends VersioningRequest {
 					.from(type)
 					.fields(SnomedComponentDocument.Fields.ID, SnomedComponentDocument.Fields.MODULE_ID, SnomedComponentDocument.Fields.EFFECTIVE_TIME)
 					.where(SnomedComponentDocument.Expressions.ids(dependencies))
-					.limit(pageSize)
+					.limit(context.getPageSize())
 					.build()
 					.stream(searcher)
 					.flatMap(Hits::stream)

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/converter/InactivationPropertiesExpander.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/converter/InactivationPropertiesExpander.java
@@ -59,12 +59,8 @@ public final class InactivationPropertiesExpander {
 		
 		final Multimap<String, SnomedReferenceSetMember> membersByReferencedComponentId = ArrayListMultimap.create();
 
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
-
 		SnomedRequests.prepareSearchMember()
-			.setLimit(pageSize)
+			.setLimit(context.getPageSize())
 			.filterByActive(true)
 			// all association type refsets and the indicator
 			.filterByRefSet(String.format("<%s OR %s", Concepts.REFSET_ASSOCIATION_TYPE, inactivationIndicatorRefSetId))

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/converter/InactivationPropertiesExpander.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/converter/InactivationPropertiesExpander.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 
 import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.commons.options.Options;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
 import com.b2international.snowowl.snomed.common.SnomedRf2Headers;
@@ -144,11 +143,8 @@ public final class InactivationPropertiesExpander {
 
 	private Map<String, SnomedConcept> expandConceptByIdMap(final Options expand, final Set<String> componentsToExpand, final BranchContext context) {
 		final Map<String, SnomedConcept> conceptsById = Maps.newHashMap();
-		final int partitionSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getTermPartitionSize();
 		
-		Iterables.partition(componentsToExpand, partitionSize).forEach(idsFilter -> {
+		Iterables.partition(componentsToExpand, context.getTermPartitionSize()).forEach(idsFilter -> {
 			SnomedRequests.prepareSearchConcept()
 			.setLimit(idsFilter.size())
 			.filterByIds(idsFilter)

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/ComponentInactivationChangeProcessor.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/ComponentInactivationChangeProcessor.java
@@ -34,7 +34,6 @@ import com.b2international.index.revision.StagingArea;
 import com.b2international.index.revision.StagingArea.RevisionDiff;
 import com.b2international.index.revision.StagingArea.RevisionPropertyDiff;
 import com.b2international.snowowl.core.ServiceProvider;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.date.EffectiveTimes;
 import com.b2international.snowowl.core.repository.ChangeSetProcessorBase;
 import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
@@ -95,9 +94,7 @@ final class ComponentInactivationChangeProcessor extends ChangeSetProcessorBase 
 		// inactivate descriptions of inactivated concepts, take current description changes into account
 		ServiceProvider context = (ServiceProvider) staging.getContext();
 		ModuleIdProvider moduleIdProvider = context.service(ModuleIdProvider.class);
-		int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
+		int pageSize = context.getPageSize();
 		
 		if (!inactivatedConceptIds.isEmpty()) {
 			
@@ -283,9 +280,6 @@ final class ComponentInactivationChangeProcessor extends ChangeSetProcessorBase 
 	private void processReactivations(StagingArea staging, RevisionSearcher searcher, Set<String> reactivatedConceptIds, Set<String> reactivatedComponentIds) throws IOException {
 		ServiceProvider context = (ServiceProvider) staging.getContext();
 		ModuleIdProvider moduleIdProvider = context.service(ModuleIdProvider.class);
-		int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
 		
 		try {
 			Query.select(String.class)
@@ -297,7 +291,7 @@ final class ComponentInactivationChangeProcessor extends ChangeSetProcessorBase 
 					.filter(SnomedDescriptionIndexEntry.Expressions.concepts(reactivatedConceptIds))
 					.filter(SnomedDescriptionIndexEntry.Expressions.activeMemberOf(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR))
 					.build())
-				.limit(pageSize)
+				.limit(context.getPageSize())
 				.build()
 				.stream(searcher)
 				.forEachOrdered(hits -> {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/ConceptChangeProcessor.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/ConceptChangeProcessor.java
@@ -32,7 +32,6 @@ import com.b2international.index.revision.RevisionSearcher;
 import com.b2international.index.revision.StagingArea;
 import com.b2international.index.revision.StagingArea.RevisionDiff;
 import com.b2international.snowowl.core.ServiceProvider;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.repository.ChangeSetProcessorBase;
 import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
 import com.b2international.snowowl.snomed.core.domain.Acceptability;
@@ -142,9 +141,7 @@ public final class ConceptChangeProcessor extends ChangeSetProcessorBase {
 
 			// load missing documents from index, the full document, using intentionally lower page value than maxTermsCount
 			final Map<String, SnomedConceptDocument> currentConceptDocumentsById = Maps.newHashMapWithExpectedSize(missingCurrentConceptIds.size());
-			final int partitionSize = ((ServiceProvider) staging.getContext()).service(RepositoryConfiguration.class)
-				.getIndexConfiguration()
-				.getTermPartitionSize();
+			final int partitionSize = ((ServiceProvider) staging.getContext()).getTermPartitionSize();
 			
 			for (List<String> missingCurrentConceptIdsPartition : Iterables.partition(missingCurrentConceptIds, partitionSize)) {
 				Query.select(SnomedConceptDocument.class)

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/DetachedContainerChangeProcessor.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/DetachedContainerChangeProcessor.java
@@ -27,14 +27,9 @@ import com.b2international.index.query.Query;
 import com.b2international.index.revision.RevisionSearcher;
 import com.b2international.index.revision.StagingArea;
 import com.b2international.snowowl.core.ServiceProvider;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.repository.ChangeSetProcessorBase;
 import com.b2international.snowowl.snomed.common.SnomedRf2Headers;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedComponentDocument;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedDescriptionIndexEntry;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedRefSetMemberIndexEntry;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedRelationshipIndexEntry;
+import com.b2international.snowowl.snomed.datastore.index.entry.*;
 
 /**
  * Processes deleted container components and makes sure that components contained by the container will be deleted/inactivated etc. as well. 
@@ -66,9 +61,7 @@ public final class DetachedContainerChangeProcessor extends ChangeSetProcessorBa
 			return;
 		}
 		
-		final int pageSize = ((ServiceProvider) staging.getContext()).service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
+		final int pageSize = ((ServiceProvider) staging.getContext()).getPageSize();
 		
 		// deleting concepts should delete all of its descriptions, relationships, and inbound relationships
 		Query.select(SnomedDescriptionIndexEntry.class)

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/SnomedRepositoryPreCommitHook.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/SnomedRepositoryPreCommitHook.java
@@ -90,7 +90,7 @@ public final class SnomedRepositoryPreCommitHook extends BaseRepositoryPreCommit
 		final RepositoryConfiguration repositoryConfiguration = context.service(RepositoryConfiguration.class);
 		final IndexConfiguration indexConfiguration = repositoryConfiguration.getIndexConfiguration();
 		final int partitionSize = indexConfiguration.getTermPartitionSize();
-		final int pageSize = indexConfiguration.getPageSize();
+		final int pageSize = context.getPageSize();
 		
 		// initialize OWL Expression converter on the current branch
 		final SnomedOWLExpressionConverter expressionConverter = new BranchSnapshotContentRequest<>(staging.getBranchPath(), branchContext -> {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/SnomedRepositoryPreCommitHook.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/SnomedRepositoryPreCommitHook.java
@@ -36,8 +36,6 @@ import com.b2international.index.query.Query;
 import com.b2international.index.revision.RevisionSearcher;
 import com.b2international.index.revision.StagingArea;
 import com.b2international.index.revision.StagingArea.RevisionPropertyDiff;
-import com.b2international.snowowl.core.config.IndexConfiguration;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.RepositoryContext;
 import com.b2international.snowowl.core.repository.BaseRepositoryPreCommitHook;
 import com.b2international.snowowl.core.repository.ChangeSetProcessor;
@@ -87,9 +85,7 @@ public final class SnomedRepositoryPreCommitHook extends BaseRepositoryPreCommit
 	@Override
 	protected Collection<ChangeSetProcessor> getChangeSetProcessors(StagingArea staging, RevisionSearcher index) throws IOException {
 		final RepositoryContext context = ClassUtils.checkAndCast(staging.getContext(), RepositoryContext.class);
-		final RepositoryConfiguration repositoryConfiguration = context.service(RepositoryConfiguration.class);
-		final IndexConfiguration indexConfiguration = repositoryConfiguration.getIndexConfiguration();
-		final int partitionSize = indexConfiguration.getTermPartitionSize();
+		final int partitionSize = context.getTermPartitionSize();
 		final int pageSize = context.getPageSize();
 		
 		// initialize OWL Expression converter on the current branch

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/EvaluateQueryRefSetMemberRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/EvaluateQueryRefSetMemberRequest.java
@@ -28,7 +28,6 @@ import org.hibernate.validator.constraints.NotEmpty;
 
 import com.b2international.commons.options.Options;
 import com.b2international.snowowl.core.authorization.AccessControl;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.core.identity.Permission;
@@ -90,9 +89,7 @@ public final class EvaluateQueryRefSetMemberRequest extends IndexResourceRequest
 
 		final Set<String> expectedConcepts = newHashSet();
 		final Options expandOptions = expand().getOptions("referencedComponent");
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
+		final int pageSize = context.getPageSize();
 		
 		// Evaluate the query expression to find out which concepts should be in the simple type reference set
 		final Stream<MemberChange> expectedConceptChanges = SnomedRequests.prepareSearchConcept()

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptUpdateRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptUpdateRequest.java
@@ -28,7 +28,6 @@ import com.b2international.commons.exceptions.BadRequestException;
 import com.b2international.index.Hits;
 import com.b2international.index.query.Query;
 import com.b2international.index.revision.RevisionSearcher;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.date.EffectiveTimes;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.domain.TransactionContext;
@@ -109,10 +108,7 @@ public final class SnomedConceptUpdateRequest extends SnomedComponentUpdateReque
 	
 	@Override
 	public Boolean execute(TransactionContext context) {
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
-		
+		final int pageSize = context.getPageSize();
 		final SnomedConceptDocument concept = context.lookup(componentId(), SnomedConceptDocument.class);
 		final SnomedConceptDocument.Builder updatedConcept = SnomedConceptDocument.builder(concept);
 

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedMemberOfFieldFixRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedMemberOfFieldFixRequest.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.exceptions.ComponentNotFoundException;
@@ -56,12 +55,9 @@ public class SnomedMemberOfFieldFixRequest implements Request<TransactionContext
 	@Override
 	@SuppressWarnings("deprecation")
 	public Set<String> execute(TransactionContext context) {
-		Logger log = LoggerFactory.getLogger("dataset-fix-SO-5690");
-
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
-
+		final Logger log = LoggerFactory.getLogger("dataset-fix-SO-5690");
+		final int pageSize = context.getPageSize();
+		
 		Set<String> referenceSetIds = SnomedRequests.prepareSearchRefSet()
 			.all()
 			.setFields(SnomedComponentDocument.Fields.ID)

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedQueryMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedQueryMemberCreateDelegate.java
@@ -17,7 +17,6 @@ package com.b2international.snowowl.snomed.datastore.request;
 
 import java.util.Set;
 
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.snomed.cis.action.IdActionRecorder;
 import com.b2international.snowowl.snomed.common.SnomedRf2Headers;
@@ -67,13 +66,9 @@ final class SnomedQueryMemberCreateDelegate extends SnomedRefSetMemberCreateDele
 
 		// add all matching members 
 		if (!Strings.isNullOrEmpty(getProperty(SnomedRf2Headers.FIELD_QUERY))) {
-			final int pageSize = context.service(RepositoryConfiguration.class)
-				.getIndexConfiguration()
-				.getPageSize();
-			
 			SnomedRequests.prepareSearchConcept()
 				.setFields(SnomedConceptDocument.Fields.ID)
-				.setLimit(pageSize)
+				.setLimit(context.getPageSize())
 				.filterByEcl(getProperty(SnomedRf2Headers.FIELD_QUERY))
 				.build()
 				.execute(context)

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/dsv/SnomedSimpleTypeRefSetDSVExporter.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/dsv/SnomedSimpleTypeRefSetDSVExporter.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 import com.b2international.commons.http.ExtendedLocale;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.date.Dates;
 import com.b2international.snowowl.core.date.EffectiveTimes;
 import com.b2international.snowowl.core.domain.BranchContext;
@@ -132,15 +131,11 @@ public class SnomedSimpleTypeRefSetDSVExporter implements IRefSetDSVExporter {
 	 * Fetches members of the specified reference set
 	 */
 	private SearchResourceRequestIterator<SnomedConceptSearchRequestBuilder, SnomedConcepts> getMemberConceptIterator(String expand) {
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
-		
 		SnomedConceptSearchRequestBuilder builder = SnomedRequests.prepareSearchConcept()
 			.setLocales(locales)
 			.setExpand(expand)
 			.sortBy(Sort.fieldAsc(SnomedConceptDocument.Fields.ID))
-			.setLimit(pageSize);
+			.setLimit(context.getPageSize());
 		
 		if (includeInactiveMembers) {
 			builder.isMemberOf(refSetId);

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/exporter/Rf2Exporter.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/exporter/Rf2Exporter.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import com.b2international.commons.BooleanUtils;
 import com.b2international.snowowl.core.api.SnowowlRuntimeException;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.date.DateFormats;
 import com.b2international.snowowl.core.date.EffectiveTimes;
 import com.b2international.snowowl.core.domain.PageableCollectionResource;
@@ -116,10 +115,6 @@ public abstract class Rf2Exporter<B extends SnomedSearchRequestBuilder<B, R>, R 
 
 		LOG.info("Exporting {} branch to '{}'", branch, getFileName());
 
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
-		
 		// Ensure that the path leading to the export file exists
 		final Path exportFileDirectory = releaseDirectory.resolve(getRelativeDirectory());
 		Files.createDirectories(exportFileDirectory);
@@ -152,7 +147,7 @@ public abstract class Rf2Exporter<B extends SnomedSearchRequestBuilder<B, R>, R 
 						createSearchRequestBuilder()
 							.filterByModules(modules) // null value will be ignored
 							.filterByEffectiveTime(effectiveTimeStart, effectiveTimeEnd)
-							.setLimit(pageSize)
+							.setLimit(context.getPageSize())
 							.setFields(Arrays.asList(getHeader()))
 							.stream(inner)
 							.flatMap(hits -> getMappedStream(hits, context, branch))

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/validation/SnomedQueryValidationRuleEvaluator.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/validation/SnomedQueryValidationRuleEvaluator.java
@@ -32,7 +32,6 @@ import com.b2international.index.query.Expressions.ExpressionBuilder;
 import com.b2international.index.query.Query;
 import com.b2international.index.revision.RevisionSearcher;
 import com.b2international.snowowl.core.ComponentIdentifier;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.date.EffectiveTimes;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.domain.PageableCollectionResource;
@@ -94,15 +93,11 @@ public final class SnomedQueryValidationRuleEvaluator implements ValidationRuleE
 		// TODO check if the expression contains only the ID list, then skip scrolling and just report them
 		List issues[] = { null }; 
 		
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
-		
 		Query.select(String.class)
 			.from(validationQuery.getDocType())
 			.fields(SnomedDocument.Fields.ID)
 			.where(where)
-			.limit(pageSize)
+			.limit(context.getPageSize())
 			.withScores(false)
 			.build()
 			.stream(context.service(RevisionSearcher.class))

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/validation/detail/SnomedValidationIssueDetailExtension.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/validation/detail/SnomedValidationIssueDetailExtension.java
@@ -33,7 +33,6 @@ import com.b2international.index.query.Query;
 import com.b2international.index.query.Query.QueryBuilder;
 import com.b2international.index.revision.RevisionSearcher;
 import com.b2international.index.util.DecimalUtils;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.internal.validation.ValidationConfiguration;
 import com.b2international.snowowl.core.plugin.Component;
@@ -124,11 +123,7 @@ public class SnomedValidationIssueDetailExtension implements ValidationIssueDeta
 		
 		if (!issueIdsByConceptIds.isEmpty()) {
 			final Set<String> sctIds = issueIdsByConceptIds.keySet();
-			final int partitionSize = context.service(RepositoryConfiguration.class)
-				.getIndexConfiguration()
-				.getTermPartitionSize();
-
-			Iterables.partition(sctIds, partitionSize).forEach(ids -> {
+			Iterables.partition(sctIds, context.getTermPartitionSize()).forEach(ids -> {
 				Query.select(String[].class)
 					.from(SnomedConceptDocument.class)
 					.fields(SnomedConceptDocument.Fields.ID, SnomedConceptDocument.Fields.ACTIVE)

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/converter/RelationshipChangeConverter.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/converter/RelationshipChangeConverter.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 import com.b2international.commons.exceptions.BadRequestException;
 import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.commons.options.Options;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.domain.RepositoryContext;
 import com.b2international.snowowl.core.events.Request;
@@ -308,11 +307,7 @@ public final class RelationshipChangeConverter
 
 		final Map<String, String> branchesByClassificationIdMap = newHashMap();
 
-		final int partitionSize = context().service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getTermPartitionSize();
-		
-		Iterables.partition(classificationTaskIds, partitionSize).forEach(ids -> {
+		Iterables.partition(classificationTaskIds, context().getTermPartitionSize()).forEach(ids -> {
 			ClassificationRequests.prepareSearchClassification()
 				.filterByIds(ids)
 				.setLimit(ids.size())

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/ClassificationJobRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/ClassificationJobRequest.java
@@ -40,7 +40,6 @@ import com.b2international.commons.exceptions.LockedException;
 import com.b2international.index.revision.RevisionSearcher;
 import com.b2international.snowowl.core.TerminologyResource;
 import com.b2international.snowowl.core.authorization.AccessControl;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.identity.Permission;
@@ -134,13 +133,9 @@ final class ClassificationJobRequest implements Request<BranchContext, Boolean>,
 		final SnomedCoreConfiguration configuration = context.service(SnomedCoreConfiguration.class);
 		final boolean concreteDomainSupported = configuration.isConcreteDomainSupported();
 
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
-
 		final ReasonerTaxonomy taxonomy;
 		try (Locks<BranchContext> locks = Locks.forContext(DatastoreLockContextDescriptions.CLASSIFY, parentLockContext).lock(context)) {
-			taxonomy = buildTaxonomy(revisionSearcher, reasonerExcludedModuleIds, concreteDomainSupported, pageSize);
+			taxonomy = buildTaxonomy(revisionSearcher, reasonerExcludedModuleIds, concreteDomainSupported, context.getPageSize());
 		} catch (final LockedException e) {
 			throw new ReasonerApiException("Couldn't acquire exclusive access to terminology store for classification; %s", e.getMessage(), e);
 		}

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/OntologyExportRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/OntologyExportRequest.java
@@ -39,7 +39,6 @@ import com.b2international.index.revision.RevisionSearcher;
 import com.b2international.snowowl.core.TerminologyResource;
 import com.b2international.snowowl.core.attachments.AttachmentRegistry;
 import com.b2international.snowowl.core.authorization.AccessControl;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.identity.Permission;
@@ -85,11 +84,7 @@ final class OntologyExportRequest implements Request<BranchContext, String>, Acc
 		final SnomedCoreConfiguration configuration = context.service(SnomedCoreConfiguration.class);
 		final boolean concreteDomainSupportEnabled = configuration.isConcreteDomainSupported();
 		
-		final int pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
-		
-		final ReasonerTaxonomyBuilder taxonomyBuilder = new ReasonerTaxonomyBuilder(reasonerExcludedModuleIds, pageSize);
+		final ReasonerTaxonomyBuilder taxonomyBuilder = new ReasonerTaxonomyBuilder(reasonerExcludedModuleIds, context.getPageSize());
 		
 		taxonomyBuilder.addActiveConceptIds(revisionSearcher);
 		taxonomyBuilder.finishConcepts();

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/SaveJobRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/SaveJobRequest.java
@@ -105,8 +105,6 @@ final class SaveJobRequest implements Request<BranchContext, Boolean>, AccessCon
 	
 	private boolean handleConcreteDomains;
 
-	private int pageSize;
-	
 	SaveJobRequest() {}
 	
 	void setClassificationId(final String classificationId) {
@@ -150,10 +148,6 @@ final class SaveJobRequest implements Request<BranchContext, Boolean>, AccessCon
 		final IProgressMonitor monitor = context.service(IProgressMonitor.class);
 		final ClassificationTracker tracker = context.service(ClassificationTracker.class);
 		final String user = !Strings.isNullOrEmpty(userId) ? userId : context.service(User.class).getUserId();
-		
-		pageSize = context.service(RepositoryConfiguration.class)
-			.getIndexConfiguration()
-			.getPageSize();
 		
 		try (Locks<BranchContext> locks = Locks.forContext(DatastoreLockContextDescriptions.SAVE_CLASSIFICATION_RESULTS, parentLockContext)
 				.by(user)
@@ -257,7 +251,7 @@ final class SaveJobRequest implements Request<BranchContext, Boolean>, AccessCon
 			final Set<String> conceptIdsToSkip) {
 
 		ClassificationRequests.prepareSearchRelationshipChange()
-				.setLimit(pageSize)
+				.setLimit(context.getPageSize())
 				.setExpand("relationship(inferredOnly:true)")
 				.filterByClassificationId(classificationId)
 				.stream(context)
@@ -339,7 +333,7 @@ final class SaveJobRequest implements Request<BranchContext, Boolean>, AccessCon
 			final Set<String> conceptIdsToSkip) {
 
 		ClassificationRequests.prepareSearchConcreteDomainChange()
-				.setLimit(pageSize)
+				.setLimit(context.getPageSize())
 				.setExpand("concreteDomainMember(inferredOnly:true)")
 				.filterByClassificationId(classificationId)
 				.stream(context)
@@ -433,7 +427,7 @@ final class SaveJobRequest implements Request<BranchContext, Boolean>, AccessCon
 		final Multimap<SnomedConcept, SnomedConcept> equivalentConcepts = HashMultimap.create();
 		
 		ClassificationRequests.prepareSearchEquivalentConceptSet()
-				.setLimit(pageSize)
+				.setLimit(context.getPageSize())
 				.setExpand(expand)
 				.filterByClassificationId(classificationId)
 				.stream(context)

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/SaveJobRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/SaveJobRequest.java
@@ -40,7 +40,6 @@ import com.b2international.index.revision.Commit;
 import com.b2international.snowowl.core.TerminologyResource;
 import com.b2international.snowowl.core.authorization.AccessControl;
 import com.b2international.snowowl.core.branch.Branch;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.core.events.Request;
@@ -200,7 +199,7 @@ final class SaveJobRequest implements Request<BranchContext, Boolean>, AccessCon
 		applyChanges(subMonitor, context, bulkRequestBuilder);
 	
 		long resultTimeStamp = Commit.NO_COMMIT_TIMESTAMP;
-		for (List<Request<TransactionContext, ?>> partition : Iterables.partition(bulkRequestBuilder.build().getRequests(), getCommitLimit(context))) {
+		for (List<Request<TransactionContext, ?>> partition : Iterables.partition(bulkRequestBuilder.build().getRequests(), context.getCommitLimit())) {
 			final BulkRequestBuilder<TransactionContext> batchRequest = BulkRequest.create();
 			partition.forEach(request -> batchRequest.add(request));
 			
@@ -224,10 +223,6 @@ final class SaveJobRequest implements Request<BranchContext, Boolean>, AccessCon
 		}		
 	}
 	
-	private final int getCommitLimit(BranchContext context) {
-		return context.service(RepositoryConfiguration.class).getIndexConfiguration().getCommitWatermarkLow();
-	}
-
 	private void applyChanges(final SubMonitor subMonitor, 
 			final BranchContext context,
 			final BulkRequestBuilder<TransactionContext> bulkRequestBuilder) {


### PR DESCRIPTION
This PR makes the following properties available on `ServiceProvider`:

- getPageSize
- getTermPartitionSize
- getCommitLimit

Existing call chains in client classes were converted to the short form as well.