### PR TITLE
SO-6056: consolidate versioning timestamps

### DIFF
--- a/core/com.b2international.snowowl.core.rest.tests/.launch/core-e2e-tests.launch
+++ b/core/com.b2international.snowowl.core.rest.tests/.launch/core-e2e-tests.launch
@@ -104,6 +104,7 @@
         <setEntry value="org.apache.aries.spifly.dynamic.bundle@2:true"/>
         <setEntry value="org.apache.commons.commons-codec@default:default"/>
         <setEntry value="org.apache.commons.commons-collections4@default:default"/>
+        <setEntry value="org.apache.commons.commons-compress@default:default"/>
         <setEntry value="org.apache.commons.commons-io@default:default"/>
         <setEntry value="org.apache.commons.lang3@default:default"/>
         <setEntry value="org.apache.commons.text@default:default"/>

--- a/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/BaseResourceApiTest.java
+++ b/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/BaseResourceApiTest.java
@@ -18,9 +18,11 @@ package com.b2international.snowowl.core.rest;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
+import org.junit.Rule;
 
 import com.b2international.snowowl.core.request.ResourceRequests;
 import com.b2international.snowowl.test.commons.Services;
+import com.b2international.snowowl.test.commons.TestMethodNameRule;
 import com.b2international.snowowl.test.commons.rest.RestExtensions;
 
 /**
@@ -28,6 +30,9 @@ import com.b2international.snowowl.test.commons.rest.RestExtensions;
  */
 public abstract class BaseResourceApiTest {
 
+	@Rule 
+	public final TestMethodNameRule testName = new TestMethodNameRule();
+	
 	@After
 	public void after() {
 		ResourceRequests

--- a/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/codesystem/CodeSystemApiTest.java
+++ b/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/codesystem/CodeSystemApiTest.java
@@ -25,7 +25,8 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.iterableWithSize;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -585,6 +586,19 @@ public class CodeSystemApiTest extends BaseResourceApiTest {
 		assertCodeSystemCreate(prepareCodeSystemCreateRequestBody("cs~34"))
 			.statusCode(400)
 			.body("message", equalTo("CodeSystem.id 'cs~34' uses an illegal character. Allowed characters are 'A-Za-z0-9-_'."));
+	}
+	
+	@Test
+	public void codesystem35_DraftActiveStatusTransitionShouldBeVisibleOnFirstVersionState() throws Exception {
+		var codeSystemId = "cs35";
+		assertCodeSystemCreate(prepareCodeSystemCreateRequestBody(codeSystemId).with("status", "draft")).statusCode(201);
+		
+		assertVersionCreated(prepareVersionCreateRequestBody(CodeSystem.uri(codeSystemId), "v1", EffectiveTimes.today()))
+			.statusCode(201);
+		
+		assertCodeSystemVersionedGet(codeSystemId, "v1")
+			.statusCode(200)
+			.body("status", equalTo("active"));
 	}
 	
 	private long getCodeSystemCreatedAt(final String id) {


### PR DESCRIPTION
Fixes issues when fetching resource state using the `version.createdAt` timestamp value but the commit was made with a later timestamp value due to getting it from a different provider.

Fixes https://snowowl.atlassian.net/browse/SO-6056