### PR TITLE
feat(snomed.datastore): Allow clients to selectively update concept members

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/domain/SnomedConcept.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/domain/SnomedConcept.java
@@ -36,6 +36,7 @@ import com.b2international.snowowl.snomed.core.domain.refset.SnomedReferenceSet;
 import com.b2international.snowowl.snomed.core.domain.refset.SnomedReferenceSetMember;
 import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument;
 import com.b2international.snowowl.snomed.datastore.request.SnomedConceptCreateRequestBuilder;
+import com.b2international.snowowl.snomed.datastore.request.SnomedConceptUpdateRequestBuilder;
 import com.b2international.snowowl.snomed.datastore.request.SnomedRequests;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -500,34 +501,39 @@ public final class SnomedConcept extends SnomedCoreComponent {
 	
 	@Override
 	public Request<TransactionContext, String> toCreateRequest(String containerId) {
+		// XXX: "containerId" parameter is ignored in case of new concepts
 		return toCreateRequestBuilder().build();
 	}
 
 	public SnomedConceptCreateRequestBuilder toCreateRequestBuilder() {
 		return SnomedRequests.prepareNewConcept()
-				.setActive(isActive())
-				.addMembers(getMembers())
-				.addRelationships(getRelationships())
-				.addDescriptions(getDescriptions())
-				.setDefinitionStatusId(getDefinitionStatusId())
-				.setId(getId())
-				.setModuleId(getModuleId())
-				.setSubclassDefinitionStatus(getSubclassDefinitionStatus());
+			.setActive(isActive())
+			.addMembers(getMembers())
+			.addRelationships(getRelationships())
+			.addDescriptions(getDescriptions())
+			.setDefinitionStatusId(getDefinitionStatusId())
+			.setId(getId())
+			.setModuleId(getModuleId())
+			.setSubclassDefinitionStatus(getSubclassDefinitionStatus());
 	}
 	
 	@Override
 	public Request<TransactionContext, Boolean> toUpdateRequest() {
-		return SnomedRequests.prepareUpdateConcept(getId())
-				.setActive(isActive())
-				.setInactivationProperties(getInactivationProperties())
-				.setDefinitionStatusId(getDefinitionStatusId())
-				.setModuleId(getModuleId())
-				.setSubclassDefinitionStatus(getSubclassDefinitionStatus())
-				.setDescriptions(getDescriptions())
-				.setRelationships(getRelationships())
-				.setMembers(getMembers())
-				.build();
+		return toUpdateRequestBuilder().build();
 	}
+
+	public SnomedConceptUpdateRequestBuilder toUpdateRequestBuilder() {
+		return SnomedRequests.prepareUpdateConcept(getId())
+			.setActive(isActive())
+			.setInactivationProperties(getInactivationProperties())
+			.setDefinitionStatusId(getDefinitionStatusId())
+			.setModuleId(getModuleId())
+			.setSubclassDefinitionStatus(getSubclassDefinitionStatus())
+			.setDescriptions(getDescriptions())
+			.setRelationships(getRelationships())
+			.setMembers(getMembers());
+	}
+
 	
 	@Override
 	public String toString() {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptUpdateRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptUpdateRequest.java
@@ -77,6 +77,7 @@ public final class SnomedConceptUpdateRequest extends SnomedComponentUpdateReque
 	private List<SnomedReferenceSetMember> members;
 
 	private SnomedReferenceSet refSet;
+	private Set<SnomedRefSetType> memberTypesToUpdate;
 	
 	SnomedConceptUpdateRequest(String componentId) {
 		super(componentId);
@@ -106,6 +107,10 @@ public final class SnomedConceptUpdateRequest extends SnomedComponentUpdateReque
 		this.refSet = refSet;
 	}
 	
+	void setMemberTypesToUpdate(Set<SnomedRefSetType> memberTypesToUpdate) {
+		this.memberTypesToUpdate = memberTypesToUpdate;
+	}
+
 	@Override
 	public Boolean execute(TransactionContext context) {
 		final int pageSize = context.getPageSize();
@@ -224,9 +229,16 @@ public final class SnomedConceptUpdateRequest extends SnomedComponentUpdateReque
 	}
 
 	private Set<String> getPreviousMemberIds(BranchContext context, String conceptId, int pageSize) {
+		// An empty set means none of the existing members should be considered
+		if (memberTypesToUpdate != null && memberTypesToUpdate.isEmpty()) {
+			return ImmutableSet.of();
+		}
+		
 		return SnomedRequests.prepareSearchMember()
 			.setLimit(pageSize)
 			.filterByReferencedComponent(conceptId)
+			// This filter handles the "null" and "non-empty set" cases
+			.filterByRefSetType(memberTypesToUpdate)
 			.stream(context)
 			.flatMap(SnomedReferenceSetMembers::stream)
 			.filter(getFilter())
@@ -239,7 +251,7 @@ public final class SnomedConceptUpdateRequest extends SnomedComponentUpdateReque
 			.filter(getFilter())
 			.collect(Collectors.toSet());
 	}
-
+	
 	private Predicate<SnomedReferenceSetMember> getFilter() {
 		return m -> !FILTERED_REFSET_IDS.contains(m.getRefsetId());
 	}

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptUpdateRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptUpdateRequestBuilder.java
@@ -16,13 +16,16 @@
 package com.b2international.snowowl.snomed.datastore.request;
 
 import java.util.List;
+import java.util.Set;
 
 import com.b2international.snowowl.snomed.core.domain.SnomedDescription;
 import com.b2international.snowowl.snomed.core.domain.SnomedRelationship;
 import com.b2international.snowowl.snomed.core.domain.SubclassDefinitionStatus;
+import com.b2international.snowowl.snomed.core.domain.refset.SnomedRefSetType;
 import com.b2international.snowowl.snomed.core.domain.refset.SnomedReferenceSet;
 import com.b2international.snowowl.snomed.core.domain.refset.SnomedReferenceSetMember;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * @since 4.5
@@ -35,6 +38,7 @@ public final class SnomedConceptUpdateRequestBuilder extends BaseSnomedComponent
 	private List<SnomedRelationship> relationships;
 	private List<SnomedReferenceSetMember> members;
 	private SnomedReferenceSet refSet;
+	private Set<SnomedRefSetType> memberTypesToUpdate;
 
 	SnomedConceptUpdateRequestBuilder(String componentId) {
 		super(componentId);
@@ -75,6 +79,34 @@ public final class SnomedConceptUpdateRequestBuilder extends BaseSnomedComponent
 		return getSelf();
 	}
 	
+	/**
+	 * Supported input values are:
+	 * 
+	 * <ul>
+	 * <li><code>null</code> &rarr; <b>all</b> existing members of a concept are
+	 * compared against the list provided in <code>members</code>
+	 * </li>
+	 * 
+	 * <li>empty set &rarr; <b>none</b> of the existing members of a concept are
+	 * compared against the list provided in <code>members</code><br>
+	 * (all elements in <code>members</code> will be added as a result)
+	 * </li>
+	 * 
+	 * <li>non-empty set &rarr; only those existing members of a concept will be
+	 * compared against the list provided in <code>members</code> that have a
+	 * type contained in this set<br>
+	 * (existing members of any other type will be ignored)
+	 * </li>
+	 * </ul>
+	 * 
+	 * @param memberTypesToUpdate - the reference set types to consider when 
+	 * updating existing members of a concept
+	 */
+	public SnomedConceptUpdateRequestBuilder setMemberTypesToUpdate(Set<SnomedRefSetType> memberTypesToUpdate) {
+		this.memberTypesToUpdate = memberTypesToUpdate != null ? ImmutableSet.copyOf(memberTypesToUpdate) : null;
+		return getSelf();
+	}
+	
 	@Override
 	protected void init(SnomedConceptUpdateRequest req) {
 		super.init(req);
@@ -84,6 +116,6 @@ public final class SnomedConceptUpdateRequestBuilder extends BaseSnomedComponent
 		req.setRelationships(relationships);
 		req.setMembers(members);
 		req.setRefSet(refSet);
+		req.setMemberTypesToUpdate(memberTypesToUpdate);
 	}
-	
 }


### PR DESCRIPTION
This is intended for users of the Java API who are not able to present a complete list of members (that includes both members to be updated as well as the ones which need to stay as they are) in `SnomedConceptUpdateRequest`'s reference set members collection.