### PR TITLE
SO-6082: nested member create request errors

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptApiTest.java
@@ -1130,4 +1130,49 @@ public class SnomedConceptApiTest extends AbstractSnomedApiTest {
 		assertThat(concept.getStatedParentIdsAsString()).contains(Concepts.ROOT_CONCEPT);
 	}
 	
+	@Test
+	public void createModuleConceptWithAxiom() throws Exception {
+		ISnomedIdentifierService identifierService = ApplicationContext.getServiceForClass(ISnomedIdentifierService.class);
+		String moduleConceptId = Iterables.getOnlyElement(identifierService.reserve(null, ComponentCategory.CONCEPT, 1));
+
+		String createdConceptId = createConcept(branchPath,
+			Json.object(
+				"id", moduleConceptId,
+				"moduleId", moduleConceptId, // module is applied to all subcomponents implicitly via the API
+				"active", true,
+				"descriptions", Json.array(
+					Json.object(
+						"typeId", Concepts.FULLY_SPECIFIED_NAME,
+						"term", "FSN of module concept",
+						"languageCode", DEFAULT_LANGUAGE_CODE,
+						"acceptability", UK_PREFERRED_MAP
+					),
+					Json.object(
+						"typeId", Concepts.SYNONYM,
+						"term", "PT of concept",
+						"languageCode", DEFAULT_LANGUAGE_CODE,
+						"acceptability", UK_PREFERRED_MAP
+					)
+				),
+				"relationships", Json.array(
+					Json.object(
+						"active", true,
+						"typeId", Concepts.IS_A,
+						"destinationId", Concepts.MODULE_ROOT,
+						"characteristicTypeId", Concepts.INFERRED_RELATIONSHIP
+					)
+				),
+				"members", Json.array(
+					Json.object(
+						"active", true,
+						"refsetId", Concepts.REFSET_OWL_AXIOM,
+						"owlExpression", String.format("SubClassOf(:%s :%s)", moduleConceptId, Concepts.MODULE_ROOT)
+					)
+				)
+			)
+		);
+		
+		assertEquals(moduleConceptId, createdConceptId);
+	}
+	
 }

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptApiTest.java
@@ -1131,7 +1131,7 @@ public class SnomedConceptApiTest extends AbstractSnomedApiTest {
 	}
 	
 	@Test
-	public void createModuleConceptWithAxiom() throws Exception {
+	public void createModuleConceptWithAxiom_ShouldPropagateModuleAsUsualWithoutErrors() throws Exception {
 		ISnomedIdentifierService identifierService = ApplicationContext.getServiceForClass(ISnomedIdentifierService.class);
 		String moduleConceptId = Iterables.getOnlyElement(identifierService.reserve(null, ComponentCategory.CONCEPT, 1));
 

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedReferenceSetMemberRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/SnomedReferenceSetMemberRestService.java
@@ -15,7 +15,6 @@
  */
 package com.b2international.snowowl.snomed.core.rest;
 
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.springdoc.core.annotations.ParameterObject;
@@ -195,10 +194,6 @@ public class SnomedReferenceSetMemberRestService extends AbstractRestService {
 		final SnomedRefSetMemberRestInput change = body.getChange();
 		final String commitComment = body.getCommitComment();
 		final String defaultModuleId = body.getDefaultModuleId();
-		
-		final String id = change.getId();
-		// Check for correct UUID format in id input
-		UUID.fromString(id);
 		
 		final String createdRefSetMemberId = change.toRequestBuilder()
 				.commit()

--- a/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/domain/SnomedRefSetMemberRestInput.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest/src/com/b2international/snowowl/snomed/core/rest/domain/SnomedRefSetMemberRestInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2011-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package com.b2international.snowowl.snomed.core.rest.domain;
 import static com.google.common.collect.Maps.newHashMap;
 
 import java.util.Map;
-import java.util.UUID;
 
 import com.b2international.snowowl.snomed.datastore.request.SnomedRefSetMemberCreateRequestBuilder;
 import com.b2international.snowowl.snomed.datastore.request.SnomedRequests;
@@ -30,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
  */
 public class SnomedRefSetMemberRestInput {
 
-	private String id = UUID.randomUUID().toString();
+	private String id;
 	private Boolean active = Boolean.TRUE;
 	private String moduleId;
 	private String referencedComponentId;

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequest.java
@@ -343,10 +343,10 @@ final class SnomedEclEvaluationRequest extends EclEvaluationRequest<BranchContex
 		final FilterValue languageRefSetId = languageRefSetFilter.getLanguageRefSetId();
 		return evaluate(context, languageRefSetId)
 			.then(resolveIds(context))
-			.then(languageReferenceSetIds -> {
+			.then(languageRefsetIds -> {
 				return Expressions.bool()
-					.should(SnomedDescriptionIndexEntry.Expressions.acceptableIn(languageReferenceSetIds))
-					.should(SnomedDescriptionIndexEntry.Expressions.preferredIn(languageReferenceSetIds))
+					.should(SnomedDescriptionIndexEntry.Expressions.acceptableIn(languageRefsetIds))
+					.should(SnomedDescriptionIndexEntry.Expressions.preferredIn(languageRefsetIds))
 					.build();
 			});
 	}
@@ -392,15 +392,15 @@ final class SnomedEclEvaluationRequest extends EclEvaluationRequest<BranchContex
 		final ExpressionBuilder dialectQuery = Expressions.bool();
 		for (DialectAlias alias : dialectAliasFilter.getDialects()) {
 			final Set<String> acceptabilityFields = getAcceptabilityFields(alias.getAcceptability());
-			final Collection<String> languageReferenceSetIds = languageMapping.get(alias.getAlias());
+			final Collection<String> languageRefsetIds = languageMapping.get(alias.getAlias());
 			
 			// empty acceptabilities or empty language reference set IDs mean that none of the provided values were valid so no match should be returned
-			if (acceptabilityFields.isEmpty() || languageReferenceSetIds.isEmpty()) {
+			if (acceptabilityFields.isEmpty() || languageRefsetIds.isEmpty()) {
 				return Promise.immediate(Expressions.matchNone());
 			}
 			
 			for (String acceptabilityField : acceptabilityFields) {
-				languageRefSetsByAcceptabilityField.putAll(acceptabilityField, languageReferenceSetIds);
+				languageRefSetsByAcceptabilityField.putAll(acceptabilityField, languageRefsetIds);
 			}
 		}
 		

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/store/SnomedMemberBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/store/SnomedMemberBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2011-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import com.b2international.snowowl.snomed.datastore.index.entry.SnomedRefSetMemb
  */
 public abstract class SnomedMemberBuilder<B extends SnomedMemberBuilder<B>> extends SnomedComponentBuilder<B, SnomedRefSetMemberIndexEntry.Builder, SnomedRefSetMemberIndexEntry> {
 
-	private String referenceSetId;
+	private String refsetId;
 	private String referencedComponent;
 	
 	protected SnomedMemberBuilder() {
@@ -54,12 +54,12 @@ public abstract class SnomedMemberBuilder<B extends SnomedMemberBuilder<B>> exte
 	/**
 	 * Specifies the reference set where this reference set member belongs.
 	 * 
-	 * @param referenceSetId
+	 * @param refsetId
 	 *            - the identifier concept ID of the reference set
 	 * @return
 	 */
-	public final B withRefSet(String referenceSetId) {
-		this.referenceSetId = referenceSetId;
+	public final B withRefSet(String refsetId) {
+		this.refsetId = refsetId;
 		return getSelf();
 	}
 	
@@ -82,15 +82,15 @@ public abstract class SnomedMemberBuilder<B extends SnomedMemberBuilder<B>> exte
 	@OverridingMethodsMustInvokeSuper
 	public void init(SnomedRefSetMemberIndexEntry.Builder component, TransactionContext context) {
 		super.init(component, context);
-		final SnomedConceptDocument refSet = context.lookup(referenceSetId, SnomedConceptDocument.class);
-		checkState(refSet.getRefSetType() != null, "RefSet properties are missing from identifier concept document %s", referenceSetId);
+		final SnomedConceptDocument refSet = context.lookup(refsetId, SnomedConceptDocument.class);
+		checkState(refSet.getRefSetType() != null, "RefSet properties are missing from identifier concept document %s", refsetId);
 		component
 			.referencedComponentId(referencedComponent)
-			.refsetId(referenceSetId)
+			.refsetId(refsetId)
 			.referenceSetType(refSet.getRefSetType());
 		
 		if (refSet.getRefSetType() == SnomedRefSetType.CONCRETE_DATA_TYPE) {
-			component.field(SnomedRefSetMemberIndexEntry.Fields.DATA_TYPE, SnomedRefSetUtil.getDataType(referenceSetId));
+			component.field(SnomedRefSetMemberIndexEntry.Fields.DATA_TYPE, SnomedRefSetUtil.getDataType(refsetId));
 		}
 	}
 	

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/entry/SnomedComponentDocument.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/entry/SnomedComponentDocument.java
@@ -45,20 +45,20 @@ public abstract class SnomedComponentDocument extends SnomedDocument {
 			return matchAny(Fields.NAMESPACE, namespaces);
 		}
 		
-		public static final Expression memberOf(String referenceSetId) {
-			return exactMatch(Fields.MEMBER_OF, referenceSetId);
+		public static final Expression memberOf(String refsetId) {
+			return exactMatch(Fields.MEMBER_OF, refsetId);
 		}
 		
-		public static final Expression memberOf(Iterable<String> referenceSetIds) {
-			return matchAny(Fields.MEMBER_OF, referenceSetIds);
+		public static final Expression memberOf(Iterable<String> refsetIds) {
+			return matchAny(Fields.MEMBER_OF, refsetIds);
 		}
 		
-		public static final Expression activeMemberOf(String referenceSetId) {
-			return exactMatch(Fields.ACTIVE_MEMBER_OF, referenceSetId);
+		public static final Expression activeMemberOf(String refsetId) {
+			return exactMatch(Fields.ACTIVE_MEMBER_OF, refsetId);
 		}
 		
-		public static final Expression activeMemberOf(Iterable<String> referenceSetIds) {
-			return matchAny(Fields.ACTIVE_MEMBER_OF, referenceSetIds);
+		public static final Expression activeMemberOf(Iterable<String> refsetIds) {
+			return matchAny(Fields.ACTIVE_MEMBER_OF, refsetIds);
 		}
 		
 	}
@@ -83,13 +83,13 @@ public abstract class SnomedComponentDocument extends SnomedDocument {
 			return getSelf();
 		}
 		
-		public B activeMemberOf(Collection<String> referenceSetIds) {
-			this.activeMemberOf = Collections3.toImmutableList(referenceSetIds);
+		public B activeMemberOf(Collection<String> refsetIds) {
+			this.activeMemberOf = Collections3.toImmutableList(refsetIds);
 			return getSelf();
 		}
 		
-		public B memberOf(Collection<String> referenceSetIds) {
-			this.memberOf = Collections3.toImmutableList(referenceSetIds);
+		public B memberOf(Collection<String> refsetIds) {
+			this.memberOf = Collections3.toImmutableList(refsetIds);
 			return getSelf();
 		}
 		

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/entry/SnomedDescriptionIndexEntry.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/entry/SnomedDescriptionIndexEntry.java
@@ -187,20 +187,20 @@ public final class SnomedDescriptionIndexEntry extends SnomedComponentDocument {
 			return matchAny(Fields.CASE_SIGNIFICANCE_ID, caseSignificanceIds);
 		}
 		
-		public static Expression acceptableIn(String languageReferenceSetId) {
-			return acceptableIn(Collections.singleton(languageReferenceSetId));
+		public static Expression acceptableIn(String languageRefsetId) {
+			return acceptableIn(Collections.singleton(languageRefsetId));
 		}
 		
-		public static Expression preferredIn(String languageReferenceSetId) {
-			return preferredIn(Collections.singleton(languageReferenceSetId));
+		public static Expression preferredIn(String languageRefsetId) {
+			return preferredIn(Collections.singleton(languageRefsetId));
 		}
 		
-		public static Expression acceptableIn(Collection<String> languageReferenceSetIds) {
-			return matchAny(Fields.ACCEPTABLE_IN, languageReferenceSetIds);
+		public static Expression acceptableIn(Collection<String> languageRefsetIds) {
+			return matchAny(Fields.ACCEPTABLE_IN, languageRefsetIds);
 		}
 		
-		public static Expression preferredIn(Collection<String> languageReferenceSetIds) {
-			return matchAny(Fields.PREFERRED_IN, languageReferenceSetIds);
+		public static Expression preferredIn(Collection<String> languageRefsetIds) {
+			return matchAny(Fields.PREFERRED_IN, languageRefsetIds);
 		}
 		
 		public static Expression languageCode(String languageCode) {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/entry/SnomedRefSetMemberIndexEntry.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/entry/SnomedRefSetMemberIndexEntry.java
@@ -269,12 +269,12 @@ public final class SnomedRefSetMemberIndexEntry extends SnomedDocument {
 
 	public static final class Expressions extends SnomedDocument.Expressions {
 		
-		public static Expression refsetId(String referenceSetId) {
-			return exactMatch(Fields.REFSET_ID, referenceSetId);
+		public static Expression refsetId(String refsetId) {
+			return exactMatch(Fields.REFSET_ID, refsetId);
 		}
 
-		public static Expression refsetIds(Collection<String> referenceSetIds) {
-			return matchAny(Fields.REFSET_ID, referenceSetIds);
+		public static Expression refsetIds(Collection<String> refsetIds) {
+			return matchAny(Fields.REFSET_ID, refsetIds);
 		}
 		
 		public static Expression referencedComponentId(String referencedComponentId) {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/BaseSnomedComponentCreateRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/BaseSnomedComponentCreateRequest.java
@@ -34,6 +34,8 @@ import com.google.common.collect.ImmutableSet;
  */
 public abstract class BaseSnomedComponentCreateRequest implements SnomedCoreComponentCreateRequest {
 
+	private static final long serialVersionUID = 1L;
+
 	@Nonnull
 	private Boolean active = Boolean.TRUE;
 	

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/IdRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/IdRequest.java
@@ -45,6 +45,7 @@ import com.b2international.snowowl.snomed.core.domain.IdGenerationStrategy;
 import com.b2international.snowowl.snomed.core.domain.NamespaceConceptIdStrategy;
 import com.b2international.snowowl.snomed.core.domain.NamespaceIdStrategy;
 import com.b2international.snowowl.snomed.datastore.index.entry.*;
+import com.google.common.base.Strings;
 import com.google.common.collect.*;
 
 /**
@@ -105,6 +106,7 @@ public final class IdRequest<C extends BranchContext, R> extends DelegatingReque
 						
 						final Set<String> refsetMemberIds = FluentIterable.from(categoryRequests)
 								.filter(SnomedRefSetMemberCreateRequest.class)
+								.filter(request -> !Strings.isNullOrEmpty(request.getId()))
 								.transform(request -> request.getId())
 								.toSet();
 						

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedAssociationMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedAssociationMemberCreateDelegate.java
@@ -47,7 +47,7 @@ final class SnomedAssociationMemberCreateDelegate extends SnomedRefSetMemberCrea
 				.withActive(isActive())
 				.withReferencedComponent(getReferencedComponentId())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withTargetComponentId(getComponentId(SnomedRf2Headers.FIELD_TARGET_COMPONENT_ID))
 				.addTo(context);
 

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedAttributeValueMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedAttributeValueMemberCreateDelegate.java
@@ -48,7 +48,7 @@ final class SnomedAttributeValueMemberCreateDelegate extends SnomedRefSetMemberC
 				.withActive(isActive())
 				.withReferencedComponent(getReferencedComponentId())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withValueId(getComponentId(SnomedRf2Headers.FIELD_VALUE_ID))
 				.addTo(context);
 

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedComplexBlockMapMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedComplexBlockMapMemberCreateDelegate.java
@@ -59,7 +59,7 @@ final class SnomedComplexBlockMapMemberCreateDelegate extends SnomedRefSetMember
 				.withActive(isActive())
 				.withReferencedComponent(getReferencedComponentId())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withMapTargetId(getComponentId(SnomedRf2Headers.FIELD_MAP_TARGET))
 				.withGroup(getProperty(SnomedRf2Headers.FIELD_MAP_GROUP, Integer.class))
 				.withPriority(getProperty(SnomedRf2Headers.FIELD_MAP_PRIORITY, Integer.class))

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedComplexMapMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedComplexMapMemberCreateDelegate.java
@@ -58,7 +58,7 @@ final class SnomedComplexMapMemberCreateDelegate extends SnomedRefSetMemberCreat
 				.withActive(isActive())
 				.withReferencedComponent(getReferencedComponentId())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withMapTargetId(getComponentId(SnomedRf2Headers.FIELD_MAP_TARGET))
 				.withGroup(getProperty(SnomedRf2Headers.FIELD_MAP_GROUP, Integer.class))
 				.withPriority(getProperty(SnomedRf2Headers.FIELD_MAP_PRIORITY, Integer.class))

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedComponentSearchRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedComponentSearchRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2022 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2011-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,38 +28,38 @@ public abstract class SnomedComponentSearchRequestBuilder<B extends SnomedCompon
 	
 	/**
 	 * Filter matches by their active membership in the given reference set or ECL expression.
-	 * @param referenceSetIdOrECL
+	 * @param refsetIdOrEcl
 	 * @return
 	 */
-	public final B isActiveMemberOf(String referenceSetIdOrECL) {
-		return addOption(OptionKey.ACTIVE_MEMBER_OF, referenceSetIdOrECL);
+	public final B isActiveMemberOf(String refsetIdOrEcl) {
+		return addOption(OptionKey.ACTIVE_MEMBER_OF, refsetIdOrEcl);
 	}
 	
 	/**
 	 * Filter matches by their active membership in any of the given reference sets.
-	 * @param referenceSetIds
+	 * @param refsetIds
 	 * @return
 	 */
-	public final B isActiveMemberOf(Iterable<String> referenceSetIds) {
-		return addOption(OptionKey.ACTIVE_MEMBER_OF, referenceSetIds);
+	public final B isActiveMemberOf(Iterable<String> refsetIds) {
+		return addOption(OptionKey.ACTIVE_MEMBER_OF, refsetIds);
 	}
 	
 	/**
 	 * Filter matches by their membership in the given reference set or ECL expression. Matches both active and inactive memberships.
-	 * @param referenceSetIdOrECL
+	 * @param refsetIdOrEcl
 	 * @return
 	 */
-	public final B isMemberOf(String referenceSetIdOrECL) {
-		return addOption(OptionKey.MEMBER_OF, referenceSetIdOrECL);
+	public final B isMemberOf(String refsetIdOrEcl) {
+		return addOption(OptionKey.MEMBER_OF, refsetIdOrEcl);
 	}
 	
 	/**
 	 * Filter matches by their membership in any of the given reference sets. Matches both active and inactive memberships.
-	 * @param referenceSetIds
+	 * @param refsetIds
 	 * @return
 	 */
-	public final B isMemberOf(Iterable<String> referenceSetIds) {
-		return addOption(OptionKey.MEMBER_OF, referenceSetIds);
+	public final B isMemberOf(Iterable<String> refsetIds) {
+		return addOption(OptionKey.MEMBER_OF, refsetIds);
 	}
 	
 	/**

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConcreteDomainMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConcreteDomainMemberCreateDelegate.java
@@ -65,7 +65,7 @@ final class SnomedConcreteDomainMemberCreateDelegate extends SnomedRefSetMemberC
 				.withGroup(getProperty(SnomedRf2Headers.FIELD_RELATIONSHIP_GROUP, Integer.class))
 				.withModuleId(getModuleId())
 				.withReferencedComponent(getReferencedComponentId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withSerializedValue(getProperty(SnomedRf2Headers.FIELD_VALUE))
 				.withTypeId(getComponentId(SnomedRf2Headers.FIELD_TYPE_ID))
 				.addTo(context);

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedDescriptionCreateRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedDescriptionCreateRequestBuilder.java
@@ -67,13 +67,13 @@ public final class SnomedDescriptionCreateRequestBuilder extends SnomedComponent
 		return getSelf();
 	}
 	
-	public SnomedDescriptionCreateRequestBuilder acceptableIn(String languageReferenceSetId) {
-		this.acceptabilityMap.put(languageReferenceSetId, Acceptability.ACCEPTABLE);
+	public SnomedDescriptionCreateRequestBuilder acceptableIn(String languageRefsetId) {
+		this.acceptabilityMap.put(languageRefsetId, Acceptability.ACCEPTABLE);
 		return getSelf();
 	}
 	
-	public SnomedDescriptionCreateRequestBuilder preferredIn(String languageReferenceSetId) {
-		this.acceptabilityMap.put(languageReferenceSetId, Acceptability.PREFERRED);
+	public SnomedDescriptionCreateRequestBuilder preferredIn(String languageRefsetId) {
+		this.acceptabilityMap.put(languageRefsetId, Acceptability.PREFERRED);
 		return getSelf();
 	}
 	

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedDescriptionTypeMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedDescriptionTypeMemberCreateDelegate.java
@@ -49,7 +49,7 @@ final class SnomedDescriptionTypeMemberCreateDelegate extends SnomedRefSetMember
 				.withActive(isActive())
 				.withReferencedComponent(getReferencedComponentId())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withDescriptionFormatId(getComponentId(SnomedRf2Headers.FIELD_DESCRIPTION_FORMAT))
 				.withDescriptionLength(getProperty(SnomedRf2Headers.FIELD_DESCRIPTION_LENGTH, Integer.class))
 				.addTo(context);

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedExtendedMapMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedExtendedMapMemberCreateDelegate.java
@@ -63,7 +63,7 @@ final class SnomedExtendedMapMemberCreateDelegate extends SnomedRefSetMemberCrea
 				.withActive(isActive())
 				.withReferencedComponent(getReferencedComponentId())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withMapTargetId(getComponentId(SnomedRf2Headers.FIELD_MAP_TARGET))
 				.withGroup(getProperty(SnomedRf2Headers.FIELD_MAP_GROUP, Integer.class))
 				.withPriority(getProperty(SnomedRf2Headers.FIELD_MAP_PRIORITY, Integer.class))

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedLanguageMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedLanguageMemberCreateDelegate.java
@@ -49,7 +49,7 @@ final class SnomedLanguageMemberCreateDelegate extends SnomedRefSetMemberCreateD
 				.withActive(isActive())
 				.withReferencedComponent(getReferencedComponentId())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withAcceptability(Acceptability.getByConceptId(getComponentId(SnomedRf2Headers.FIELD_ACCEPTABILITY_ID)))
 				.addTo(context);
 

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedMRCMAttributeDomainMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedMRCMAttributeDomainMemberCreateDelegate.java
@@ -53,7 +53,7 @@ final class SnomedMRCMAttributeDomainMemberCreateDelegate extends SnomedRefSetMe
 				.withId(getId())
 				.withActive(isActive())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withReferencedComponent(getReferencedComponentId())
 				.withDomainId(getProperty(SnomedRf2Headers.FIELD_MRCM_DOMAIN_ID))
 				.withGrouped(getProperty(SnomedRf2Headers.FIELD_MRCM_GROUPED, Boolean.class))

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedMRCMAttributeRangeMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedMRCMAttributeRangeMemberCreateDelegate.java
@@ -51,7 +51,7 @@ final class SnomedMRCMAttributeRangeMemberCreateDelegate extends SnomedRefSetMem
 				.withId(getId())
 				.withActive(isActive())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withReferencedComponent(getReferencedComponentId())
 				.withRangeConstraint(getProperty(SnomedRf2Headers.FIELD_MRCM_RANGE_CONSTRAINT))
 				.withAttributeRule(getProperty(SnomedRf2Headers.FIELD_MRCM_ATTRIBUTE_RULE))

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedMRCMDomainMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedMRCMDomainMemberCreateDelegate.java
@@ -50,7 +50,7 @@ final class SnomedMRCMDomainMemberCreateDelegate extends SnomedRefSetMemberCreat
 				.withId(getId())
 				.withActive(isActive())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withReferencedComponent(getReferencedComponentId())
 				.withDomainConstraint(getProperty(SnomedRf2Headers.FIELD_MRCM_DOMAIN_CONSTRAINT))
 				.withParentDomain(getProperty(SnomedRf2Headers.FIELD_MRCM_PARENT_DOMAIN))

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedMRCMModuleScopeMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedMRCMModuleScopeMemberCreateDelegate.java
@@ -48,7 +48,7 @@ final class SnomedMRCMModuleScopeMemberCreateDelegate extends SnomedRefSetMember
 				.withId(getId())
 				.withActive(isActive())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withReferencedComponent(getReferencedComponentId())
 				.withMRCMRuleRefsetId(getProperty(SnomedRf2Headers.FIELD_MRCM_RULE_REFSET_ID))
 				.addTo(context);

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedModuleDependencyMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedModuleDependencyMemberCreateDelegate.java
@@ -48,7 +48,7 @@ final class SnomedModuleDependencyMemberCreateDelegate extends SnomedRefSetMembe
 				.withActive(isActive())
 				.withReferencedComponent(getReferencedComponentId())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId());
+				.withRefSet(getRefsetId());
 		
 		try {
 			

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedOWLExpressionMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedOWLExpressionMemberCreateDelegate.java
@@ -48,7 +48,7 @@ final class SnomedOWLExpressionMemberCreateDelegate extends SnomedRefSetMemberCr
 				.withActive(isActive())
 				.withReferencedComponent(getReferencedComponentId())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withOWLExpression(getProperty(SnomedRf2Headers.FIELD_OWL_EXPRESSION))
 				.addTo(context);
 

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedQueryMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedQueryMemberCreateDelegate.java
@@ -97,7 +97,7 @@ final class SnomedQueryMemberCreateDelegate extends SnomedRefSetMemberCreateDele
 				.withActive(isActive())
 				.withReferencedComponent(getReferencedComponentId())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withQuery(getProperty(SnomedRf2Headers.FIELD_QUERY))
 				.addTo(context);
 

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedRefSetMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedRefSetMemberCreateDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2017-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,8 +59,8 @@ abstract class SnomedRefSetMemberCreateDelegate {
 		return request.getModuleId();
 	}
 
-	String getReferenceSetId() {
-		return request.getReferenceSetId();
+	String getRefsetId() {
+		return request.getRefsetId();
 	}
 
 	String getReferencedComponentId() {
@@ -142,21 +142,21 @@ abstract class SnomedRefSetMemberCreateDelegate {
 
 	protected final void checkHasProperty(String key) {
 		if (!hasProperty(key)) {
-			throw new BadRequestException("Property '%s' must be set for '%s' reference set members.", key, request.getReferenceSetId());
+			throw new BadRequestException("Property '%s' must be set for '%s' reference set members.", key, request.getRefsetId());
 		}
 	}
 
 	protected final void checkNonEmptyProperty(String key) {
 		checkHasProperty(key);
 		if (CompareUtils.isEmpty(getProperty(key, Object.class))) {
-			throw new BadRequestException("Property '%s' may not be null or empty for '%s' reference set members.", key, request.getReferenceSetId());
+			throw new BadRequestException("Property '%s' may not be null or empty for '%s' reference set members.", key, request.getRefsetId());
 		}
 	}
 	
 	protected final void checkNonNullProperty(String key) {
 		checkHasProperty(key);
 		if (getProperty(key, Object.class) == null) {
-			throw new BadRequestException("Property '%s' may not be null for '%s' reference set members.", key, request.getReferenceSetId());
+			throw new BadRequestException("Property '%s' may not be null for '%s' reference set members.", key, request.getRefsetId());
 		}
 	}
 

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedRefSetMemberCreateRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedRefSetMemberCreateRequest.java
@@ -16,12 +16,8 @@
 package com.b2international.snowowl.snomed.datastore.request;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Maps.newHashMap;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import javax.annotation.Nonnull;
 
@@ -36,7 +32,6 @@ import com.b2international.snowowl.snomed.datastore.converter.SnomedReferenceSet
 import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSet.Builder;
 
 import jakarta.validation.constraints.NotEmpty;
 
@@ -47,6 +42,7 @@ final class SnomedRefSetMemberCreateRequest implements SnomedComponentCreateRequ
 
 	private static final long serialVersionUID = 1L;
 
+	// Not @NotEmpty, it can be populated after the request is validated (eg. auto-generated ids)
 	private String id;
 
 	@Nonnull
@@ -57,10 +53,11 @@ final class SnomedRefSetMemberCreateRequest implements SnomedComponentCreateRequ
 	
 	// Not @NotEmpty, it can be populated after the request is validated (eg. nested create requests)
 	private String moduleId;
-	
+
+	// Not @NotEmpty, it can be populated after the request is validated (eg. nested create requests)
 	private String referencedComponentId;
 	
-	private Map<String, Object> properties = newHashMap();
+	private Map<String, Object> properties = new HashMap<>(2);
 
 	SnomedRefSetMemberCreateRequest() { }
 	
@@ -156,7 +153,7 @@ final class SnomedRefSetMemberCreateRequest implements SnomedComponentCreateRequ
 		try {
 			SnomedReferenceSet refSet = getRefSet(context);
 			SnomedRefSetMemberCreateDelegate delegate = getDelegate(refSet.getType());
-			Builder<String> requiredComponentIds = ImmutableSet.<String>builder().addAll(delegate.getRequiredComponentIds());
+			ImmutableSet.Builder<String> requiredComponentIds = ImmutableSet.<String>builder().addAll(delegate.getRequiredComponentIds());
 			requiredComponentIds.add(refsetId);
 			if (!Strings.isNullOrEmpty(referencedComponentId)) {
 				requiredComponentIds.add(referencedComponentId);
@@ -180,7 +177,7 @@ final class SnomedRefSetMemberCreateRequest implements SnomedComponentCreateRequ
 			try {
 				UUID.fromString(id);
 			} catch (IllegalArgumentException e) {
-				throw new BadRequestException("Refset Member uses an illegal non-UUID identifier '%s'.", id);
+				throw new BadRequestException("Reference set Member uses an illegal non-UUID identifier '%s'.", id);
 			}
 		}
 		

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedRefSetMemberCreateRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedRefSetMemberCreateRequest.java
@@ -21,10 +21,9 @@ import static com.google.common.collect.Maps.newHashMap;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import javax.annotation.Nonnull;
-
-import jakarta.validation.constraints.NotEmpty;
 
 import com.b2international.commons.exceptions.BadRequestException;
 import com.b2international.commons.options.Options;
@@ -39,22 +38,25 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
 
+import jakarta.validation.constraints.NotEmpty;
+
 /**
  * @since 4.5
  */
 final class SnomedRefSetMemberCreateRequest implements SnomedComponentCreateRequest {
 
-	@Nonnull
+	private static final long serialVersionUID = 1L;
+
 	private String id;
 
 	@Nonnull
 	private Boolean active = Boolean.TRUE;
 	
 	@NotEmpty
-	private String moduleId;
+	private String refsetId;
 	
-	@NotEmpty
-	private String referenceSetId;
+	// Not @NotEmpty, it can be populated after the request is validated (eg. nested create requests)
+	private String moduleId;
 	
 	private String referencedComponentId;
 	
@@ -76,8 +78,8 @@ final class SnomedRefSetMemberCreateRequest implements SnomedComponentCreateRequ
 		return moduleId;
 	}
 	
-	String getReferenceSetId() {
-		return referenceSetId;
+	String getRefsetId() {
+		return refsetId;
 	}
 	
 	String getReferencedComponentId() {
@@ -126,8 +128,8 @@ final class SnomedRefSetMemberCreateRequest implements SnomedComponentCreateRequ
 		this.referencedComponentId = referencedComponentId;
 	}
 	
-	void setReferenceSetId(String referenceSetId) {
-		this.referenceSetId = referenceSetId;
+	void setRefsetId(String refsetId) {
+		this.refsetId = refsetId;
 	}
 	
 	void setModuleId(String moduleId) {
@@ -155,7 +157,7 @@ final class SnomedRefSetMemberCreateRequest implements SnomedComponentCreateRequ
 			SnomedReferenceSet refSet = getRefSet(context);
 			SnomedRefSetMemberCreateDelegate delegate = getDelegate(refSet.getType());
 			Builder<String> requiredComponentIds = ImmutableSet.<String>builder().addAll(delegate.getRequiredComponentIds());
-			requiredComponentIds.add(referenceSetId);
+			requiredComponentIds.add(refsetId);
 			if (!Strings.isNullOrEmpty(referencedComponentId)) {
 				requiredComponentIds.add(referencedComponentId);
 			}
@@ -170,6 +172,18 @@ final class SnomedRefSetMemberCreateRequest implements SnomedComponentCreateRequ
 
 	@Override
 	public String execute(TransactionContext context) {
+		// generate id field as UUID if not defined otherwise
+		if (Strings.isNullOrEmpty(id)) {
+			id = UUID.randomUUID().toString();
+		} else {
+			// otherwise validate that it is a valid UUID
+			try {
+				UUID.fromString(id);
+			} catch (IllegalArgumentException e) {
+				throw new BadRequestException("Refset Member uses an illegal non-UUID identifier '%s'.", id);
+			}
+		}
+		
 		/* 
 		 * TODO: Generalize the logic below: any attempts of retrieving a missing component during component creation
 		 * should return a 400 response instead of a 404. 
@@ -184,7 +198,7 @@ final class SnomedRefSetMemberCreateRequest implements SnomedComponentCreateRequ
 	}
 
 	private SnomedReferenceSet getRefSet(TransactionContext context) {
-		final SnomedReferenceSet refSet = new SnomedReferenceSetConverter(context, Options.builder().build(), Collections.emptyList()).convert(context.lookup(referenceSetId, SnomedConceptDocument.class));
+		final SnomedReferenceSet refSet = new SnomedReferenceSetConverter(context, Options.builder().build(), Collections.emptyList()).convert(context.lookup(refsetId, SnomedConceptDocument.class));
 		checkArgument(refSet.getType() != null, "Reference Set Properties are missing from identifier concept document: %s.", refSet.getId());
 		return refSet;
 	}

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedRefSetMemberCreateRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedRefSetMemberCreateRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2011-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public final class SnomedRefSetMemberCreateRequestBuilder
 	private String id = UUID.randomUUID().toString();
 	private Boolean active = Boolean.TRUE;
 	private String moduleId;
-	private String referenceSetId;
+	private String refsetId;
 	private String referencedComponentId;
 	private Map<String, Object> properties = Collections.emptyMap();
 	
@@ -65,8 +65,8 @@ public final class SnomedRefSetMemberCreateRequestBuilder
 		return getSelf();
 	}
 	
-	public SnomedRefSetMemberCreateRequestBuilder setRefsetId(String referenceSetId) {
-		this.referenceSetId = referenceSetId;
+	public SnomedRefSetMemberCreateRequestBuilder setRefsetId(String refsetId) {
+		this.refsetId = refsetId;
 		return getSelf();
 	}
 	
@@ -90,7 +90,7 @@ public final class SnomedRefSetMemberCreateRequestBuilder
 		request.setActive(active);
 		request.setModuleId(moduleId);
 		request.setReferencedComponentId(referencedComponentId);
-		request.setReferenceSetId(referenceSetId);
+		request.setRefsetId(refsetId);
 		request.setProperties(properties);
 		return request;
 	}

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedRefSetMemberCreateRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedRefSetMemberCreateRequestBuilder.java
@@ -17,7 +17,6 @@ package com.b2international.snowowl.snomed.datastore.request;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.UUID;
 
 import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.core.events.BaseRequestBuilder;
@@ -35,7 +34,7 @@ public final class SnomedRefSetMemberCreateRequestBuilder
 		extends BaseRequestBuilder<SnomedRefSetMemberCreateRequestBuilder, TransactionContext, String>
 		implements SnomedTransactionalRequestBuilder<String> {
 
-	private String id = UUID.randomUUID().toString();
+	private String id;
 	private Boolean active = Boolean.TRUE;
 	private String moduleId;
 	private String refsetId;

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedSimpleMapMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedSimpleMapMemberCreateDelegate.java
@@ -53,7 +53,7 @@ final class SnomedSimpleMapMemberCreateDelegate extends SnomedRefSetMemberCreate
 				.withActive(isActive())
 				.withReferencedComponent(getReferencedComponentId())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withMapTargetId(getComponentId(SnomedRf2Headers.FIELD_MAP_TARGET))
 				.addTo(context);
 

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedSimpleMapMemberWithDescriptionCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedSimpleMapMemberWithDescriptionCreateDelegate.java
@@ -54,7 +54,7 @@ final class SnomedSimpleMapMemberWithDescriptionCreateDelegate extends SnomedRef
 				.withActive(isActive())
 				.withReferencedComponent(getReferencedComponentId())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withMapTargetId(getComponentId(SnomedRf2Headers.FIELD_MAP_TARGET))
 				.withMapTargetDescription(Strings.nullToEmpty(getProperty(SnomedRf2Headers.FIELD_MAP_TARGET_DESCRIPTION)))
 				.addTo(context);

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedSimpleMapToMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedSimpleMapToMemberCreateDelegate.java
@@ -54,7 +54,7 @@ final class SnomedSimpleMapToMemberCreateDelegate extends SnomedRefSetMemberCrea
 				.withActive(isActive())
 				.withReferencedComponent(getReferencedComponentId())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.withMapSourceId(getComponentId(SnomedRf2Headers.FIELD_MAP_SOURCE))
 				.addTo(context);
 

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedSimpleMemberCreateDelegate.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedSimpleMemberCreateDelegate.java
@@ -44,7 +44,7 @@ final class SnomedSimpleMemberCreateDelegate extends SnomedRefSetMemberCreateDel
 				.withActive(isActive())
 				.withReferencedComponent(getReferencedComponentId())
 				.withModuleId(getModuleId())
-				.withRefSet(getReferenceSetId())
+				.withRefSet(getRefsetId())
 				.addTo(context);
 
 		return member.getId();

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/exporter/Rf2RefSetExporter.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/exporter/Rf2RefSetExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2018-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -205,12 +205,12 @@ public class Rf2RefSetExporter extends Rf2Exporter<SnomedRefSetMemberSearchReque
 
 	@Override
 	protected SnomedRefSetMemberSearchRequestBuilder createSearchRequestBuilder() {
-		final Set<String> referenceSetIds = referenceSets.stream()
+		final Set<String> refsetIds = referenceSets.stream()
 				.map(c -> c.getId())
 				.collect(Collectors.toSet());
 		
 		return SnomedRequests.prepareSearchMember()
-				.filterByRefSet(referenceSetIds)
+				.filterByRefSet(refsetIds)
 				.sortBy(
 						Sort.fieldAsc(SnomedRefSetMemberIndexEntry.Fields.REFSET_ID), 
 						Sort.fieldAsc(SnomedRefSetMemberIndexEntry.Fields.ID));

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/importer/Rf2RefSetContentType.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/rf2/importer/Rf2RefSetContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2017-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ interface Rf2RefSetContentType extends Rf2ContentType<SnomedReferenceSetMember> 
 	@Override
 	default void validateByContentType(ImportDefectBuilder defectBuilder, String[] values) {
 		final String memberId = values[0];
-		final String referenceSetId = values[4];
+		final String refsetId = values[4];
 		final String referencedComponentId = values[5];
 		
 		defectBuilder
@@ -53,7 +53,7 @@ interface Rf2RefSetContentType extends Rf2ContentType<SnomedReferenceSetMember> 
 			.error("%s %s", Rf2ValidationDefects.INVALID_UUID, memberId);
 		
 		validateId(defectBuilder, referencedComponentId);
-		validateConceptIds(defectBuilder, referenceSetId);
+		validateConceptIds(defectBuilder, refsetId);
 		validateMembersByReferenceSetContentType(defectBuilder, values);
 	}
 	


### PR DESCRIPTION
Performing a concept create request with the following body throws `moduleId` is missing HTTP 400 Bad Request error, how ever concept moduleId should get propagated down to the nested create request.

```
{
  moduleId: <a-module-id>
  members: [
    {
      active: true,
      refsetId: '733073007',
      owlExpression: 'SubClassOf(:<pre-generated-concept-id> :900000000000443000)'
    }
  ],
  ...
}
```

Additionally: 
* improved the error message when `refsetId` field is missing
* deferred UUID generation to a later stage to speed up ID duplication check and request validation
