### PR TITLE
Allow ObjectNode fields on ES documents

### DIFF
--- a/commons/com.b2international.index.tests/.launch/index-tcp-unit-tests.launch
+++ b/commons/com.b2international.index.tests/.launch/index-tcp-unit-tests.launch
@@ -84,6 +84,7 @@
         <setEntry value="org.apache.commons.commons-codec@default:default"/>
         <setEntry value="org.apache.commons.commons-collections4@default:default"/>
         <setEntry value="org.apache.commons.commons-compress@default:default"/>
+        <setEntry value="org.apache.commons.commons-io@default:default"/>
         <setEntry value="org.apache.commons.lang3@default:default"/>
         <setEntry value="org.apache.commons.logging@default:default"/>
         <setEntry value="org.apache.httpcomponents.httpasyncclient@default:default"/>

--- a/commons/com.b2international.index.tests/src/com/b2international/index/Fixtures.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/Fixtures.java
@@ -28,6 +28,7 @@ import com.b2international.index.mapping.FieldAlias;
 import com.b2international.index.mapping.FieldAlias.FieldAliasType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.MoreObjects;
 
 /**
@@ -469,6 +470,90 @@ public class Fixtures {
 			return Objects.hash(id, properties);
 		}
 		
+	}
+	
+	@Doc
+	public static class DataWithJson {
+		
+		@ID
+		private final String id;
+		
+		@Field(index = false)
+		private final ObjectNode model;
+		
+		@JsonCreator
+		public DataWithJson(
+			@JsonProperty("id") String id, 
+			@JsonProperty("model") ObjectNode model
+		) {
+			this.id = id;
+			this.model = model;
+		}
+		
+		public String getId() {
+			return id;
+		}
+		
+		public ObjectNode getModel() {
+			return model;
+		}
+		
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) return true;
+			if (obj == null) return false;
+			if (getClass() != obj.getClass()) return false;
+			
+			DataWithJson other = (DataWithJson) obj;
+			return Objects.equals(id, other.id) && Objects.equals(model, other.model);
+		}
+		
+		@Override
+		public int hashCode() {
+			return Objects.hash(id, model);
+		}
+	}
+	
+	@Doc
+	public static class DataWithDynamicJson {
+		
+		@ID
+		private final String id;
+
+		// Dynamic mapping is created for this field
+		private final ObjectNode model;
+		
+		@JsonCreator
+		public DataWithDynamicJson(
+			@JsonProperty("id") String id, 
+			@JsonProperty("model") ObjectNode model
+		) {
+			this.id = id;
+			this.model = model;
+		}
+		
+		public String getId() {
+			return id;
+		}
+		
+		public ObjectNode getModel() {
+			return model;
+		}
+		
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) return true;
+			if (obj == null) return false;
+			if (getClass() != obj.getClass()) return false;
+			
+			DataWithDynamicJson other = (DataWithDynamicJson) obj;
+			return Objects.equals(id, other.id) && Objects.equals(model, other.model);
+		}
+		
+		@Override
+		public int hashCode() {
+			return Objects.hash(id, model);
+		}
 	}
 	
 	@Doc

--- a/commons/com.b2international.index/src/com/b2international/index/es/admin/EsIndexAdmin.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/admin/EsIndexAdmin.java
@@ -674,7 +674,7 @@ public final class EsIndexAdmin implements IndexAdmin {
 			final String property = field.getName();
 			final Class<?> fieldType = NumericClassUtils.unwrapCollectionType(field);
 			
-			if (Map.class.isAssignableFrom(fieldType)) {
+			if (Map.class.isAssignableFrom(fieldType) || ObjectNode.class.isAssignableFrom(fieldType)) {
 				// allow dynamic mappings for dynamic objects like field using Map
 				final Map<String, Object> prop = newHashMap();
 				prop.put("type", "object");


### PR DESCRIPTION
The property `index` on the field-level annotation `Field` controls whether it becomes a source-only or a dynamically mapped object in Elasticsearch's mapping. In the latter case top-level properties of the JSON object become searchable.