### PR TITLE
SO-4992: ETag and Cache-Control header support

### DIFF
--- a/commons/com.b2international.commons/.classpath
+++ b/commons/com.b2international.commons/.classpath
@@ -6,7 +6,7 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry exported="true" kind="lib" path="lib/bucket4j-core-8.7.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/bucket4j-core-8.10.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/zjsonpatch-0.4.16.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jgrapht-core-1.5.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jheaps-0.14.jar"/>

--- a/commons/com.b2international.commons/META-INF/MANIFEST.MF
+++ b/commons/com.b2international.commons/META-INF/MANIFEST.MF
@@ -120,7 +120,7 @@ Import-Package: jakarta.el;version="[5.0.1,6.0.0)",
  jakarta.validation.valueextraction;version="[3.0.2,4.0.0)",
  org.slf4j;version="2.0.0"
 Bundle-ClassPath: .,
- lib/bucket4j-core-8.7.0.jar,
+ lib/bucket4j-core-8.10.1.jar,
  lib/zjsonpatch-0.4.16.jar,
  lib/jgrapht-core-1.5.2.jar,
  lib/jheaps-0.14.jar,

--- a/commons/com.b2international.commons/pom.xml
+++ b/commons/com.b2international.commons/pom.xml
@@ -14,7 +14,7 @@
 
 	<properties>
 		<!-- Rate limiting -->
-		<bucket4j.version>8.7.0</bucket4j.version>
+		<bucket4j.version>8.10.1</bucket4j.version>
 		<!-- RFC 6902 JSON Patch implementation - zjsonpatch requires Jackson 2.14+ and Commons Collections 4.4 -->
 		<zjsonpatch.version>0.4.16</zjsonpatch.version>
 		<!-- Graph algorithms lib -->
@@ -123,7 +123,7 @@
 								jboss-logging,
 								picocli,
 								jsr305,
-								javax.annotation-api,
+								javax.annotation-api
 							</includeArtifactIds>
 							<outputDirectory>${basedir}/lib</outputDirectory>
 						</configuration>

--- a/commons/com.b2international.commons/src/com/b2international/commons/exceptions/NotModifiedException.java
+++ b/commons/com.b2international.commons/src/com/b2international/commons/exceptions/NotModifiedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/commons/com.b2international.commons/src/com/b2international/commons/exceptions/NotModifiedException.java
+++ b/commons/com.b2international.commons/src/com/b2international/commons/exceptions/NotModifiedException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.commons.exceptions;
+
+/**
+ * @since 8.10
+ */
+public class NotModifiedException extends ApiException {
+
+	private static final long serialVersionUID = 1L;
+
+	public NotModifiedException() {
+		super("");
+	}
+	
+	@Override
+	protected Integer getStatus() {
+		return 304;
+	}
+
+}

--- a/commons/com.b2international.commons/src/com/b2international/commons/exceptions/NotModifiedException.java
+++ b/commons/com.b2international.commons/src/com/b2international/commons/exceptions/NotModifiedException.java
@@ -16,7 +16,7 @@
 package com.b2international.commons.exceptions;
 
 /**
- * @since 8.10
+ * @since 9.2
  */
 public class NotModifiedException extends ApiException {
 

--- a/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranchRef.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranchRef.java
@@ -24,10 +24,12 @@ import java.util.stream.Collectors;
 import com.b2international.index.query.Expression;
 import com.b2international.index.query.Expressions;
 import com.b2international.index.query.Expressions.ExpressionBuilder;
+import com.google.common.base.Charsets;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
 
 /**
  * Reference to a set of revision branch segments to query the contents visible from the branch at a given time.
@@ -216,6 +218,13 @@ public final class RevisionBranchRef {
 				.filter(segment -> segment.isBefore(timestamp)) // consider segments that are before the currently desired timestamp
 				.map(segment -> segment.restrictEnd(timestamp))
 				.collect(Collectors.toCollection(TreeSet::new)), deletedBranch);
+	}
+
+	/**
+	 * @return an ETag value for this branch reference
+	 */
+	public String eTag() {
+		return Hashing.murmur3_128().hashString(toString(), Charsets.UTF_8).toString();
 	}
 
 }

--- a/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/rate/RateLimitTest.java
+++ b/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/rate/RateLimitTest.java
@@ -33,8 +33,8 @@ import com.b2international.commons.exceptions.TooManyRequestsException;
 import com.b2international.snowowl.core.ApplicationContext;
 import com.b2international.snowowl.core.Resources;
 import com.b2international.snowowl.core.events.util.Response;
-import com.b2international.snowowl.core.rate.ApiConfiguration;
 import com.b2international.snowowl.core.rate.ApiPlugin;
+import com.b2international.snowowl.core.rate.RateLimitConfig;
 import com.b2international.snowowl.core.rate.RateLimitConsumption;
 import com.b2international.snowowl.core.rate.RateLimiter;
 import com.b2international.snowowl.core.request.ResourceRequests;
@@ -55,11 +55,11 @@ public class RateLimitTest {
 	public void setup() throws Exception {
 		// inject rate limit feature into the system until we run the rate limit tests
 		Environment env = ApplicationContext.getServiceForClass(Environment.class);
-		ApiConfiguration apiConfig = new ApiConfiguration();
+		RateLimitConfig rateLimitConfig = new RateLimitConfig();
 		// this means that the user is able to perform 2 requests at a time, with one second refill rate (default value, but just in case fix it here as well)
-		apiConfig.setOverdraft(2L);
-		apiConfig.setRefillRate(1L);
-		new ApiPlugin().initRateLimiter(env, apiConfig);
+		rateLimitConfig.setOverdraft(2L);
+		rateLimitConfig.setRefillRate(1L);
+		new ApiPlugin().initRateLimiter(env, rateLimitConfig);
 		this.rateLimiter = env.service(RateLimiter.class);
 		
 	}

--- a/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/rate/RateLimitTest.java
+++ b/core/com.b2international.snowowl.core.rest.tests/src/com/b2international/snowowl/core/rest/rate/RateLimitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2023-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ public class RateLimitTest {
 		Environment env = ApplicationContext.getServiceForClass(Environment.class);
 		RateLimitConfig rateLimitConfig = new RateLimitConfig();
 		// this means that the user is able to perform 2 requests at a time, with one second refill rate (default value, but just in case fix it here as well)
-		rateLimitConfig.setOverdraft(2L);
+		rateLimitConfig.setCapacity(2L);
 		rateLimitConfig.setRefillRate(1L);
 		new ApiPlugin().initRateLimiter(env, rateLimitConfig);
 		this.rateLimiter = env.service(RateLimiter.class);

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/ControllerExceptionMapper.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/ControllerExceptionMapper.java
@@ -112,6 +112,12 @@ public class ControllerExceptionMapper {
 	}
 	
 	@ExceptionHandler
+	@ResponseStatus(HttpStatus.NOT_MODIFIED)
+	public ResponseEntity<Void> handle(final NotModifiedException e) {
+		return new ResponseEntity<>(HttpStatus.NOT_MODIFIED);
+	}
+	
+	@ExceptionHandler
 	@ResponseStatus(HttpStatus.UNAUTHORIZED)
 	public ResponseEntity<RestApiError> handle(final UnauthorizedException ex) {
 		final ApiError err = ex.toApiError();

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/SnowOwlApiConfig.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/SnowOwlApiConfig.java
@@ -243,14 +243,21 @@ public class SnowOwlApiConfig extends WebMvcConfigurationSupport {
 	@Scope(scopeName = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.INTERFACES)
 	public Provider<IEventBus> eventBus(@Autowired HttpServletRequest request) {
 		final String authorization = extractAuthorizationToken(request);
-		return () -> new AuthorizedEventBus(ApplicationContext.getInstance().getServiceChecked(IEventBus.class), ImmutableMap.of(HttpHeaders.AUTHORIZATION, authorization));
+		ImmutableMap.Builder<String, String> headers = ImmutableMap.builder();
+		headers.put(HttpHeaders.AUTHORIZATION, authorization);
+		
+		if (!Strings.isNullOrEmpty(request.getHeader(ApiConfiguration.IF_NONE_MATCH_HEADER))) {
+			headers.put(ApiConfiguration.IF_NONE_MATCH_HEADER, request.getHeader(ApiConfiguration.IF_NONE_MATCH_HEADER));
+		}
+		
+		return () -> new AuthorizedEventBus(ApplicationContext.getInstance().getServiceChecked(IEventBus.class), headers.build());
 	}
 	
 	/*
 	 * Prefer Authorization header content, but allow token query parameter as well.
 	 */
 	private String extractAuthorizationToken(HttpServletRequest request) {
-		String authorizationToken = request.getHeader("Authorization");
+		String authorizationToken = request.getHeader(HttpHeaders.AUTHORIZATION);
 		if (Strings.isNullOrEmpty(authorizationToken)) {
 			authorizationToken = request.getParameter("token");
 		}

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/admin/ServerInfoRestService.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/admin/ServerInfoRestService.java
@@ -15,10 +15,9 @@
  */
 package com.b2international.snowowl.core.rest.admin;
 
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.b2international.snowowl.core.ServerInfo;
 import com.b2international.snowowl.core.events.util.Promise;
@@ -33,7 +32,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * @since 5.8
  */
 @Tag(description="Administration", name = CoreApiConfig.ADMINISTRATION)
-@Controller
+@RestController
 @RequestMapping(value = "/info") 
 public class ServerInfoRestService extends AbstractRestService {
 
@@ -42,7 +41,7 @@ public class ServerInfoRestService extends AbstractRestService {
 		description="Retrieves information about the running server, including version, available repositories, etc."
 	)
 	@RequestMapping(method = { RequestMethod.GET, RequestMethod.HEAD }, produces = { AbstractRestService.JSON_MEDIA_TYPE })
-	public @ResponseBody Promise<ServerInfo> info() {
+	public Promise<ServerInfo> info() {
 		return RepositoryRequests.prepareGetServerInfo()
 				.buildAsync()
 				.execute(getBus());

--- a/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/util/PromiseMethodReturnValueHandler.java
+++ b/core/com.b2international.snowowl.core.rest/src/com/b2international/snowowl/core/rest/util/PromiseMethodReturnValueHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2019-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,7 @@ package com.b2international.snowowl.core.rest.util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.MethodParameter;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.ResponseEntity.BodyBuilder;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.async.DeferredResult;
 import org.springframework.web.context.request.async.WebAsyncUtils;
@@ -30,6 +28,8 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.events.util.Response;
+
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * @since 7.2
@@ -54,7 +54,7 @@ public class PromiseMethodReturnValueHandler implements HandlerMethodReturnValue
 			final Promise<?> promise = (Promise<?>) returnValue;
 			final DeferredResult<ResponseEntity<?>> result = new DeferredResult<>();
 			promise
-				.thenRespond(promiseResponse -> setDeferredResult(result, promiseResponse))
+				.thenRespond(promiseResponse -> setDeferredResult(result, promiseResponse, webRequest))
 				.fail(err -> {
 					if (result.isSetOrExpired()) {
 						LOG.warn("Deferred result is already set or expired, could not deliver Throwable.", err);
@@ -70,31 +70,28 @@ public class PromiseMethodReturnValueHandler implements HandlerMethodReturnValue
 		}
 	}
 
-	private Response<?> setDeferredResult(DeferredResult<ResponseEntity<?>> result, Response<?> promiseResponse) {
+	private Response<?> setDeferredResult(DeferredResult<ResponseEntity<?>> result, Response<?> promiseResponse, NativeWebRequest webRequest) {
 		if (result.isSetOrExpired()) {
 			LOG.warn("Deferred result is already set or expired, could not deliver result {}.", promiseResponse);
-		} else { 
+		} else {
 			final Object body = promiseResponse.getBody();
 			final ResponseEntity<?> response;
 			if (body instanceof ResponseEntity<?> b) {
-				// return a custom ResponseEntity, copy it and apply headers returned from the system
-				HttpHeaders headers = b.getHeaders();
-				// append headers returned from system
-				promiseResponse.getHeaders().forEach((headerName, headerValue) -> {
-					headers.set(headerName, headerValue);
-				});
-				response = new ResponseEntity<>(b.getBody(), headers, b.getStatusCode());
-				
+				// returning a standard object as response, with the given status code and without the headers to prevent header duplication
+				response = ResponseEntity.status(b.getStatusCode()).body(b.getBody());
 			} else {
-				// returning a standard object as reponse, use HTTP 200 OK
-				BodyBuilder responseBuilder = ResponseEntity.ok();
-				// append headers returned from system
-				promiseResponse.getHeaders().forEach((headerName, headerValue) -> {
-					responseBuilder.header(headerName, headerValue);
-				});
-				response = responseBuilder
-						.body(body);
+				// returning a standard object as response, use HTTP 200 OK
+				response = ResponseEntity.ok().body(body);
 			}
+			
+			// append headers returned from system directly into the HTTP Response
+			// see Spring Security issue not being able to properly prevent duplicate caching headers
+			// https://github.com/spring-projects/spring-security/issues/12865 
+			promiseResponse.getHeaders().forEach((headerName, headerValue) -> {
+				// XXX using set header here, for most of our use cases we only need a single response header, so overwrite anything that has been injected by Spring earlier
+				webRequest.getNativeResponse(HttpServletResponse.class).setHeader(headerName, headerValue);
+			});
+			
 			result.setResult(response);
 		}
 		return null;

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/Branch.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/Branch.java
@@ -28,10 +28,12 @@ import com.b2international.index.revision.RevisionBranchMergeSource;
 import com.b2international.snowowl.core.api.IBranchPath;
 import com.b2international.snowowl.core.events.Request;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.hash.Hashing;
 
 /**
  * Represents a {@link Branch} in a terminology repository. A {@link Branch} can be uniquely identified by using its {@link #path()} and
@@ -246,6 +248,10 @@ public final class Branch implements MetadataHolder, Serializable {
 			.append(", children=").append(children).append("]");
 		return builder.toString();
 	}
-	
+
+	public String eTag() {
+		// TODO temporary branch eTag value calculation, change to use branchRef instead
+		return Hashing.murmur3_128().hashString(path(), Charsets.UTF_8).toString();
+	}
 		
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/Branch.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/branch/Branch.java
@@ -28,12 +28,10 @@ import com.b2international.index.revision.RevisionBranchMergeSource;
 import com.b2international.snowowl.core.api.IBranchPath;
 import com.b2international.snowowl.core.events.Request;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.hash.Hashing;
 
 /**
  * Represents a {@link Branch} in a terminology repository. A {@link Branch} can be uniquely identified by using its {@link #path()} and
@@ -249,9 +247,4 @@ public final class Branch implements MetadataHolder, Serializable {
 		return builder.toString();
 	}
 
-	public String eTag() {
-		// TODO temporary branch eTag value calculation, change to use branchRef instead
-		return Hashing.murmur3_128().hashString(path(), Charsets.UTF_8).toString();
-	}
-		
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/context/TerminologyResourceContentRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/context/TerminologyResourceContentRequest.java
@@ -15,16 +15,23 @@
  */
 package com.b2international.snowowl.core.context;
 
+import java.util.Objects;
+
+import com.b2international.commons.exceptions.NotModifiedException;
 import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.TerminologyResource;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.events.DelegatingRequest;
 import com.b2international.snowowl.core.events.Request;
+import com.b2international.snowowl.core.events.util.RequestHeaders;
+import com.b2international.snowowl.core.events.util.ResponseHeaders;
+import com.b2international.snowowl.core.rate.ApiConfiguration;
 import com.b2international.snowowl.core.request.BranchRealtimeContentRequest;
 import com.b2international.snowowl.core.request.BranchSnapshotContentRequest;
 import com.b2international.snowowl.core.request.RepositoryRequest;
 import com.b2international.snowowl.core.uri.ResourceURIPathResolver;
 import com.b2international.snowowl.core.uri.ResourceURIPathResolver.PathWithVersion;
+import com.google.common.base.Strings;
 
 /**
  * @since 7.5
@@ -52,7 +59,9 @@ public final class TerminologyResourceContentRequest<R> extends DelegatingReques
 		final String path = branchPathWithVersion.getPath();
 		final ResourceURI versionResourceURI = branchPathWithVersion.getVersionResourceURI();
 		
-		if (versionResourceURI != null) {
+		final boolean versionedContentAccess = versionResourceURI != null;
+		
+		if (versionedContentAccess) {
 			context = context.inject()
 				.bind(ResourceURI.class, versionResourceURI)
 				.bind(PathWithVersion.class, branchPathWithVersion)
@@ -60,7 +69,26 @@ public final class TerminologyResourceContentRequest<R> extends DelegatingReques
 		}
 		
 		return new RepositoryRequest<R>(resource.getToolingId(),
-			snapshot ? new BranchSnapshotContentRequest<>(path, next()) : new BranchRealtimeContentRequest<>(path, next())
+			snapshot ? new BranchSnapshotContentRequest<>(path, versionedContentAccess ? nextWithCaching() : next()) : new BranchRealtimeContentRequest<>(path, next())
 		).execute(context);
+	}
+
+	private Request<BranchContext, R> nextWithCaching() {
+		return ctx -> {
+			// before executing the request, check whether we have an IfNoneMatch header set in the incoming request, if yes, check the current ETag with any of the attached values, if none matches evaluate the query otherwise send back HTTP 304
+			String ifNoneMatchHeaderValue = ctx.service(RequestHeaders.class).header(ApiConfiguration.IF_NONE_MATCH_HEADER);
+			if (!Strings.isNullOrEmpty(ifNoneMatchHeaderValue) && Objects.equals(ifNoneMatchHeaderValue.replaceAll("\"", ""), ctx.branch().eTag())) {
+				throw new NotModifiedException();
+			}
+			
+			R response = next().execute(ctx);
+			// once we have the response ready calculate Cache-Control and ETag headers
+			final ApiConfiguration apiConfiguration = ctx.service(ApiConfiguration.class);
+			final ResponseHeaders responseHeaders = ctx.service(ResponseHeaders.class);
+			responseHeaders.set(ApiConfiguration.ETAG_HEADER, ctx.branch().eTag());
+			// configure HTTP Cache-Control headers here using the currently configured api.cache_control value
+			responseHeaders.set(ApiConfiguration.CACHE_CONTROL_HEADER, apiConfiguration.getCacheControl());
+			return response;
+		};
 	}
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/context/TerminologyResourceContentRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/context/TerminologyResourceContentRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2020-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.b2international.snowowl.core.context;
 import java.util.Objects;
 
 import com.b2international.commons.exceptions.NotModifiedException;
+import com.b2international.index.revision.RevisionSearcher;
 import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.TerminologyResource;
 import com.b2international.snowowl.core.domain.BranchContext;
@@ -59,9 +60,7 @@ public final class TerminologyResourceContentRequest<R> extends DelegatingReques
 		final String path = branchPathWithVersion.getPath();
 		final ResourceURI versionResourceURI = branchPathWithVersion.getVersionResourceURI();
 		
-		final boolean versionedContentAccess = versionResourceURI != null;
-		
-		if (versionedContentAccess) {
+		if (versionResourceURI != null) {
 			context = context.inject()
 				.bind(ResourceURI.class, versionResourceURI)
 				.bind(PathWithVersion.class, branchPathWithVersion)
@@ -69,25 +68,31 @@ public final class TerminologyResourceContentRequest<R> extends DelegatingReques
 		}
 		
 		return new RepositoryRequest<R>(resource.getToolingId(),
-			snapshot ? new BranchSnapshotContentRequest<>(path, versionedContentAccess ? nextWithCaching() : next()) : new BranchRealtimeContentRequest<>(path, next())
+			snapshot ? new BranchSnapshotContentRequest<>(path, nextWithCaching()) : new BranchRealtimeContentRequest<>(path, next())
 		).execute(context);
 	}
 
 	private Request<BranchContext, R> nextWithCaching() {
 		return ctx -> {
-			// before executing the request, check whether we have an IfNoneMatch header set in the incoming request, if yes, check the current ETag with any of the attached values, if none matches evaluate the query otherwise send back HTTP 304
+			
+			final String eTag = ctx.service(RevisionSearcher.class).ref().eTag();
+			
+			// before executing the request, check whether we have an If-None-Match header set in the incoming request
+			// if yes, check the current ETag with any of the attached values, if none matches evaluate the query otherwise send back HTTP 304
 			String ifNoneMatchHeaderValue = ctx.service(RequestHeaders.class).header(ApiConfiguration.IF_NONE_MATCH_HEADER);
-			if (!Strings.isNullOrEmpty(ifNoneMatchHeaderValue) && Objects.equals(ifNoneMatchHeaderValue.replaceAll("\"", ""), ctx.branch().eTag())) {
+			if (!Strings.isNullOrEmpty(ifNoneMatchHeaderValue) && Objects.equals(ifNoneMatchHeaderValue.replaceAll("\"", ""), eTag)) {
 				throw new NotModifiedException();
 			}
 			
 			R response = next().execute(ctx);
+			
 			// once we have the response ready calculate Cache-Control and ETag headers
 			final ApiConfiguration apiConfiguration = ctx.service(ApiConfiguration.class);
 			final ResponseHeaders responseHeaders = ctx.service(ResponseHeaders.class);
-			responseHeaders.set(ApiConfiguration.ETAG_HEADER, ctx.branch().eTag());
-			// configure HTTP Cache-Control headers here using the currently configured api.cache_control value
+			responseHeaders.set(ApiConfiguration.ETAG_HEADER, eTag);
+			// configure HTTP Cache-Control headers here using the currently configured global api.cache_control value
 			responseHeaders.set(ApiConfiguration.CACHE_CONTROL_HEADER, apiConfiguration.getCacheControl());
+			
 			return response;
 		};
 	}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/ApiConfiguration.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/ApiConfiguration.java
@@ -15,38 +15,20 @@
  */
 package com.b2international.snowowl.core.rate;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
 
 /**
  * @since 7.2
  */
 public class ApiConfiguration {
 
-	@Min(0)
-	private long overdraft = 0L;
-	
-	@Min(1)
-	private long refillRate = 1L;
+	@Valid
+	private RateLimitConfig rateLimit = new RateLimitConfig();
 	
 	@Valid
 	private HttpConfig http = new HttpConfig();
-	
-	public long getOverdraft() {
-		return overdraft;
-	}
-	
-	public void setOverdraft(long overdraft) {
-		this.overdraft = overdraft;
-	}
-	
-	public long getRefillRate() {
-		return refillRate;
-	}
-	
-	public void setRefillRate(long refillRate) {
-		this.refillRate = refillRate;
-	}
 	
 	public HttpConfig getHttp() {
 		return http;
@@ -56,4 +38,23 @@ public class ApiConfiguration {
 		this.http = http;
 	}
 	
+	public RateLimitConfig getRateLimit() {
+		return rateLimit;
+	}
+	
+	public void setRateLimit(RateLimitConfig rateLimit) {
+		this.rateLimit = rateLimit;
+	}
+	
+	// backward compatible configuration methods
+	@JsonProperty
+	/*package*/ void setOverdraft(long overdraft) {
+		rateLimit.setOverdraft(overdraft);
+	}
+	
+	@JsonProperty
+	/*package*/ void setRefillRate(long refillRate) {
+		rateLimit.setRefillRate(refillRate);
+	}
+
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/ApiConfiguration.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/ApiConfiguration.java
@@ -63,10 +63,12 @@ public class ApiConfiguration {
 		this.http = http;
 	}
 
+	@JsonProperty("rate_limit")
 	public RateLimitConfig getRateLimit() {
 		return rateLimit;
 	}
 
+	@JsonProperty("rate_limit")
 	public void setRateLimit(RateLimitConfig rateLimit) {
 		this.rateLimit = rateLimit;
 	}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/ApiConfiguration.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/ApiConfiguration.java
@@ -18,42 +18,77 @@ package com.b2international.snowowl.core.rate;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 
 /**
  * @since 7.2
  */
 public class ApiConfiguration {
 
+	public static final String ETAG_HEADER = "ETag";
+	public static final String IF_NONE_MATCH_HEADER = "If-None-Match";
+	public static final String CACHE_CONTROL_HEADER = "Cache-Control";
+
 	@Valid
 	private RateLimitConfig rateLimit = new RateLimitConfig();
-	
+
 	@Valid
 	private HttpConfig http = new HttpConfig();
-	
+
+	/**
+	 * The default value of this configuration is the desired Cache-Control header value to set when responding to any GET requests that is targeting
+	 * a resource's content branch. Since objects in our system are stored in a revision-controlled way (along with authorization information) we are
+	 * unable to let downstream HTTP caches to cache our content without enforcing revalidation of it immediately (to prevent data leakage). Thus the
+	 * default value of this Cache-Control allows well crafted HTTP proxies to store the response in their cache, but immediately set it to stale
+	 * (max-age=0) and enforce revalidation of that stale content (must-revalidate). This ensures that we use downstream caches as much as possible by
+	 * preventing data leakage and stale responses.
+	 * 
+	 * <p>
+	 * <h3>Revalidation</h3> When a browser or proxy HTTP cache would try to use the cached response with this header they must first send a request
+	 * to the server to check whether the cached response can be used or not. All the content served by Snow Owl will have an ETag header set so that
+	 * during revalidation the client can send the ETag value in the If-None-Match header for verification. If the ETag value is still valid the cache
+	 * response can be used (HTTP 304 Not Modified will be sent back as response), if not the server will generate a new response and send it back to
+	 * update the cached value.
+	 * </p>
+	 * 
+	 */
+	@NotEmpty
+	private String cacheControl = "s-maxage=0,max-age=0,must-revalidate";
+
 	public HttpConfig getHttp() {
 		return http;
 	}
-	
+
 	public void setHttp(HttpConfig http) {
 		this.http = http;
 	}
-	
+
 	public RateLimitConfig getRateLimit() {
 		return rateLimit;
 	}
-	
+
 	public void setRateLimit(RateLimitConfig rateLimit) {
 		this.rateLimit = rateLimit;
 	}
-	
+
+	@JsonProperty("cache_control")
+	public String getCacheControl() {
+		return cacheControl;
+	}
+
+	@JsonProperty("cache_control")
+	public void setCacheControl(String cacheControl) {
+		this.cacheControl = cacheControl;
+	}
+
 	// backward compatible configuration methods
 	@JsonProperty
-	/*package*/ void setOverdraft(long overdraft) {
+	/* package */ void setOverdraft(long overdraft) {
 		rateLimit.setOverdraft(overdraft);
 	}
-	
+
 	@JsonProperty
-	/*package*/ void setRefillRate(long refillRate) {
+	/* package */ void setRefillRate(long refillRate) {
 		rateLimit.setRefillRate(refillRate);
 	}
 

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/ApiPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/ApiPlugin.java
@@ -36,14 +36,14 @@ public class ApiPlugin extends Plugin {
 	@Override
 	public void init(SnowOwlConfiguration configuration, Environment env) throws Exception {
 		ApiConfiguration apiConfig = configuration.getModuleConfig(ApiConfiguration.class);
-		initRateLimiter(env, apiConfig);
+		initRateLimiter(env, apiConfig.getRateLimit());
 	}
 
 	@VisibleForTesting
-	public void initRateLimiter(Environment env, ApiConfiguration apiConfig) {
+	public void initRateLimiter(Environment env, RateLimitConfig config) {
 		final RateLimiter limiter;
-		if (apiConfig.getOverdraft() > 0L) {
-			limiter = new Bucket4jRateLimiter(apiConfig);
+		if (config.getOverdraft() > 0L) {
+			limiter = new Bucket4jRateLimiter(config);
 		} else {
 			limiter = RateLimiter.NOOP;
 		}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/ApiPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/ApiPlugin.java
@@ -36,6 +36,7 @@ public class ApiPlugin extends Plugin {
 	@Override
 	public void init(SnowOwlConfiguration configuration, Environment env) throws Exception {
 		ApiConfiguration apiConfig = configuration.getModuleConfig(ApiConfiguration.class);
+		env.services().registerService(ApiConfiguration.class, apiConfig);
 		initRateLimiter(env, apiConfig.getRateLimit());
 	}
 

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/ApiPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/ApiPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2019-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public class ApiPlugin extends Plugin {
 	@VisibleForTesting
 	public void initRateLimiter(Environment env, RateLimitConfig config) {
 		final RateLimiter limiter;
-		if (config.getOverdraft() > 0L) {
+		if (config.isEnabled()) {
 			limiter = new Bucket4jRateLimiter(config);
 		} else {
 			limiter = RateLimiter.NOOP;

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/Bucket4jRateLimiter.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/Bucket4jRateLimiter.java
@@ -21,11 +21,12 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.MapMaker;
 
-import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 import io.github.bucket4j.ConsumptionProbe;
 
 /**
+ * For more information see Bucket4j reference: https://bucket4j.com/8.10.1/toc.html#bandwidth
+ * 
  * @since 7.2
  */
 final class Bucket4jRateLimiter implements RateLimiter {
@@ -40,20 +41,22 @@ final class Bucket4jRateLimiter implements RateLimiter {
 
 	@Override
 	public RateLimitConsumption consume(String username) {
-		Bucket bucket = bucketByUser.get(username);
-		if (bucket == null) {
-			bucket = createNewBucket();
-			bucketByUser.put(username, bucket);
-		}
-		
+		final Bucket bucket = bucketByUser.computeIfAbsent(username, this::createNewBucket);
 		final ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);
 		return new RateLimitConsumption(probe.isConsumed(), probe.getRemainingTokens(), TimeUnit.NANOSECONDS.toSeconds(probe.getNanosToWaitForRefill()));
 	}
 
-	private Bucket createNewBucket() {
-		long overdraft = configuration.getOverdraft();
-		Bandwidth bandwidth = Bandwidth.builder().capacity(overdraft).refillGreedy(configuration.getRefillRate(), Duration.ofSeconds(1)).build();
-		return Bucket.builder().addLimit(bandwidth).build();
+	/*
+	 * userId argument is currently unused, tempting to assign it to the Bandwidth as optional identifier via #id(...), but that only increased memory consumption without any actual gain
+	 */
+	private Bucket createNewBucket(String userId) {
+		return Bucket.builder()
+				.addLimit(bandwidth -> 
+					bandwidth
+						.capacity(configuration.getCapacity())
+						.refillGreedy(configuration.getRefillRate(), Duration.ofSeconds(1))
+				)
+				.build();
 	}
 
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/Bucket4jRateLimiter.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/Bucket4jRateLimiter.java
@@ -30,10 +30,10 @@ import io.github.bucket4j.ConsumptionProbe;
  */
 final class Bucket4jRateLimiter implements RateLimiter {
 
-	private final ApiConfiguration configuration;
+	private final RateLimitConfig configuration;
 	private final ConcurrentMap<String, Bucket> bucketByUser;
 
-	public Bucket4jRateLimiter(ApiConfiguration configuration) {
+	public Bucket4jRateLimiter(RateLimitConfig configuration) {
 		this.configuration = configuration;
 		this.bucketByUser = new MapMaker().makeMap();
 	}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/RateLimitConfig.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/RateLimitConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2023-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package com.b2international.snowowl.core.rate;
 
-import javax.validation.constraints.Min;
+import jakarta.validation.constraints.Min;
 
 /**
  * @since 8.10

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/RateLimitConfig.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/RateLimitConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.rate;
+
+import javax.validation.constraints.Min;
+
+/**
+ * @since 8.10
+ */
+public class RateLimitConfig {
+
+	@Min(0)
+	private long overdraft = 0L;
+	
+	@Min(1)
+	private long refillRate = 1L;
+	
+	public long getOverdraft() {
+		return overdraft;
+	}
+	
+	public void setOverdraft(long overdraft) {
+		this.overdraft = overdraft;
+	}
+	
+	public long getRefillRate() {
+		return refillRate;
+	}
+	
+	public void setRefillRate(long refillRate) {
+		this.refillRate = refillRate;
+	}
+	
+}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/RateLimitConfig.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/RateLimitConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,25 +15,41 @@
  */
 package com.b2international.snowowl.core.rate;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import jakarta.validation.constraints.Min;
 
 /**
- * @since 8.10
+ * @since 9.2
  */
 public class RateLimitConfig {
 
+	private static final long RATE_LIMITING_DISABLED = 0L;
+
+	/**
+	 * Capacity is the maximum number of tokens a single user can have. Defaults to zero which disables rate-limiting. Increase to any positive number to enable it.
+	 */
 	@Min(0)
-	private long overdraft = 0L;
+	private long capacity = RATE_LIMITING_DISABLED;
 	
+	/**
+	 * Refill rate describes the number of tokens that will be refilled after one second in a given user's token pool. Defaults to refill 1 token per second.
+	 */
 	@Min(1)
 	private long refillRate = 1L;
 	
-	public long getOverdraft() {
-		return overdraft;
+	public long getCapacity() {
+		return capacity;
 	}
 	
-	public void setOverdraft(long overdraft) {
-		this.overdraft = overdraft;
+	public void setCapacity(long capacity) {
+		this.capacity = capacity;
+	}
+	
+	@JsonProperty("overdraft")
+	/* package */ void setOverdraft(long overdraft) {
+		setCapacity(overdraft);
 	}
 	
 	public long getRefillRate() {
@@ -42,6 +58,11 @@ public class RateLimitConfig {
 	
 	public void setRefillRate(long refillRate) {
 		this.refillRate = refillRate;
+	}
+
+	@JsonIgnore
+	public boolean isEnabled() {
+		return getCapacity() > RATE_LIMITING_DISABLED;
 	}
 	
 }

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/AllSnomedApiTests.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/AllSnomedApiTests.java
@@ -34,6 +34,7 @@ import com.b2international.snowowl.snomed.core.request.*;
 import com.b2international.snowowl.snomed.core.rest.branches.SnomedBranchingApiTest;
 import com.b2international.snowowl.snomed.core.rest.branches.SnomedMergeApiTest;
 import com.b2international.snowowl.snomed.core.rest.branches.SnomedMergeConflictTest;
+import com.b2international.snowowl.snomed.core.rest.cache.SnomedApiCacheControlTest;
 import com.b2international.snowowl.snomed.core.rest.classification.SnomedClassificationApiTest;
 import com.b2international.snowowl.snomed.core.rest.components.*;
 import com.b2international.snowowl.snomed.core.rest.ext.SnomedComponentEffectiveTimeRestoreTest;
@@ -125,6 +126,8 @@ import com.b2international.snowowl.test.commons.SnowOwlAppRule;
 	SnomedMrcmTest.class,
 	ResourceLockRequestTest.class,
 	ResourceSearchRequestTest.class,
+	// HTTP Caching
+	SnomedApiCacheControlTest.class
 })
 public class AllSnomedApiTests {
 

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/SnomedClassificationRestRequests.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/SnomedClassificationRestRequests.java
@@ -16,7 +16,6 @@
 package com.b2international.snowowl.snomed.core.rest;
 
 import static com.b2international.snowowl.test.commons.rest.RestExtensions.givenAuthenticatedRequest;
-import static com.b2international.snowowl.test.commons.rest.RestExtensions.lastPathSegment;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -28,6 +27,7 @@ import com.b2international.snowowl.core.api.IBranchPath;
 import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
 import com.b2international.snowowl.snomed.datastore.config.SnomedCoreConfiguration;
 import com.b2international.snowowl.snomed.reasoner.domain.ClassificationStatus;
+import com.b2international.snowowl.test.commons.rest.RestExtensions;
 import com.google.common.collect.ImmutableSet;
 
 import io.restassured.http.ContentType;
@@ -58,13 +58,12 @@ public abstract class SnomedClassificationRestRequests {
 				.contentType(ContentType.JSON)
 				.body(requestBody)
 				.post("/classifications")
-				.then();
+				.then()
+				.log().ifValidationFails();
 	}
 
 	public static String getClassificationJobId(ValidatableResponse response) {
-		return lastPathSegment(response.statusCode(201)
-				.extract()
-				.header("Location"));
+		return RestExtensions.assertCreated(response);
 	}
 
 	public static ValidatableResponse getClassification(IBranchPath branchPath, String classificationId) {

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/cache/SnomedApiCacheControlTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/cache/SnomedApiCacheControlTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.snomed.core.rest.cache;
+
+import org.elasticsearch.core.Map;
+import org.junit.Test;
+
+import com.b2international.snowowl.snomed.core.rest.AbstractSnomedApiTest;
+import com.b2international.snowowl.test.commons.rest.BranchBase;
+
+/**
+ * @since 8.10
+ */
+@BranchBase(isolateTests = false)
+public class SnomedApiCacheControlTest extends AbstractSnomedApiTest {
+
+	@Test
+	public void cacheControlVersioned() throws Exception {
+		assertSearchConcepts(getDefaultSnomedResourceUri().withPath("2002-01-31"), Map.of(), 10)
+			.statusCode(200)
+			.header("Cache-Control", "s-maxage=0,max-age=0,must-revalidate")
+			.header("ETag", "TODO");
+	}
+	
+	@Test
+	public void cacheControlUnversioned() throws Exception {
+		assertSearchConcepts(getDefaultSnomedResourceUri(), Map.of(), 10)
+			.statusCode(200)
+			.header("Cache-Control", "s-maxage=0,max-age=0,must-revalidate")
+			.header("ETag", "TODO");
+	}
+	
+}

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/cache/SnomedApiCacheControlTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/cache/SnomedApiCacheControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ public class SnomedApiCacheControlTest extends AbstractSnomedApiTest {
 
 	@Test
 	public void cacheControlVersioned() throws Exception {
-		assertSearchConcepts(getDefaultSnomedResourceUri().withPath("2002-01-31"), Map.of(), 10)
+		assertSearchConcepts(getDefaultSnomedResourceUri().withPath("2002-01-31"), Map.of(), 1)
 			.statusCode(200)
 			.header("Cache-Control", "s-maxage=0,max-age=0,must-revalidate")
 			.header("ETag", "TODO");
@@ -37,7 +37,7 @@ public class SnomedApiCacheControlTest extends AbstractSnomedApiTest {
 	
 	@Test
 	public void cacheControlUnversioned() throws Exception {
-		assertSearchConcepts(getDefaultSnomedResourceUri(), Map.of(), 10)
+		assertSearchConcepts(getDefaultSnomedResourceUri(), Map.of(), 1)
 			.statusCode(200)
 			.header("Cache-Control", "s-maxage=0,max-age=0,must-revalidate")
 			.header("ETag", "TODO");

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedPartialLoadingApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedPartialLoadingApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2020-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ import com.b2international.snowowl.core.ApplicationContext;
 import com.b2international.snowowl.core.context.TerminologyResourceContentRequest;
 import com.b2international.snowowl.core.context.TerminologyResourceRequest;
 import com.b2international.snowowl.core.domain.PageableCollectionResource;
+import com.b2international.snowowl.core.events.util.RequestHeaders;
+import com.b2international.snowowl.core.events.util.ResponseHeaders;
 import com.b2international.snowowl.core.identity.User;
 import com.b2international.snowowl.core.setup.Environment;
 import com.b2international.snowowl.snomed.cis.SnomedIdentifiers;
@@ -61,6 +63,8 @@ public class SnomedPartialLoadingApiTest extends AbstractSnomedApiTest {
 			)
 		).execute(ApplicationContext.getServiceForClass(Environment.class).inject()
 				.bind(User.class, User.SYSTEM)
+				.bind(RequestHeaders.class, new RequestHeaders(Map.of()))
+				.bind(ResponseHeaders.class, new ResponseHeaders())
 				.build());
 		hits.forEach(hit -> {
 			// simple assertions to parse the ID as SCT ID and effective time as short date

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedClassificationRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedClassificationRestService.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -49,7 +48,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * @since 1.0
  */
 @Tag(description="Classifications", name = SnomedApiConfig.CLASSIFICATIONS)
-@Controller
+@RestController
 @RequestMapping(value = "/classifications")
 public class SnomedClassificationRestService extends AbstractRestService {
 
@@ -66,7 +65,7 @@ public class SnomedClassificationRestService extends AbstractRestService {
 		@ApiResponse(responseCode = "404", description = "Branch not found")
 	})
 	@GetMapping(produces = { AbstractRestService.JSON_MEDIA_TYPE })
-	public @ResponseBody Promise<ClassificationTasks> getAllClassificationRuns(
+	public Promise<ClassificationTasks> getAllClassificationRuns(
 			@Parameter(description = "The resource path", required = true)
 			@RequestParam(value="path", required=false) 
 			final String path,
@@ -145,7 +144,7 @@ public class SnomedClassificationRestService extends AbstractRestService {
 		@ApiResponse(responseCode = "404", description = "Branch or classification not found")
 	})
 	@GetMapping(value = "/{classificationId}", produces = { AbstractRestService.JSON_MEDIA_TYPE })
-	public @ResponseBody Promise<ClassificationTask> getClassificationRun(
+	public Promise<ClassificationTask> getClassificationRun(
 			@Parameter(description ="The classification identifier")
 			@PathVariable(value="classificationId") 
 			final String classificationId) {
@@ -165,7 +164,7 @@ public class SnomedClassificationRestService extends AbstractRestService {
 		@ApiResponse(responseCode = "404", description = "Branch or classification not found")
 	})
 	@GetMapping(value = "/{classificationId}/equivalent-concepts", produces = { AbstractRestService.JSON_MEDIA_TYPE })
-	public @ResponseBody Promise<EquivalentConceptSets> getEquivalentConceptSets(
+	public Promise<EquivalentConceptSets> getEquivalentConceptSets(
 			@Parameter(description ="The classification identifier")
 			@PathVariable(value="classificationId") 
 			final String classificationId,
@@ -204,7 +203,7 @@ public class SnomedClassificationRestService extends AbstractRestService {
 	@GetMapping(
 			value = "/{classificationId}/relationship-changes", 
 			produces = { AbstractRestService.JSON_MEDIA_TYPE, AbstractRestService.CSV_MEDIA_TYPE })
-	public @ResponseBody Promise<RelationshipChanges> getRelationshipChanges(
+	public Promise<RelationshipChanges> getRelationshipChanges(
 			@Parameter(description ="The classification identifier")
 			@PathVariable(value="classificationId") 
 			final String classificationId,

--- a/tests/com.b2international.snowowl.test.commons/src/com/b2international/snowowl/test/commons/rest/RestExtensions.java
+++ b/tests/com.b2international.snowowl.test.commons/src/com/b2international/snowowl/test/commons/rest/RestExtensions.java
@@ -236,6 +236,7 @@ public class RestExtensions {
 	
 	public static String assertCreated(ValidatableResponse response) {
 		return lastPathSegment(response.statusCode(201)
+				.header("Location", CoreMatchers.notNullValue())
 				.extract()
 				.header("Location"));
 	}


### PR DESCRIPTION
This PR adds support for `ETag` and `Cache-Control` headers so that HTTP clients, proxies, and intermediaries can cache the responses earlier than caching only in an HTTP browser. 

~Still somewhat blocked by https://github.com/spring-projects/spring-security/issues/12865. We need to figure out a way of preventing Spring from adding the default cache-control headers when we set our own.~

Resolved the above in the meantime by explicitly setting the headers in the response before Spring can write its defaults incorrectly.

Background: https://snowowl.atlassian.net/browse/SO-4992

