### PR TITLE
SO-5901: support description languages in generic concept model

### DIFF
--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/Concept.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/Concept.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2020-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,11 @@
  */
 package com.b2international.snowowl.core.domain;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.SortedSet;
 
+import com.b2international.commons.collections.Collections3;
 import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.uri.ComponentURI;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -41,7 +43,7 @@ public final class Concept extends BaseComponent {
 	private Boolean active;
 	private String term;
 	private String iconId;
-	private SortedSet<String> alternativeTerms;
+	private SortedSet<Description> alternativeTerms;
 	
 	private List<String> parentIds;
 	private List<String> ancestorIds;
@@ -55,7 +57,7 @@ public final class Concept extends BaseComponent {
 			@JsonProperty("code") ComponentURI code, 
 			@JsonProperty("active") Boolean active, 
 			@JsonProperty("term") String term, 
-			@JsonProperty("alternativeTerms") SortedSet<String> alternativeTerms, 
+			@JsonProperty("alternativeTerms") SortedSet<Description> alternativeTerms, 
 			@JsonProperty("iconId") String iconId, 
 			@JsonProperty("parentIds") List<String> parentIds, 
 			@JsonProperty("ancestorIds") List<String> ancestorIds,
@@ -104,8 +106,8 @@ public final class Concept extends BaseComponent {
 		this.iconId = iconId;
 	}
 	
-	public void setAlternativeTerms(SortedSet<String> alternativeTerms) {
-		this.alternativeTerms = alternativeTerms;
+	public void setAlternativeTerms(Collection<Description> alternativeTerms) {
+		this.alternativeTerms = alternativeTerms == null ? null : Collections3.toImmutableSortedSet(alternativeTerms);
 	}
 	
 	public void setScore(Float score) {
@@ -115,7 +117,7 @@ public final class Concept extends BaseComponent {
 	/**
 	 * @return optionally set alternative terms for this concept, may be <code>null</code> if there are not alternative terms present for this code
 	 */
-	public SortedSet<String> getAlternativeTerms() {
+	public SortedSet<Description> getAlternativeTerms() {
 		return alternativeTerms;
 	}
 	

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/Concept.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/Concept.java
@@ -43,7 +43,7 @@ public final class Concept extends BaseComponent {
 	private Boolean active;
 	private String term;
 	private String iconId;
-	private SortedSet<Description> alternativeTerms;
+	private SortedSet<Description> descriptions;
 	
 	private List<String> parentIds;
 	private List<String> ancestorIds;
@@ -57,7 +57,7 @@ public final class Concept extends BaseComponent {
 			@JsonProperty("code") ComponentURI code, 
 			@JsonProperty("active") Boolean active, 
 			@JsonProperty("term") String term, 
-			@JsonProperty("alternativeTerms") SortedSet<Description> alternativeTerms, 
+			@JsonProperty("descriptions") SortedSet<Description> descriptions, 
 			@JsonProperty("iconId") String iconId, 
 			@JsonProperty("parentIds") List<String> parentIds, 
 			@JsonProperty("ancestorIds") List<String> ancestorIds,
@@ -66,7 +66,7 @@ public final class Concept extends BaseComponent {
 		setId(code.identifier());
 		setActive(active);
 		setTerm(term);
-		setAlternativeTerms(alternativeTerms);
+		setDescriptions(descriptions);
 		setIconId(iconId);
 		setScore(score);
 		setParentIds(parentIds);
@@ -106,8 +106,19 @@ public final class Concept extends BaseComponent {
 		this.iconId = iconId;
 	}
 	
+	/**
+	 * @param alternativeTerms
+	 * @deprecated deserialization only: if descriptions property is set via the constructor during deserialization then this ignores the incoming value, use {@link #setDescriptions(Collection)} instead
+	 */
+	@JsonProperty
 	public void setAlternativeTerms(Collection<Description> alternativeTerms) {
-		this.alternativeTerms = alternativeTerms == null ? null : Collections3.toImmutableSortedSet(alternativeTerms);
+		if (descriptions == null) {
+			setDescriptions(alternativeTerms);
+		}
+	}
+	
+	public void setDescriptions(Collection<Description> descriptions) {
+		this.descriptions = descriptions == null ? null : Collections3.toImmutableSortedSet(descriptions);
 	}
 	
 	public void setScore(Float score) {
@@ -116,9 +127,14 @@ public final class Concept extends BaseComponent {
 	
 	/**
 	 * @return optionally set alternative terms for this concept, may be <code>null</code> if there are not alternative terms present for this code
+	 * @deprecated serialization only for backward compatibility, use {@link #getDescriptions()} instead  
 	 */
 	public SortedSet<Description> getAlternativeTerms() {
-		return alternativeTerms;
+		return getDescriptions();
+	}
+	
+	public SortedSet<Description> getDescriptions() {
+		return descriptions;
 	}
 	
 	public Float getScore() {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/Description.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/Description.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 B2i Healthcare, https://b2ihealthcare.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.domain;
+
+import java.util.Comparator;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @since 9.2 
+ */
+public final class Description implements Comparable<Description> {
+
+	@JsonIgnore
+	private static final Comparator<Description> DEFAULT_COMPARATOR = Comparator.comparing(Description::getTerm).thenComparing(Description::getLanguage);
+	
+	private final String term;
+	private final String language;
+	
+	public Description(@JsonProperty("term") String term) {
+		this(term, null);
+	}
+	
+	@JsonCreator
+	public Description(@JsonProperty("term") String term, @JsonProperty("language") String language) {
+		this.term = term;
+		this.language = language;
+	}
+	
+	public String getTerm() {
+		return term;
+	}
+	
+	public String getLanguage() {
+		return language;
+	}
+	
+	@Override
+	public int compareTo(Description other) {
+		return DEFAULT_COMPARATOR.compare(this, other);
+	}
+	
+}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/Description.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/Description.java
@@ -32,6 +32,8 @@ public final class Description implements Comparable<Description> {
 	private final String term;
 	private final String language;
 	
+	private Object internalDescription;
+	
 	public Description(@JsonProperty("term") String term) {
 		this(term, null);
 	}
@@ -48,6 +50,15 @@ public final class Description implements Comparable<Description> {
 	
 	public String getLanguage() {
 		return language;
+	}
+	
+	public <T> T getInternalDescription() {
+		return (T) internalDescription;
+	}
+	
+	public Description withInternalDescription(Object internalDescription) {
+		this.internalDescription = internalDescription;
+		return this;
 	}
 	
 	@Override

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/suggest/ConceptSuggestionContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/suggest/ConceptSuggestionContext.java
@@ -15,9 +15,7 @@
  */
 package com.b2international.snowowl.core.request.suggest;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.SortedSet;
+import java.util.*;
 import java.util.stream.Stream;
 
 import com.b2international.commons.collections.Collections3;
@@ -35,7 +33,6 @@ import com.b2international.snowowl.core.domain.Concepts;
 import com.b2international.snowowl.core.domain.DelegatingContext;
 import com.b2international.snowowl.core.domain.Description;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 
 /**
@@ -134,15 +131,17 @@ public final class ConceptSuggestionContext extends DelegatingContext {
 		return locales;
 	}
 	
-	private List<String> getAllTerms(Concept concept) {
-		ImmutableList.Builder<String> allTerms = ImmutableList.<String> builder();
+	private Set<String> getAllTerms(Concept concept) {
+		final Set<String> allTerms = new HashSet<>();
+		
+		// just in case keep adding the selected display term even though the description list of the generic concept should already contain all descriptions, not just alternatives
 		if (concept.getTerm() != null) {
 			allTerms.add(concept.getTerm());
 		}
-		if (concept.getAlternativeTerms() != null) {
-			concept.getAlternativeTerms().stream().map(Description::getTerm).forEach(allTerms::add);
+		if (concept.getDescriptions() != null) {
+			concept.getDescriptions().stream().map(Description::getTerm).forEach(allTerms::add);
 		}
-		return allTerms.build();
+		return allTerms;
 	}
 
 	public Collection<String> exclusionQuery(ResourceURI resourceUri) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/suggest/ConceptSuggestionContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/suggest/ConceptSuggestionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2022-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import com.b2international.snowowl.core.codesystem.CodeSystemRequests;
 import com.b2international.snowowl.core.domain.Concept;
 import com.b2international.snowowl.core.domain.Concepts;
 import com.b2international.snowowl.core.domain.DelegatingContext;
+import com.b2international.snowowl.core.domain.Description;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
@@ -139,7 +140,7 @@ public final class ConceptSuggestionContext extends DelegatingContext {
 			allTerms.add(concept.getTerm());
 		}
 		if (concept.getAlternativeTerms() != null) {
-			allTerms.addAll(concept.getAlternativeTerms());
+			concept.getAlternativeTerms().stream().map(Description::getTerm).forEach(allTerms::add);
 		}
 		return allTerms.build();
 	}

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/model/Designation.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/model/Designation.java
@@ -15,8 +15,11 @@
  */
 package com.b2international.snowowl.fhir.core.model;
 
-import jakarta.validation.constraints.NotEmpty;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
+import com.b2international.snowowl.core.domain.Description;
 import com.b2international.snowowl.fhir.core.model.dt.Code;
 import com.b2international.snowowl.fhir.core.model.dt.Coding;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -24,6 +27,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import jakarta.validation.constraints.NotEmpty;
 
 /**
  * This class represents a FHIR designation.
@@ -125,6 +130,19 @@ public final class Designation {
 		protected Designation doBuild() {
 			return new Designation(language, use, value);
 		}
+	}
+
+	/**
+	 * Maps the given collection of {@link Description} objects into FHIR {@link Designation} objects by mapping the term and language fields to the matching properties.
+	 * @param descriptions
+	 * @return a {@link List} of {@link Designation} objects, never <code>null</code>.
+	 */
+	@JsonIgnore
+	public static List<Designation> fromDescriptions(Collection<Description> descriptions) {
+		return descriptions
+				.stream()
+				.map(description -> Designation.builder().value(description.getTerm()).language(description.getLanguage()).build())
+				.collect(Collectors.toList());
 	}
 	
 }

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/model/valueset/expansion/Contains.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/model/valueset/expansion/Contains.java
@@ -15,21 +15,19 @@
  */
 package com.b2international.snowowl.fhir.core.model.valueset.expansion;
 
+import java.util.ArrayList;
 import java.util.Collection;
-
-import jakarta.validation.Valid;
 
 import com.b2international.snowowl.fhir.core.model.Designation;
 import com.b2international.snowowl.fhir.core.model.ValidatingBuilder;
 import com.b2international.snowowl.fhir.core.model.dt.Code;
 import com.b2international.snowowl.fhir.core.model.dt.Uri;
-import com.b2international.snowowl.fhir.core.model.valueset.Include;
-import com.b2international.snowowl.fhir.core.model.valueset.Compose.Builder;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import com.google.common.collect.Sets;
+
+import jakarta.validation.Valid;
 
 /**
  * The codes that are contained in the value set expansion.
@@ -67,8 +65,16 @@ public class Contains {
 	@JsonProperty
 	private Collection<Contains> contains;
 
-	Contains(Uri system, Boolean isAbstract, Boolean inactive, String version, Code code, String display, Collection<Designation> designations,
-			Collection<Contains> contains) {
+	Contains(
+		Uri system, 
+		Boolean isAbstract, 
+		Boolean inactive, 
+		String version, 
+		Code code, 
+		String display, 
+		Collection<Designation> designations,
+		Collection<Contains> contains) {
+		
 		this.system = system;
 		this.isAbstract = isAbstract;
 		this.inactive = inactive;
@@ -77,6 +83,7 @@ public class Contains {
 		this.display = display;
 		this.designations = designations;
 		this.contains = contains;
+		
 	}
 	
 	public Uri getSystem() {
@@ -183,9 +190,8 @@ public class Contains {
 		}
 		
 		public Builder addDesignation(final Designation designation) {
-			
 			if (designations == null) {
-				designations = Sets.newHashSet();
+				designations = new ArrayList<>();
 			}
 			designations.add(designation);
 			return this;
@@ -200,7 +206,7 @@ public class Contains {
 		
 		public Builder addContains(Contains content) {
 			if (contains == null) {
-				contains = Sets.newHashSet();
+				contains = new ArrayList<>();
 			}
 			contains.add(content);
 			return this;

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemLookupConverter.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemLookupConverter.java
@@ -58,7 +58,7 @@ public interface FhirCodeSystemLookupConverter {
 	 */
 	default List<Designation> expandDesignations(ServiceProvider context, CodeSystem codeSystem, Concept concept, LookupRequest request, String acceptLanguage) {
 		if (request.isPropertyRequested(SupportedCodeSystemRequestProperties.DESIGNATION)) {
-			return Designation.fromDescriptions(concept.getAlternativeTerms());
+			return Designation.fromDescriptions(concept.getDescriptions());
 		} else {
 			return null;
 		}

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemLookupConverter.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemLookupConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2021-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package com.b2international.snowowl.fhir.core.request.codesystem;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.domain.Concept;
@@ -59,7 +58,7 @@ public interface FhirCodeSystemLookupConverter {
 	 */
 	default List<Designation> expandDesignations(ServiceProvider context, CodeSystem codeSystem, Concept concept, LookupRequest request, String acceptLanguage) {
 		if (request.isPropertyRequested(SupportedCodeSystemRequestProperties.DESIGNATION)) {
-			return concept.getAlternativeTerms().stream().map(term -> Designation.builder().value(term).build()).collect(Collectors.toList());
+			return Designation.fromDescriptions(concept.getAlternativeTerms());
 		} else {
 			return null;
 		}

--- a/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/codesystem/FhirCodeSystemLookupOperationTest.java
+++ b/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/codesystem/FhirCodeSystemLookupOperationTest.java
@@ -26,8 +26,8 @@ import org.junit.Test;
 import com.b2international.snowowl.fhir.core.model.codesystem.LookupRequest;
 import com.b2international.snowowl.fhir.core.model.dt.Coding;
 import com.b2international.snowowl.fhir.tests.FhirRestTest;
-import com.b2international.snowowl.snomed.common.SnomedTerminologyComponentConstants;
 import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
+import com.b2international.snowowl.snomed.common.SnomedTerminologyComponentConstants;
 import com.b2international.snowowl.test.commons.codesystem.CodeSystemRestRequests;
 
 /**
@@ -176,9 +176,21 @@ public class FhirCodeSystemLookupOperationTest extends FhirRestTest {
 			.body("parameter[1].name", equalTo("display"))
 			.body("parameter[1].valueString", equalTo("Clinical finding"))
 			.body("parameter[2].name", equalTo("designation"))
-			.body("parameter[2].part[0].valueCode", equalTo("en"))
-			.body("parameter[2].part[1].valueCoding.code", equalTo("900000000000003001"))
-			.body("parameter[2].part[2].valueString", equalTo("Clinical finding (finding)"));
+			.body("parameter[2].part[0].valueCode", equalTo("en-x-" + Concepts.REFSET_LANGUAGE_TYPE_UK))
+			.body("parameter[2].part[1].valueCoding.code", equalTo("900000000000013009"))
+			.body("parameter[2].part[2].valueString", equalTo("Clinical finding"))
+			.body("parameter[3].name", equalTo("designation"))
+			.body("parameter[3].part[0].valueCode", equalTo("en-x-" + Concepts.REFSET_LANGUAGE_TYPE_US))
+			.body("parameter[3].part[1].valueCoding.code", equalTo("900000000000013009"))
+			.body("parameter[3].part[2].valueString", equalTo("Clinical finding"))
+			.body("parameter[4].name", equalTo("designation"))
+			.body("parameter[4].part[0].valueCode", equalTo("en-x-" + Concepts.REFSET_LANGUAGE_TYPE_UK))
+			.body("parameter[4].part[1].valueCoding.code", equalTo("900000000000003001"))
+			.body("parameter[4].part[2].valueString", equalTo("Clinical finding (finding)"))
+			.body("parameter[5].name", equalTo("designation"))
+			.body("parameter[5].part[0].valueCode", equalTo("en-x-" + Concepts.REFSET_LANGUAGE_TYPE_US))
+			.body("parameter[5].part[1].valueCoding.code", equalTo("900000000000003001"))
+			.body("parameter[5].part[2].valueString", equalTo("Clinical finding (finding)"));
 	}
 	
 	@Test

--- a/snomed/com.b2international.snowowl.snomed.fhir/src/com/b2international/snowowl/snomed/fhir/SnomedFhirCodeSystemLookupConverter.java
+++ b/snomed/com.b2international.snowowl.snomed.fhir/src/com/b2international/snowowl/snomed/fhir/SnomedFhirCodeSystemLookupConverter.java
@@ -62,7 +62,7 @@ public final class SnomedFhirCodeSystemLookupConverter implements FhirCodeSystem
 	public List<Designation> expandDesignations(ServiceProvider context, CodeSystem codeSystem, Concept concept, LookupRequest request, String acceptLanguage) {
 		SnomedConcept snomedConcept = concept.getInternalConceptAs();
 		if (request.isPropertyRequested(SupportedCodeSystemRequestProperties.DESIGNATION)) {
-			final SortedSet<Description> alternativeTerms = SnomedConceptSearchRequestEvaluator.generateAlternativeTerms(snomedConcept.getDescriptions());
+			final SortedSet<Description> alternativeTerms = SnomedConceptSearchRequestEvaluator.generateGenericDescriptions(snomedConcept.getDescriptions());
 			// convert to Designation model
 			final List<Designation> designations = new ArrayList<>(alternativeTerms.size());
 			for (Description description : alternativeTerms) {


### PR DESCRIPTION
This PR adds support for generic descriptions instead of a List of Strings on the generic Concept model.
The primary use for this is going to be FHIR endpoints where additional (even on the fly generated) designations need to be sent back in the response along with the concept's display.
In case of SNOMED CT Snow Owl now follows the latest spec version which requires designations to be returned for each languageCode + language reference set id combination.