### PR TITLE
fix(deps): upgrade commons-compress to 1.26.0

### DIFF
--- a/releng/target-platform/target-platform.target
+++ b/releng/target-platform/target-platform.target
@@ -693,7 +693,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-compress</artifactId>
-				<version>1.25.0</version>
+				<version>1.26.0</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>

--- a/tests/com.b2international.snowowl.test.dependencies/META-INF/MANIFEST.MF
+++ b/tests/com.b2international.snowowl.test.dependencies/META-INF/MANIFEST.MF
@@ -46,6 +46,6 @@ Export-Package: com.b2international.snowowl.rules,
  org.testcontainers.utility
 Require-Bundle: org.junit;bundle-version="4.11.0",
  com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.10.5",
- org.apache.commons.commons-compress;bundle-version="1.25.0"
+ org.apache.commons.commons-compress;bundle-version="1.26.0"
 Bundle-ActivationPolicy: lazy
 Import-Package: org.slf4j;version="2.0.0"


### PR DESCRIPTION
Resolves security vulnerabilities of CVE-2024-25710 and CVE-2024-26308.