### PR TITLE
Improve compatibility with BCP-47 language tags

### DIFF
--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemLookupConverter.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemLookupConverter.java
@@ -53,18 +53,20 @@ public interface FhirCodeSystemLookupConverter {
 	 * @param codeSystem
 	 * @param concept
 	 * @param parameters
-	 * @param acceptLanguage
 	 * @return
 	 */
-	default List<CodeSystemLookupResultParameters.Designation> expandDesignations(ServiceProvider context, CodeSystem codeSystem, Concept concept, CodeSystemLookupParameters parameters, String acceptLanguage) {
-		if (parameters.isPropertyRequested("designation")) {
-			return concept.getDescriptions()
-				.stream()
-				.map(description -> new CodeSystemLookupResultParameters.Designation().setValue(description.getTerm()).setLanguage(description.getLanguage()))
-				.collect(Collectors.toList());
-		} else {
+	default List<CodeSystemLookupResultParameters.Designation> expandDesignations(ServiceProvider context, CodeSystem codeSystem, Concept concept, CodeSystemLookupParameters parameters) {
+		if (!parameters.isPropertyRequested(CodeSystemLookupParameters.PROPERTY_DESIGNATION)) {
 			return null;
 		}
+		
+		return concept.getDescriptions()
+			.stream()
+			.map(description -> new CodeSystemLookupResultParameters.Designation()
+				.setValue(description.getTerm())
+				// Split private use extension values returned by Snow Owl into sections of at most 8 characters
+				.setLanguage(FhirRequest.expandLocale(description.getLanguage())))
+			.collect(Collectors.toList());
 	}
 
 	/**

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemLookupRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemLookupRequest.java
@@ -62,7 +62,7 @@ final class FhirCodeSystemLookupRequest extends FhirRequest<CodeSystemLookupResu
 	protected CodeSystemLookupResultParameters doExecute(ServiceProvider context, CodeSystem codeSystem) {
 		validateRequestedProperties(codeSystem);
 		
-		final String acceptLanguage = extractLocales(parameters.getDisplayLanguage());
+		final String displayLanguage = compactLocale(parameters.getDisplayLanguage());
 
 		FhirCodeSystemLookupConverter converter = context.service(RepositoryManager.class).get(codeSystem.getUserString(TerminologyResource.Fields.TOOLING_ID))
 				.optionalService(FhirCodeSystemLookupConverter.class)
@@ -75,7 +75,7 @@ final class FhirCodeSystemLookupRequest extends FhirRequest<CodeSystemLookupResu
 			.one()
 			.filterByCodeSystemUri(resourceUri)
 			.filterById(parameters.extractCode())
-			.setLocales(acceptLanguage)
+			.setLocales(displayLanguage)
 			.setExpand(conceptExpand)
 			.buildAsync()
 			.execute(context)
@@ -87,7 +87,7 @@ final class FhirCodeSystemLookupRequest extends FhirRequest<CodeSystemLookupResu
 		result.setName(codeSystem.getName());
 		result.setDisplay(concept.getTerm());
 		result.setVersion(codeSystem.getVersion());
-		result.setDesignation(converter.expandDesignations(context, codeSystem, concept, parameters, acceptLanguage));
+		result.setDesignation(converter.expandDesignations(context, codeSystem, concept, parameters));
 		result.setProperty(converter.expandProperties(context, codeSystem, concept, parameters));
 		
 		return result;
@@ -97,7 +97,7 @@ final class FhirCodeSystemLookupRequest extends FhirRequest<CodeSystemLookupResu
 		final Set<String> requestedProperties = Set.copyOf(parameters.getPropertyValues());
 		// first check if any of the properties are lookup request properties
 		final Set<String> nonLookupProperties = Sets.difference(requestedProperties, CodeSystemLookupParameters.OFFICIAL_R5_PROPERTY_VALUES);
-		
+
 		// second check if the remaining unsupported properties supported by the CodeSystem either via full URL
 		final Set<String> supportedProperties = codeSystem.getProperty() == null 
 				? Collections.emptySet() 

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemValidateCodeRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirCodeSystemValidateCodeRequest.java
@@ -26,6 +26,7 @@ import org.hl7.fhir.r5.model.Coding;
 
 import com.b2international.fhir.r5.operations.CodeSystemValidateCodeParameters;
 import com.b2international.fhir.r5.operations.CodeSystemValidateCodeResultParameters;
+import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.codesystem.CodeSystemRequests;
 import com.b2international.snowowl.core.domain.Concept;
@@ -58,46 +59,50 @@ final class FhirCodeSystemValidateCodeRequest extends FhirRequest<CodeSystemVali
 
 	@Override
 	public CodeSystemValidateCodeResultParameters doExecute(ServiceProvider context, CodeSystem codeSystem) {
-		Set<Coding> codings = collectCodingsToValidate(parameters);
-		Map<String, Coding> codingsById = codings.stream().collect(Collectors.toMap(Coding::getCode, c -> c));
+		final Set<Coding> codings = collectCodingsToValidate(parameters);
+		final String displayLanguage = compactLocale(parameters.getDisplayLanguage());
+		final ResourceURI codeSystemUri = FhirModelHelpers.resourceUriFrom(codeSystem);
+
+		final Map<String, Coding> codingsById = codings.stream()
+			.collect(Collectors.toMap(
+				c -> c.getCode(), 
+				c -> c));
+
+		final Map<String, Concept> conceptsById = CodeSystemRequests.prepareSearchConcepts()
+			.setLimit(codingsById.keySet().size())
+			.filterByCodeSystemUri(codeSystemUri)
+			.filterByIds(codingsById.keySet())
+			.setLocales(displayLanguage)
+			.buildAsync()
+			.execute(context)
+			.stream()
+			.collect(Collectors.toMap(
+				c -> c.getId(), 
+				c -> c));
 		
-		// extract locales from the request
-		Map<String, Concept> conceptsById = CodeSystemRequests.prepareSearchConcepts()
-				.setLimit(codingsById.keySet().size())
-				.filterByCodeSystemUri(FhirModelHelpers.resourceUriFrom(codeSystem))
-				.filterByIds(codingsById.keySet())
-				.setLocales(extractLocales(parameters.getDisplayLanguage()))
-				.buildAsync()
-				.execute(context)
-				.stream()
-				.collect(Collectors.toMap(Concept::getId, c -> c));
-		
-		// check if both Maps have the same keys and report if not
-		
+		// Check if both Maps have the same keys and report if not
 		Set<String> missingConceptIds = Sets.difference(codingsById.keySet(), conceptsById.keySet());
 		
 		if (!missingConceptIds.isEmpty()) {
 			return new CodeSystemValidateCodeResultParameters()
-					.setResult(false)
-					.setMessage(String.format("Could not find code%s '%s'.", missingConceptIds.size() == 1 ? "" : "s", ImmutableSortedSet.copyOf(missingConceptIds)));
+				.setResult(false)
+				.setMessage(String.format("Could not find code%s '%s'.", missingConceptIds.size() == 1 ? "" : "s", ImmutableSortedSet.copyOf(missingConceptIds)));
 		}
 		
-		// iterate over requested IDs to detect if one does not have any concept returned
-		// XXX it would be great to have support for multiple messages/validation results in a single request
-		for (String id : codingsById.keySet()) {
-			// check display if provided
-			Coding providedCoding = codingsById.get(id);
-			if (providedCoding.getDisplay() != null) {
+		// TODO: add more validation functionality that is checked for each coding (eg. alternative terms)
+		for (final String id : codingsById.keySet()) {
+			final Coding coding = codingsById.get(id);
+			final String expectedDisplay = coding.getDisplay();
+			
+			if (expectedDisplay != null) {
+				final Concept actualConcept = conceptsById.get(id);
+				final String actualDisplay = actualConcept.getTerm();
 				
-				Concept concept = conceptsById.get(id);
-				
-				// TODO what about alternative terms?
-				
-				if (!providedCoding.getDisplay().equals(concept.getTerm())) {
+				if (!expectedDisplay.equals(actualDisplay)) {
 					return new CodeSystemValidateCodeResultParameters()
-							.setResult(false)
-							.setMessage(String.format("Incorrect display '%s' for code '%s'.", providedCoding.getDisplay(), providedCoding.getCode())) 
-							.setDisplay(concept.getTerm());
+						.setResult(false)
+						.setMessage(String.format("Incorrect display '%s' for code '%s'.", expectedDisplay, coding.getCode())) 
+						.setDisplay(actualDisplay);
 				}
 			}
 		}
@@ -110,8 +115,8 @@ final class FhirCodeSystemValidateCodeRequest extends FhirRequest<CodeSystemVali
 				
 		if (parameters.getCode() != null) {
 			Coding coding = new Coding()
-					.setCode(parameters.getCode().getValue())
-					.setDisplay(parameters.getDisplay() != null ? parameters.getDisplay().getValue() : null);
+				.setCode(parameters.getCode().getValue())
+				.setDisplay(parameters.getDisplay() != null ? parameters.getDisplay().getValue() : null);
 			
 			codings.add(coding);
 		}
@@ -124,7 +129,7 @@ final class FhirCodeSystemValidateCodeRequest extends FhirRequest<CodeSystemVali
 		if (codeableConcept != null && codeableConcept.getCoding() != null) {
 			codeableConcept.getCoding().forEach(codings::add);
 		}
+		
 		return codings;
 	}
-	
 }

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirRequest.java
@@ -15,13 +15,16 @@
  */
 package com.b2international.snowowl.fhir.core.request.codesystem;
 
+import java.util.IllformedLocaleException;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.hl7.fhir.r5.model.Bundle;
 import org.hl7.fhir.r5.model.CodeSystem;
 import org.hl7.fhir.r5.model.CodeType;
 
-import com.b2international.commons.CompareUtils;
+import com.b2international.commons.StringUtils;
 import com.b2international.commons.exceptions.NotFoundException;
 import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.snowowl.core.RepositoryManager;
@@ -29,7 +32,9 @@ import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.uri.ResourceURLSchemaSupport;
 import com.b2international.snowowl.fhir.core.Summary;
+import com.b2international.snowowl.fhir.core.exceptions.BadRequestException;
 import com.b2international.snowowl.fhir.core.request.FhirRequests;
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 
 /**
@@ -120,12 +125,78 @@ public abstract class FhirRequest<R> implements Request<ServiceProvider, R> {
 		return Summary.TRUE;
 	}
 
-	public static final String extractLocales(CodeType displayLanguage) {
-		String locales = displayLanguage != null ? displayLanguage.getCode() : null;
-		if (CompareUtils.isEmpty(locales)) {
-			locales = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER;
+	/**
+	 * Converts a BCP-47 language tag (where the private use extension portions
+	 * are split into at most 8 characters, separated by dashes) into the "compact"
+	 * non-standard representation used in Snow Owl's internal API.
+	 * 
+	 * @param localeAsCode
+	 * @return
+	 */
+	public static final String compactLocale(final CodeType localeAsCode) {
+		final String locale = (localeAsCode != null) ? localeAsCode.getCode() : null;
+		if (StringUtils.isEmpty(locale)) {
+			return AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER;
 		}
-		return locales;
+		
+		return compactLocale(locale);
+	}
+
+	public static String compactLocale(final String locale) {
+		// Parse the input in accordance with BCP-47 grammar (it should be valid)
+		final Locale.Builder builder = new Locale.Builder();
+		try {
+			builder.setLanguageTag(locale);
+		} catch (IllformedLocaleException ex) {
+			throw new BadRequestException(ex.getMessage());
+		}
+		
+		// Remove hyphen separators from the private use extension
+		final Locale parsedLocale = builder.build();
+		final String privateUseExtension = parsedLocale.getExtension(Locale.PRIVATE_USE_EXTENSION);
+		if (StringUtils.isEmpty(privateUseExtension)) {
+			return locale;
+		}
+		
+		/*
+		 * Remove dashes and replace the old private use extension with the compact one
+		 * (using "-x-" as the anchoring prefix -- it should not appear elsewhere in the
+		 * language tag)
+		 */
+		final String separatorsRemovedExtension = privateUseExtension.replace("-", "");
+		return locale.replace("-x-" + privateUseExtension, "-x-" + separatorsRemovedExtension);
+	}
+	
+	/**
+	 * Converts a "compact" locale representation into a BCP-47 language tag by
+	 * splitting the private use extension portions into at most 8 characters,
+	 * separating each section with a dash.
+	 * 
+	 * @param locale
+	 * @return
+	 */
+	public static final String expandLocale(String locale) {
+		if (StringUtils.isEmpty(locale)) {
+			return null;
+		}
+		
+		/*
+		 * XXX: Assuming locales returned by Snow Owl are in the form of eg. "en-US" or
+		 * "en-x-1234567890123456789" (We can not use Java's built-in parser as at this
+		 * point the extension breaks length limits and the language tag is invalid)
+		 */
+		final int privateUseIdx = locale.lastIndexOf("-x-");
+		if (privateUseIdx < 0 || privateUseIdx + 3 >= locale.length()) {
+			return locale;
+		}
+		
+		final String separatorsRemovedExtension = locale.substring(privateUseIdx + 3);
+		final String privateUseExtension = Splitter.fixedLength(8) // split private use portion into 8 character segments
+			.splitToStream(separatorsRemovedExtension)
+			.collect(Collectors.joining("-")); // combine again with hyphens
+		
+		// Replace the old private use extension
+		return locale.replace("-x-" + separatorsRemovedExtension, "-x-" + privateUseExtension);
 	}
 
 	protected abstract R doExecute(ServiceProvider context, CodeSystem codeSystem);

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/codesystem/FhirRequest.java
@@ -184,6 +184,8 @@ public abstract class FhirRequest<R> implements Request<ServiceProvider, R> {
 		 * XXX: Assuming locales returned by Snow Owl are in the form of eg. "en-US" or
 		 * "en-x-1234567890123456789" (We can not use Java's built-in parser as at this
 		 * point the extension breaks length limits and the language tag is invalid)
+		 * 
+		 * See FhirLocaleTest#expandSplitPrivateUseExtension for an example.
 		 */
 		final int privateUseIdx = locale.lastIndexOf("-x-");
 		if (privateUseIdx < 0 || privateUseIdx + 3 >= locale.length()) {

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/valueset/FhirValueSetExpandRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/valueset/FhirValueSetExpandRequest.java
@@ -18,40 +18,24 @@ package com.b2international.snowowl.fhir.core.request.valueset;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import org.elasticsearch.common.Strings;
 import org.hl7.fhir.r5.model.Bundle;
 import org.hl7.fhir.r5.model.CodeSystem;
-import org.hl7.fhir.r5.model.StringType;
 import org.hl7.fhir.r5.model.Enumerations.FilterOperator;
 import org.hl7.fhir.r5.model.Enumerations.PublicationStatus;
 import org.hl7.fhir.r5.model.ValueSet;
-import org.hl7.fhir.r5.model.ValueSet.ConceptReferenceDesignationComponent;
 
-import com.b2international.commons.CompareUtils;
 import com.b2international.commons.exceptions.NotFoundException;
-import com.b2international.fhir.r5.operations.CodeSystemLookupResultParameters.Designation;
 import com.b2international.fhir.r5.operations.ValueSetExpandParameters;
 import com.b2international.snowowl.core.RepositoryManager;
 import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.TerminologyResource;
-import com.b2international.snowowl.core.codesystem.CodeSystemRequests;
-import com.b2international.snowowl.core.domain.Concept;
-import com.b2international.snowowl.core.domain.Concepts;
-import com.b2international.snowowl.core.domain.Description;
 import com.b2international.snowowl.core.events.Request;
-import com.b2international.snowowl.core.request.ConceptSearchRequestBuilder;
-import com.b2international.snowowl.core.request.SearchIndexResourceRequest;
-import com.b2international.snowowl.core.request.SearchResourceRequest;
 import com.b2international.snowowl.fhir.core.FhirModelHelpers;
 import com.b2international.snowowl.fhir.core.R5ObjectFields;
 import com.b2international.snowowl.fhir.core.exceptions.BadRequestException;
 import com.b2international.snowowl.fhir.core.request.FhirRequests;
-import com.b2international.snowowl.fhir.core.request.codesystem.FhirRequest;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.Hashing;
@@ -71,9 +55,12 @@ final class FhirValueSetExpandRequest implements Request<ServiceProvider, ValueS
 	
 	@Override
 	public ValueSet execute(ServiceProvider context) {
+		
 		final String uri = parameters.getUrl().asStringValue();
 		ValueSet valueSet = null;
+		
 		try {
+			
 			valueSet = FhirRequests.valueSets().prepareGet(uri)
 					.setElements(ImmutableList.<String>builder()
 							.addAll(R5ObjectFields.ValueSet.SUMMARY)
@@ -82,25 +69,30 @@ final class FhirValueSetExpandRequest implements Request<ServiceProvider, ValueS
 							.build())
 					.buildAsync()
 					.execute(context);
-			return context.service(RepositoryManager.class)
-					.get(valueSet.getUserString(TerminologyResource.Fields.TOOLING_ID))
-					.optionalService(FhirValueSetExpander.class)
-					.orElse(FhirValueSetExpander.NOOP)
-					.expand(context, valueSet, parameters);
-		} catch (NotFoundException e) {
-			// if there is no Value Set present for the given URL, then try to parse the URL to a meaningful value if possible and evaluate it
-			if (uri.startsWith("http://")) {
-				ValueSet implicitVs = computeFhirValueSetUsingUrl(context, uri);
-				if (implicitVs != null) {
-					return implicitVs;
-				}
-			}
 			
-			throw e;
+		} catch (NotFoundException e) {
+			
+			// If there is no Value Set present for the given URL, then try to parse the URL to a meaningful value if possible and evaluate it
+			if (uri.startsWith("http://")) {
+				valueSet = expandImplicitValueSet(context, uri);
+			}
+
+			// If we couldn't come up with an implicit value set definition, fail using the original exception...
+			if (valueSet == null) {
+				throw e;
+			}
 		}
+
+		// ...otherwise we should have a VS composition that can be evaluated 
+		return context.service(RepositoryManager.class)
+			.get(valueSet.getUserString(TerminologyResource.Fields.TOOLING_ID))
+			.optionalService(FhirValueSetExpander.class)
+			.orElse(FhirValueSetExpander.NOOP)
+			.expand(context, valueSet, parameters);
+
 	}
 
-	private ValueSet computeFhirValueSetUsingUrl(ServiceProvider context, String urlValue) {
+	private ValueSet expandImplicitValueSet(ServiceProvider context, String urlValue) {
 		// only URLs with query parts are supported, every other case is rejected for now
 		if (urlValue.contains("#")) {
 			return null;
@@ -138,29 +130,16 @@ final class FhirValueSetExpandRequest implements Request<ServiceProvider, ValueS
 		// return the content of the CodeSystem as Value Set
 		String id = Hashing.goodFastHash(8).hashString(urlValue, Charsets.UTF_8).toString();
 		ValueSet valueSet = (ValueSet) new ValueSet()
-				.setUrl(urlValue)
-				// according to https://terminology.hl7.org/SNOMEDCT.html#snomed-ct-implicit-value-sets publication status is always ACTIVE
-				.setStatus(PublicationStatus.ACTIVE)
-				.setId(id);
+			.setUrl(urlValue)
+			// according to https://terminology.hl7.org/SNOMEDCT.html#snomed-ct-implicit-value-sets publication status is always ACTIVE
+			.setStatus(PublicationStatus.ACTIVE)
+			.setId(id);
 		
-		final ValueSet.ValueSetExpansionComponent expansion = new ValueSet.ValueSetExpansionComponent()
-				.setIdentifier(id)
-				.setTimestampElement(FhirModelHelpers.toDateTimeElement(new Date()));
+		// XXX: Use the code system's tooling ID as the expand service selector
+		valueSet.setUserData(TerminologyResource.Fields.TOOLING_ID, codeSystem.getUserString(TerminologyResource.Fields.TOOLING_ID));
+		valueSet.setUserData("codeSystemUri", FhirModelHelpers.resourceUriFrom(codeSystem));
+		valueSet.setUserData("baseUrl", baseUrl);
 		
-		final String termFilter = parameters.getFilter() == null ? null : parameters.getFilter().getValue();
-		
-		ConceptSearchRequestBuilder req = CodeSystemRequests.prepareSearchConcepts()
-				.filterByCodeSystemUri(FhirModelHelpers.resourceUriFrom(codeSystem))
-				.filterByActive(parameters.getActiveOnly() == null ? null : parameters.getActiveOnly().getValue())
-				.filterByTerm(termFilter)
-				.setLimit(parameters.getCount() == null ? 10 : parameters.getCount().getValue())
-				.setSearchAfter(parameters.getAfter() == null ? null : parameters.getAfter().getValue())
-				// SNOMED only preferred display support (VS should always use FSN)
-				.setPreferredDisplay("FSN") 
-				.setLocales(FhirRequest.extractLocales(parameters.getDisplayLanguage()))
-				// always return sorted results for consistency, in case of term filtering return by score otherwise by ID
-				.sortBy(!CompareUtils.isEmpty(termFilter) ? SearchIndexResourceRequest.SCORE : SearchResourceRequest.Sort.fieldAsc("id"));
-
 		ValueSet.ValueSetComposeComponent compose = null;
 		
 		// configure query based on fhir_vs query parameter and also build the compose declaration for this implicit Value Set
@@ -178,11 +157,11 @@ final class FhirValueSetExpandRequest implements Request<ServiceProvider, ValueS
 					throw new BadRequestException("Failed to decode ECL expression: " + e.getMessage());
 				}
 				
-				req.filterByQuery(ecl);
 				// configure Value Set for ECL
 				valueSet
 					.setName(String.format("%s Concepts matching %s", codeSystem.getName(), ecl))
 					.setDescription(String.format("All SNOMED CT concepts that match the expression constraint %s", ecl));
+				
 				// configure compose for ECL
 				compose = new ValueSet.ValueSetComposeComponent();
 				compose.addInclude(
@@ -191,11 +170,12 @@ final class FhirValueSetExpandRequest implements Request<ServiceProvider, ValueS
 							new ValueSet.ConceptSetFilterComponent()
 								.setProperty("constraint")
 								.setOp(FilterOperator.EQUAL)
+								.setValue(ecl)
 						)
 				);
 			} else if (fhirVsValue.startsWith("isa/")) {
 				String parent = fhirVsValue.replace("isa/", "");
-				req.filterByAncestor(parent);
+				
 				// configure Value Set for IS A
 				valueSet
 					.setName(String.format("%s Concept %s and descendants", codeSystem.getName(), parent))
@@ -218,7 +198,6 @@ final class FhirValueSetExpandRequest implements Request<ServiceProvider, ValueS
 					// TODO support refset identifier concept search
 					return null;
 				} else {
-					req.filterByQuery("^"+refsetId);
 					// configure Value Set for REFSET
 					valueSet
 						.setName(String.format("%s Reference Set %s", codeSystem.getName(), refsetId))
@@ -243,41 +222,7 @@ final class FhirValueSetExpandRequest implements Request<ServiceProvider, ValueS
 				return null;
 			}
 		}
-		
-		Concepts concepts = req.buildAsync().execute(context);
-		
-		expansion
-			.setTotal(concepts.getTotal())
-			.addExtension(FhirValueSetExpander.EXTENSION_AFTER_PROPERTY_URL, new StringType(concepts.getSearchAfter()));
-		
-		for (Concept concept : concepts) {
-			var contains = new ValueSet.ValueSetExpansionContainsComponent()
-				.setCode(concept.getId())
-				.setSystem(baseUrl)
-				.setDisplay(concept.getTerm());
-			
-			if (parameters.getIncludeDesignations() != null && parameters.getIncludeDesignations().getValue()) {
-				contains.setDesignation(fromDescriptions(concept.getDescriptions()));
-			}
-			
-			expansion.addContains(contains);
-		}
-		
-		return valueSet
-				.setCompose(compose)
-				.setExpansion(expansion);
-	}
 
-	/**
-	 * Maps the given collection of {@link Description} objects into FHIR {@link Designation} objects by mapping the term and language fields to the matching properties.
-	 * @param descriptions
-	 * @return a {@link List} of {@link Designation} objects, never <code>null</code>.
-	 */
-	public static List<ConceptReferenceDesignationComponent> fromDescriptions(Collection<Description> descriptions) {
-		return descriptions
-				.stream()
-				.map(description -> new ConceptReferenceDesignationComponent().setValue(description.getTerm()).setLanguage(description.getLanguage()))
-				.collect(Collectors.toList());
+		return valueSet.setCompose(compose);
 	}
-	
 }

--- a/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/FhirLocaleTest.java
+++ b/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/FhirLocaleTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024 B2i Healthcare, https://b2ihealthcare.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.fhir.rest.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import org.hl7.fhir.r5.model.CodeType;
+import org.junit.Test;
+
+import com.b2international.commons.http.AcceptLanguageHeader;
+import com.b2international.snowowl.fhir.core.exceptions.BadRequestException;
+import com.b2international.snowowl.fhir.core.request.codesystem.FhirRequest;
+
+public class FhirLocaleTest {
+
+	@Test
+	public void compactNull() {
+		assertEquals(AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, FhirRequest.compactLocale((CodeType) null));
+	}
+	
+	@Test
+	public void compactNullValue() {
+		assertEquals(AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, FhirRequest.compactLocale(new CodeType()));
+	}
+	
+	@Test
+	public void compactEmptyValue() {
+		assertEquals(AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, FhirRequest.compactLocale(new CodeType("")));
+	}
+	
+	@Test
+	public void compactValidLanguage() {
+		assertEquals("en", FhirRequest.compactLocale(new CodeType("en")));
+	}
+	
+	@Test
+	public void compactValidCountry() {
+		assertEquals("en-US", FhirRequest.compactLocale(new CodeType("en-US")));
+	}
+	
+	@Test
+	public void compactValidPrivateUseExtension() {
+		assertEquals("en-US-x-compact", FhirRequest.compactLocale(new CodeType("en-US-x-compact")));
+	}
+	
+	@Test
+	public void compactLongPrivateUseExtension() {
+		// 19 digits represent the SCTID of a language reference set
+		assertEquals("en-US-x-1234567890123456789", FhirRequest.compactLocale(new CodeType("en-US-x-12345678-90123456-789")));
+	}
+	
+	@Test
+	public void compactInvalidPrivateUseExtension() {
+		// 19 digits as "unbroken" input is not allowed however
+		assertThrows(BadRequestException.class, () -> FhirRequest.compactLocale(new CodeType("en-US-x-1234567890123456789")));
+	}
+	
+	@Test
+	public void compactInvalidLanguage() {
+		// 9 characters long input can not be accepted as a language tag
+		assertThrows(BadRequestException.class, () -> FhirRequest.compactLocale(new CodeType("notsubtag")));
+	}
+	
+	@Test
+	public void expandNull() {
+		assertNull(FhirRequest.expandLocale(null));
+	}
+	
+	@Test
+	public void expandEmpty() {
+		assertNull(FhirRequest.expandLocale(""));
+	}
+	
+	@Test
+	public void expandValidLanguage() {
+		assertEquals("en", FhirRequest.expandLocale("en"));
+	}
+	
+	@Test
+	public void expandValidCountry() {
+		assertEquals("en-US", FhirRequest.expandLocale("en-US"));
+	}
+	
+	@Test
+	public void expandShortPrivateUseExtension() {
+		// Short private use extensions will work but are not supported
+		assertEquals("en-US-x-expand", FhirRequest.expandLocale("en-US-x-expand"));
+	}
+	
+	@Test
+	public void expandSplitPrivateUseExtension() {
+		/*
+		 * Extensions that are already broken up into shorter segments may get split
+		 * further when passed through this method.
+		 */
+		assertEquals("en-US-x-expanded--priv-us-e", FhirRequest.expandLocale("en-US-x-expanded-priv-use"));
+	}
+	
+	@Test
+	public void expandInvalidPrivateUseExtension() {
+		// 19 digits should be broken up into at most 8 character segments 
+		assertEquals("en-US-x-12345678-90123456-789", FhirRequest.expandLocale("en-US-x-1234567890123456789"));
+	}
+	
+}

--- a/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/FhirRestTest.java
+++ b/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/FhirRestTest.java
@@ -15,6 +15,8 @@
  */
 package com.b2international.snowowl.fhir.rest.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -23,8 +25,11 @@ import org.junit.Before;
 import org.junit.Rule;
 
 import com.b2international.snowowl.snomed.common.SnomedTerminologyComponentConstants;
+import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
 import com.b2international.snowowl.test.commons.TestMethodNameRule;
 import com.b2international.snowowl.test.commons.codesystem.CodeSystemRestRequests;
+
+import io.restassured.path.json.JsonPath;
 
 /**
  * Superclass for common REST-related test functionality. All tests receive a single Code System to test/verify/use as test fixture. The CodeSystemId
@@ -80,4 +85,15 @@ public abstract class FhirRestTest extends FhirTest {
 		return CodeSystemRestRequests.getSnomedIntUrl(getTestCodeSystemId());
 	}
 
+	protected final static void checkDesignationUseContext(JsonPath jsonPath, String rootPath, String refsetId, String typeId) {
+		jsonPath.setRootPath(rootPath);
+		assertThat(jsonPath.getString("url")).isEqualTo("http://snomed.info/fhir/StructureDefinition/designation-use-context");
+		
+		assertThat(jsonPath.getString("extension[0].url")).isEqualTo("context");
+		assertThat(jsonPath.getString("extension[0].valueCoding.code")).isEqualTo(refsetId);
+		assertThat(jsonPath.getString("extension[1].url")).isEqualTo("role");
+		assertThat(jsonPath.getString("extension[1].valueCoding.code")).isEqualTo(Concepts.REFSET_DESCRIPTION_ACCEPTABILITY_PREFERRED);
+		assertThat(jsonPath.getString("extension[2].url")).isEqualTo("type");
+		assertThat(jsonPath.getString("extension[2].valueCoding.code")).isEqualTo(typeId);
+	}
 }

--- a/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/codesystem/FhirSnomedCodeSystemLookupTest.java
+++ b/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/codesystem/FhirSnomedCodeSystemLookupTest.java
@@ -17,6 +17,7 @@ package com.b2international.snowowl.fhir.rest.tests.codesystem;
 
 import static com.b2international.snowowl.fhir.rest.tests.FhirRestTest.Endpoints.CODESYSTEM_LOOKUP;
 import static com.b2international.snowowl.test.commons.rest.RestExtensions.givenAuthenticatedRequest;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -32,6 +33,8 @@ import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
 import com.b2international.snowowl.snomed.common.SnomedTerminologyComponentConstants;
 import com.b2international.snowowl.test.commons.codesystem.CodeSystemRestRequests;
 import com.b2international.snowowl.test.commons.rest.RestExtensions;
+
+import io.restassured.path.json.JsonPath;
 
 /**
  * CodeSystem $lookup operation for FHIR code systems REST end-point test cases
@@ -197,7 +200,7 @@ public class FhirSnomedCodeSystemLookupTest extends FhirRestTest {
 	
 	@Test
 	public void GET_CodeSystem_$lookup_Designations() throws Exception {
-		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
+		JsonPath jsonPath = givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
 			.queryParam("system", SNOMEDCT_URL)
 			.queryParam("code", CLINICAL_FINDING)
 			.queryParam("property", "designation")
@@ -210,30 +213,33 @@ public class FhirSnomedCodeSystemLookupTest extends FhirRestTest {
 			.body("parameter[0].valueString", equalTo("SNOMEDCT"))
 			.body("parameter[1].name", equalTo("display"))
 			.body("parameter[1].valueString", equalTo("Clinical finding"))
-			.body("parameter[2].name", equalTo("designation"))
-			.body("parameter[2].part[0].valueCode", equalTo("en"))
-			.body("parameter[2].part[1].valueCoding.code", equalTo("900000000000013009"))
-			.body("parameter[2].part[2].valueString", equalTo("Clinical finding"))
-			.body("parameter[3].name", equalTo("designation"))
-			.body("parameter[3].part[0].valueCode", equalTo("en-x-" + Concepts.REFSET_LANGUAGE_TYPE_UK))
-			.body("parameter[3].part[1].valueCoding.code", equalTo("900000000000013009"))
-			.body("parameter[3].part[2].valueString", equalTo("Clinical finding"))
-			.body("parameter[4].name", equalTo("designation"))
-			.body("parameter[4].part[0].valueCode", equalTo("en-x-" + Concepts.REFSET_LANGUAGE_TYPE_US))
-			.body("parameter[4].part[1].valueCoding.code", equalTo("900000000000013009"))
-			.body("parameter[4].part[2].valueString", equalTo("Clinical finding"))
-			.body("parameter[5].name", equalTo("designation"))
-			.body("parameter[5].part[0].valueCode", equalTo("en"))
-			.body("parameter[5].part[1].valueCoding.code", equalTo("900000000000003001"))
-			.body("parameter[5].part[2].valueString", equalTo("Clinical finding (finding)"))
-			.body("parameter[6].name", equalTo("designation"))
-			.body("parameter[6].part[0].valueCode", equalTo("en-x-" + Concepts.REFSET_LANGUAGE_TYPE_UK))
-			.body("parameter[6].part[1].valueCoding.code", equalTo("900000000000003001"))
-			.body("parameter[6].part[2].valueString", equalTo("Clinical finding (finding)"))
-			.body("parameter[7].name", equalTo("designation"))
-			.body("parameter[7].part[0].valueCode", equalTo("en-x-" + Concepts.REFSET_LANGUAGE_TYPE_US))
-			.body("parameter[7].part[1].valueCoding.code", equalTo("900000000000003001"))
-			.body("parameter[7].part[2].valueString", equalTo("Clinical finding (finding)"));
+			.extract()
+			.jsonPath();
+		
+		jsonPath.setRootPath("parameter[2]");
+		assertThat(jsonPath.getString("name")).isEqualTo("designation");
+
+		assertThat(jsonPath.getString("part[0].name")).isEqualTo("language");
+		assertThat(jsonPath.getString("part[0].valueCode")).isEqualTo("en");
+		assertThat(jsonPath.getString("part[1].name")).isEqualTo("use");
+		assertThat(jsonPath.getString("part[1].valueCoding.code")).isEqualTo(Concepts.FULLY_SPECIFIED_NAME);
+		assertThat(jsonPath.getString("part[2].name")).isEqualTo("value");
+		assertThat(jsonPath.getString("part[2].valueString")).isEqualTo("Clinical finding (finding)");
+
+		jsonPath.setRootPath("parameter[3]");
+		assertThat(jsonPath.getString("name")).isEqualTo("designation");
+
+		assertThat(jsonPath.getString("part[0].name")).isEqualTo("language");
+		assertThat(jsonPath.getString("part[0].valueCode")).isEqualTo("en");
+		assertThat(jsonPath.getString("part[1].name")).isEqualTo("use");
+		assertThat(jsonPath.getString("part[1].valueCoding.code")).isEqualTo(Concepts.SYNONYM);
+		assertThat(jsonPath.getString("part[2].name")).isEqualTo("value");
+		assertThat(jsonPath.getString("part[2].valueString")).isEqualTo("Clinical finding");
+		
+		checkDesignationUseContext(jsonPath, "parameter[2].extension[0]", Concepts.REFSET_LANGUAGE_TYPE_UK, Concepts.FULLY_SPECIFIED_NAME);
+		checkDesignationUseContext(jsonPath, "parameter[2].extension[1]", Concepts.REFSET_LANGUAGE_TYPE_US, Concepts.FULLY_SPECIFIED_NAME);
+		checkDesignationUseContext(jsonPath, "parameter[3].extension[0]", Concepts.REFSET_LANGUAGE_TYPE_UK, Concepts.SYNONYM);
+		checkDesignationUseContext(jsonPath, "parameter[3].extension[1]", Concepts.REFSET_LANGUAGE_TYPE_US, Concepts.SYNONYM);
 	}
 	
 	@Test

--- a/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/valueset/FhirSnomedValueSetExpandTest.java
+++ b/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/valueset/FhirSnomedValueSetExpandTest.java
@@ -27,7 +27,10 @@ import org.junit.Test;
 import com.b2international.commons.json.Json;
 import com.b2international.snowowl.fhir.rest.tests.FhirRestTest;
 import com.b2international.snowowl.snomed.common.SnomedTerminologyComponentConstants;
+import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
 import com.b2international.snowowl.test.commons.rest.RestExtensions;
+
+import io.restassured.path.json.JsonPath;
 
 /**
  * @since 8.0
@@ -111,7 +114,7 @@ public class FhirSnomedValueSetExpandTest extends FhirRestTest {
 	
 	@Test
 	public void expandSnomedCodeSystemURL_IncludeDesignations() throws Exception {
-		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
+		JsonPath jsonPath = givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
 			.queryParam("url", RestExtensions.encodeQueryParameter(SnomedTerminologyComponentConstants.SNOMED_URI_SCT + "/900000000000207008?fhir_vs=ecl/<!138875005"))
 			.queryParam("includeDesignations", true)
 			.when().get("/ValueSet/$expand")
@@ -125,16 +128,15 @@ public class FhirSnomedValueSetExpandTest extends FhirRestTest {
 			.body("expansion.contains[0].display", equalTo("Substance (substance)"))
 			.body("expansion.contains[0].designation[0].value", equalTo("Substance"))
 			.body("expansion.contains[0].designation[0].language", equalTo("en"))
-			.body("expansion.contains[0].designation[1].value", equalTo("Substance"))
-			.body("expansion.contains[0].designation[1].language", equalTo("en-x-900000000000508004"))
-			.body("expansion.contains[0].designation[2].value", equalTo("Substance"))
-			.body("expansion.contains[0].designation[2].language", equalTo("en-x-900000000000509007"))
-			.body("expansion.contains[0].designation[3].value", equalTo("Substance (substance)"))
-			.body("expansion.contains[0].designation[3].language", equalTo("en"))
-			.body("expansion.contains[0].designation[4].value", equalTo("Substance (substance)"))
-			.body("expansion.contains[0].designation[4].language", equalTo("en-x-900000000000508004"))
-			.body("expansion.contains[0].designation[5].value", equalTo("Substance (substance)"))
-			.body("expansion.contains[0].designation[5].language", equalTo("en-x-900000000000509007"));
+			.body("expansion.contains[0].designation[1].value", equalTo("Substance (substance)"))
+			.body("expansion.contains[0].designation[1].language", equalTo("en"))
+			.extract()
+			.jsonPath();
+		
+		checkDesignationUseContext(jsonPath, "expansion.contains[0].designation[0].extension[0]", Concepts.REFSET_LANGUAGE_TYPE_UK, Concepts.SYNONYM);
+		checkDesignationUseContext(jsonPath, "expansion.contains[0].designation[0].extension[1]", Concepts.REFSET_LANGUAGE_TYPE_US, Concepts.SYNONYM);
+		checkDesignationUseContext(jsonPath, "expansion.contains[0].designation[1].extension[0]", Concepts.REFSET_LANGUAGE_TYPE_UK, Concepts.FULLY_SPECIFIED_NAME);
+		checkDesignationUseContext(jsonPath, "expansion.contains[0].designation[1].extension[1]", Concepts.REFSET_LANGUAGE_TYPE_US, Concepts.FULLY_SPECIFIED_NAME);
 	}
 	
 	@Test

--- a/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/valueset/FhirSnomedValueSetExpandTest.java
+++ b/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/valueset/FhirSnomedValueSetExpandTest.java
@@ -169,7 +169,6 @@ public class FhirSnomedValueSetExpandTest extends FhirRestTest {
 			.body("expansion.next", endsWith(FHIR_ROOT_CONTEXT 
 				+ "/ValueSet/$expand"
 				+ "?url=http://snomed.info/sct/900000000000207008?fhir_vs=ecl/<!138875005"
-				+ "&displayLanguage=en-US;q=0.8,en-GB;q=0.6,en;q=0.4"
 				+ "&count=5"
 				+ "&after=AoIpMjU0MjkxMDAwKTI1NDI5MTAwMA=="));
 	}

--- a/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirCodeSystemLookupController.java
+++ b/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirCodeSystemLookupController.java
@@ -25,7 +25,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.fhir.operations.OperationParametersFactory;
 import com.b2international.fhir.r5.operations.CodeSystemLookupParameters;
 import com.b2international.snowowl.core.events.util.Promise;
@@ -107,7 +106,7 @@ public class FhirCodeSystemLookupController extends AbstractFhirController {
 		final Optional<String> date,
 		
 		@Parameter(description = "Language code for display") 
-		@RequestParam(value = "displayLanguage", defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required = false) 
+		@RequestParam(value = "displayLanguage", required = false) 
 		final Optional<String> displayLanguage,
 		
 		@Parameter(description = "Properties to return in the output") 

--- a/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirValueSetExpandOperationController.java
+++ b/fhir/com.b2international.snowowl.fhir.rest/src/com/b2international/snowowl/fhir/rest/FhirValueSetExpandOperationController.java
@@ -26,7 +26,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.fhir.operations.OperationParametersFactory;
 import com.b2international.fhir.r5.operations.ValueSetExpandParameters;
 import com.b2international.snowowl.core.events.util.Promise;
@@ -104,7 +103,7 @@ public class FhirValueSetExpandOperationController extends AbstractFhirControlle
 		final Boolean activeOnly,
 		
 		@Parameter(description = "Specify the display language for the returned codes") 
-		@RequestParam(value = "displayLanguage", defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required = false)
+		@RequestParam(value = "displayLanguage", required = false)
 		final String displayLanguage,
 		
 		@Parameter(description = "Controls whether concept designations are to be included or excluded in value set expansions") 
@@ -366,7 +365,7 @@ public class FhirValueSetExpandOperationController extends AbstractFhirControlle
 		final Boolean activeOnly,
 		
 		@Parameter(description = "Specify the display language for the returned codes") 
-		@RequestParam(value = "displayLanguage", defaultValue = AcceptLanguageHeader.DEFAULT_ACCEPT_LANGUAGE_HEADER, required = false)
+		@RequestParam(value = "displayLanguage", required = false)
 		final String displayLanguage,
 		
 		@Parameter(description = "Controls whether concept designations are to be included or excluded in value set expansions") 

--- a/snomed/com.b2international.snowowl.snomed.fhir/src/com/b2international/snowowl/snomed/fhir/SnomedFhirCodeSystemLookupConverter.java
+++ b/snomed/com.b2international.snowowl.snomed.fhir/src/com/b2international/snowowl/snomed/fhir/SnomedFhirCodeSystemLookupConverter.java
@@ -15,7 +15,12 @@
  */
 package com.b2international.snowowl.snomed.fhir;
 
-import java.util.*;
+import static com.google.common.collect.Lists.newArrayListWithCapacity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.hl7.fhir.r5.model.*;
@@ -26,17 +31,12 @@ import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.date.DateFormats;
 import com.b2international.snowowl.core.date.EffectiveTimes;
 import com.b2international.snowowl.core.domain.Concept;
-import com.b2international.snowowl.core.domain.Description;
 import com.b2international.snowowl.fhir.core.request.codesystem.FhirCodeSystemLookupConverter;
 import com.b2international.snowowl.snomed.cis.SnomedIdentifiers;
 import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
 import com.b2international.snowowl.snomed.common.SnomedTerminologyComponentConstants;
 import com.b2international.snowowl.snomed.core.SnomedDisplayTermType;
-import com.b2international.snowowl.snomed.core.domain.Acceptability;
-import com.b2international.snowowl.snomed.core.domain.RelationshipValue;
-import com.b2international.snowowl.snomed.core.domain.SnomedConcept;
-import com.b2international.snowowl.snomed.core.domain.SnomedDescription;
-import com.b2international.snowowl.snomed.core.request.SnomedConceptSearchRequestEvaluator;
+import com.b2international.snowowl.snomed.core.domain.*;
 import com.b2international.snowowl.snomed.datastore.request.SnomedRequests;
 
 /**
@@ -56,80 +56,85 @@ public final class SnomedFhirCodeSystemLookupConverter implements FhirCodeSystem
 	}
 	
 	@Override
-	public List<CodeSystemLookupResultParameters.Designation> expandDesignations(ServiceProvider context, CodeSystem codeSystem, Concept concept, CodeSystemLookupParameters parameters, String acceptLanguage) {
-		SnomedConcept snomedConcept = concept.getInternalConceptAs();
-		if (parameters.isPropertyRequested(CodeSystemLookupParameters.PROPERTY_DESIGNATION)) {
-			final SortedSet<Description> alternativeTerms = SnomedConceptSearchRequestEvaluator.generateGenericDescriptions(snomedConcept.getDescriptions());
-			// convert to Designation model
-			final List<CodeSystemLookupResultParameters.Designation> designations = new ArrayList<>(alternativeTerms.size());
-			for (Description description : alternativeTerms) {
-				SnomedDescription snomedDescription = description.getInternalDescription();
-				// use context describes type of description
-				Coding use = new Coding()
-					.setSystem(codeSystem.getUrl())
-					.setCode(snomedDescription.getTypeId())
-					.setDisplay(SnomedDisplayTermType.PT.getLabel(snomedDescription.getType()));
-				
-				Map<String,Acceptability> acceptabilityMap = snomedDescription.getAcceptabilityMap();
-				
-				List<Extension> designationExtensions = new ArrayList<>(acceptabilityMap.size());
-				
-				for (String refsetId : acceptabilityMap.keySet().stream().sorted().toList()) {
-					
-					var acceptability = acceptabilityMap.get(refsetId);
-					
-					Extension useContextExtension = new Extension("http://snomed.info/fhir/StructureDefinition/designation-use-context");
-					
-					// Set code
-					Extension code = new Extension("context");
-					
-					Coding codeCoding = new Coding()
-							.setSystem(SNOMED_SYSTEM_URL)
-							.setCode(refsetId);
-					code.setValue(codeCoding);
-					
-					useContextExtension.addExtension(code);
-					
-					// Set role
-					Extension role = new Extension("role");
-					
-					Coding roleCoding = new Coding()
-							.setSystem(SNOMED_SYSTEM_URL)
-							.setCode(acceptability.getConceptId())
-							.setDisplay(acceptability.name());
-					role.setValue(roleCoding);
-					
-					useContextExtension.addExtension(role);
-					
-					// Set type
-					Extension type = new Extension("type");
-					
-					Coding typeCoding = new Coding()
-							.setSystem(SNOMED_SYSTEM_URL)
-							.setCode(snomedDescription.getTypeId())
-							.setDisplay(SnomedDisplayTermType.PT.getLabel(snomedDescription.getType()));
-					type.setValue(typeCoding);
-					
-					useContextExtension.addExtension(type);
-					
-					designationExtensions.add(useContextExtension);
-				}
-				
-				var designation = new CodeSystemLookupResultParameters.Designation();
-				
-				designation
-					// term and language code comes from the generated alternative term generic model
-					.setValue(description.getTerm())
-					.setLanguage(description.getLanguage())
-					.setUse(use)
-					.setExtension(designationExtensions);
-				
-				designations.add(designation);
-			}
-			return designations;
-		} else {
-			return FhirCodeSystemLookupConverter.super.expandDesignations(context, codeSystem, concept, parameters, acceptLanguage);
+	public List<CodeSystemLookupResultParameters.Designation> expandDesignations(ServiceProvider context, CodeSystem codeSystem, Concept concept, CodeSystemLookupParameters parameters) {
+		if (!parameters.isPropertyRequested(CodeSystemLookupParameters.PROPERTY_DESIGNATION)) {
+			return null;
 		}
+
+		/*
+		 * According to an example response, we no longer need to create separate "virtual descriptions" for each 
+		 * language code <--> language reference set ID pair; we will consult the native descriptions directly instead.
+		 */
+		final SnomedConcept snomedConcept = concept.getInternalConceptAs();
+		final SnomedDescriptions snomedDescriptions = snomedConcept.getDescriptions();
+		final List<CodeSystemLookupResultParameters.Designation> designations = newArrayListWithCapacity(snomedDescriptions.getItems().size());
+
+		for (final SnomedDescription snomedDescription : snomedDescriptions) {
+
+			/* 
+			 * Convert language reference set ID, acceptability and description type triples into "designation-use-context" extensions
+			 * https://confluence.ihtsdotools.org/display/FHIR/Designation+extension
+			 */
+			final Map<String, Acceptability> acceptabilityMap = snomedDescription.getAcceptabilityMap();
+			final List<Extension> designationExtensions = newArrayListWithCapacity(acceptabilityMap.size());
+			final List<String> languageRefsetIds = acceptabilityMap.keySet()
+				.stream()
+				.sorted()
+				.toList();
+
+			// Extract information about the description type here because it is used both in "designation-use-context" and the converted designation
+			final Coding typeCoding = new Coding()
+				.setSystem(SNOMED_SYSTEM_URL)
+				.setCode(snomedDescription.getTypeId())
+				.setDisplay(SnomedDisplayTermType.PT.getLabel(snomedDescription.getType()));
+
+			for (String languageRefsetId : languageRefsetIds) {
+
+				// Extension "context" encodes the language reference set ID
+				final Coding contextCoding = new Coding()
+					// FIXME: "system" may need to be set to the code system's URL we are calling from
+					.setSystem(SNOMED_SYSTEM_URL)
+					.setCode(languageRefsetId);
+				
+				// Extension "role" encodes the acceptability ID for the language reference set
+				final Acceptability acceptability = acceptabilityMap.get(languageRefsetId);
+				
+				final Coding roleCoding = new Coding()
+					// FIXME: "system" may need to be set to the code system's URL we are calling from
+					.setSystem(SNOMED_SYSTEM_URL)
+					.setCode(acceptability.getConceptId())
+					.setDisplay(acceptability.name());
+				
+				final Extension useContextExtension = new Extension("http://snomed.info/fhir/StructureDefinition/designation-use-context");
+				
+				useContextExtension.addExtension()
+					.setUrl("context")
+					.setValue(contextCoding);
+
+				useContextExtension.addExtension()
+					.setUrl("role")
+					.setValue(roleCoding);
+
+				useContextExtension.addExtension()
+					.setUrl("type")
+					.setValue(typeCoding);
+				
+				designationExtensions.add(useContextExtension);
+			}
+			
+			// Now convert the native SNOMED CT description into a FHIR designation
+			var designation = new CodeSystemLookupResultParameters.Designation();
+			
+			designation
+				.setValue(snomedDescription.getTerm())
+				.setLanguage(snomedDescription.getLanguageCode())
+				.setUse(typeCoding)
+				.setExtension(designationExtensions);
+			
+			designations.add(designation);
+		}
+		
+		return designations;
 	}
 	
 	@Override

--- a/snomed/com.b2international.snowowl.snomed.fhir/src/com/b2international/snowowl/snomed/fhir/SnomedFhirPlugin.java
+++ b/snomed/com.b2international.snowowl.snomed.fhir/src/com/b2international/snowowl/snomed/fhir/SnomedFhirPlugin.java
@@ -23,6 +23,7 @@ import com.b2international.snowowl.core.setup.Environment;
 import com.b2international.snowowl.core.setup.Plugin;
 import com.b2international.snowowl.fhir.core.request.codesystem.FhirCodeSystemLookupConverter;
 import com.b2international.snowowl.fhir.core.request.codesystem.FhirCodeSystemResourceConverter;
+import com.b2international.snowowl.fhir.core.request.valueset.FhirValueSetExpander;
 import com.b2international.snowowl.snomed.common.SnomedTerminologyComponentConstants;
 
 /**
@@ -40,7 +41,8 @@ public class SnomedFhirPlugin extends Plugin implements TerminologyRepositoryCon
 	public Map<Class<?>, Object> bindAdditionalServices(Environment env) {
 		return Map.of(
 			FhirCodeSystemResourceConverter.class, new SnomedFhirCodeSystemResourceConverter(),
-			FhirCodeSystemLookupConverter.class, new SnomedFhirCodeSystemLookupConverter()
+			FhirCodeSystemLookupConverter.class, new SnomedFhirCodeSystemLookupConverter(),
+			FhirValueSetExpander.class, new SnomedFhirValueSetExpander()
 		);
 	}
 

--- a/snomed/com.b2international.snowowl.snomed.fhir/src/com/b2international/snowowl/snomed/fhir/SnomedFhirValueSetExpander.java
+++ b/snomed/com.b2international.snowowl.snomed.fhir/src/com/b2international/snowowl/snomed/fhir/SnomedFhirValueSetExpander.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2024 B2i Healthcare, https://b2ihealthcare.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.snomed.fhir;
+
+import static com.google.common.collect.Lists.newArrayListWithCapacity;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.hl7.fhir.r5.model.Coding;
+import org.hl7.fhir.r5.model.Enumerations.FilterOperator;
+import org.hl7.fhir.r5.model.Extension;
+import org.hl7.fhir.r5.model.StringType;
+import org.hl7.fhir.r5.model.ValueSet;
+import org.hl7.fhir.r5.model.ValueSet.*;
+
+import com.b2international.commons.CompareUtils;
+import com.b2international.fhir.r5.operations.ValueSetExpandParameters;
+import com.b2international.snowowl.core.ResourceURI;
+import com.b2international.snowowl.core.ServiceProvider;
+import com.b2international.snowowl.core.codesystem.CodeSystemRequests;
+import com.b2international.snowowl.core.domain.Concept;
+import com.b2international.snowowl.core.domain.Concepts;
+import com.b2international.snowowl.core.request.ConceptSearchRequestBuilder;
+import com.b2international.snowowl.core.request.SearchIndexResourceRequest;
+import com.b2international.snowowl.core.request.SearchResourceRequest;
+import com.b2international.snowowl.fhir.core.FhirModelHelpers;
+import com.b2international.snowowl.fhir.core.request.codesystem.FhirRequest;
+import com.b2international.snowowl.fhir.core.request.valueset.FhirValueSetExpander;
+import com.b2international.snowowl.snomed.core.SnomedDisplayTermType;
+import com.b2international.snowowl.snomed.core.domain.Acceptability;
+import com.b2international.snowowl.snomed.core.domain.SnomedConcept;
+import com.b2international.snowowl.snomed.core.domain.SnomedDescription;
+import com.b2international.snowowl.snomed.core.domain.SnomedDescriptions;
+
+/**
+ * @since 9.5.0
+ */
+public class SnomedFhirValueSetExpander implements FhirValueSetExpander {
+
+	@Override
+	public ValueSet expand(ServiceProvider context, ValueSet valueSet, ValueSetExpandParameters parameters) {
+		
+		final String termFilter = parameters.getFilter() == null ? null : parameters.getFilter().getValue();
+		
+		ConceptSearchRequestBuilder req = CodeSystemRequests.prepareSearchConcepts()
+			.filterByCodeSystemUri((ResourceURI) valueSet.getUserData("codeSystemUri"))
+			.filterByActive(parameters.getActiveOnly() == null ? null : parameters.getActiveOnly().getValue())
+			.filterByTerm(termFilter)
+			.setLimit(parameters.getCount() == null ? 10 : parameters.getCount().getValue())
+			.setSearchAfter(parameters.getAfter() == null ? null : parameters.getAfter().getValue())
+			// SNOMED only preferred display support (VS should always use FSN)
+			.setPreferredDisplay("FSN") 
+			.setLocales(FhirRequest.compactLocale(parameters.getDisplayLanguage()))
+			// always return sorted results for consistency, in case of term filtering return by score otherwise by ID
+			.sortBy(!CompareUtils.isEmpty(termFilter) ? SearchIndexResourceRequest.SCORE : SearchResourceRequest.Sort.fieldAsc("id"));
+
+		final ValueSetComposeComponent compose = valueSet.getCompose();
+		
+		if (compose == null) {
+			// do nothing, search all concepts
+		} else {
+			final ConceptSetComponent firstInclude = compose.getIncludeFirstRep();
+			final ConceptSetFilterComponent firstFilter = firstInclude.getFilterFirstRep();
+			
+			if ("constraint".equals(firstFilter.getProperty()) && FilterOperator.EQUAL.equals(firstFilter.getOp())) {
+				// Filter concepts by ECL
+				req.filterByQuery(firstFilter.getValue());
+			} else if ("constraint".equals(firstFilter.getProperty()) && FilterOperator.ISA.equals(firstFilter.getOp())) {
+				// Filter concepts by ancestor
+				req.filterByAncestor(firstFilter.getValue());
+			} else if ("concept".equals(firstFilter.getProperty()) && FilterOperator.IN.equals(firstFilter.getOp())) {
+				req.filterByQuery("^" + firstFilter.getValue());
+			} else {
+				throw new IllegalStateException("Unsupported implicit value set compose definition: " + compose);
+			}
+		}
+		
+		final Concepts concepts = req.buildAsync().execute(context);
+		
+		final ValueSet.ValueSetExpansionComponent expansion = new ValueSet.ValueSetExpansionComponent()
+				.setIdentifier(valueSet.getId())
+				.setTimestampElement(FhirModelHelpers.toDateTimeElement(new Date()))
+				.setTotal(concepts.getTotal());
+
+		expansion.addExtension(FhirValueSetExpander.EXTENSION_AFTER_PROPERTY_URL, new StringType(concepts.getSearchAfter()));
+		
+		final String baseUrl = valueSet.getUserString("baseUrl");
+		
+		for (Concept concept : concepts) {
+			var contains = new ValueSet.ValueSetExpansionContainsComponent()
+				.setCode(concept.getId())
+				.setSystem(baseUrl)
+				.setDisplay(concept.getTerm());
+			
+			if (parameters.getIncludeDesignations() != null && parameters.getIncludeDesignations().getValue()) {
+				includeDesignations(baseUrl, concept, contains);
+			}
+			
+			expansion.addContains(contains);
+		}
+		
+		return valueSet.setExpansion(expansion);
+	}
+
+	private void includeDesignations(final String baseUrl, Concept concept, ValueSetExpansionContainsComponent contains) {
+		final SnomedConcept snomedConcept = concept.getInternalConceptAs();
+		final SnomedDescriptions snomedDescriptions = snomedConcept.getDescriptions();
+
+		for (final SnomedDescription snomedDescription : snomedDescriptions) {
+
+			/* 
+			 * Convert language reference set ID, acceptability and description type triples into "designation-use-context" extensions
+			 * https://confluence.ihtsdotools.org/display/FHIR/Designation+extension
+			 */
+			final Map<String, Acceptability> acceptabilityMap = snomedDescription.getAcceptabilityMap();
+			final List<Extension> designationExtensions = newArrayListWithCapacity(acceptabilityMap.size());
+			final List<String> languageRefsetIds = acceptabilityMap.keySet()
+				.stream()
+				.sorted()
+				.toList();
+
+			// Extract information about the description type here because it is used both in "designation-use-context" and the converted designation
+			final Coding typeCoding = new Coding()
+				.setSystem(baseUrl)
+				.setCode(snomedDescription.getTypeId())
+				.setDisplay(SnomedDisplayTermType.PT.getLabel(snomedDescription.getType()));
+
+			for (String languageRefsetId : languageRefsetIds) {
+
+				// Extension "context" encodes the language reference set ID
+				final Coding contextCoding = new Coding()
+					// FIXME: "system" may need to be set to the code system's URL we are calling from
+					.setSystem(baseUrl)
+					.setCode(languageRefsetId);
+				
+				// Extension "role" encodes the acceptability ID for the language reference set
+				final Acceptability acceptability = acceptabilityMap.get(languageRefsetId);
+				
+				final Coding roleCoding = new Coding()
+					// FIXME: "system" may need to be set to the code system's URL we are calling from
+					.setSystem(baseUrl)
+					.setCode(acceptability.getConceptId())
+					.setDisplay(acceptability.name());
+				
+				final Extension useContextExtension = new Extension("http://snomed.info/fhir/StructureDefinition/designation-use-context");
+				
+				useContextExtension.addExtension()
+					.setUrl("context")
+					.setValue(contextCoding);
+
+				useContextExtension.addExtension()
+					.setUrl("role")
+					.setValue(roleCoding);
+
+				useContextExtension.addExtension()
+					.setUrl("type")
+					.setValue(typeCoding);
+				
+				designationExtensions.add(useContextExtension);
+			}
+			
+			// Now convert the native SNOMED CT description into a FHIR designation
+			var designation = new ConceptReferenceDesignationComponent();
+			
+			designation
+				.setValue(snomedDescription.getTerm())
+				.setLanguage(snomedDescription.getLanguageCode())
+				.setUse(typeCoding)
+				.setExtension(designationExtensions);
+			
+			contains.addDesignation(designation);
+		}
+	}
+}

--- a/snomed/com.b2international.snowowl.snomed.fhir/src/com/b2international/snowowl/snomed/fhir/SnomedFhirValueSetExpander.java
+++ b/snomed/com.b2international.snowowl.snomed.fhir/src/com/b2international/snowowl/snomed/fhir/SnomedFhirValueSetExpander.java
@@ -20,6 +20,7 @@ import static com.google.common.collect.Lists.newArrayListWithCapacity;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.hl7.fhir.r5.model.Coding;
 import org.hl7.fhir.r5.model.Enumerations.FilterOperator;
@@ -43,9 +44,7 @@ import com.b2international.snowowl.fhir.core.request.codesystem.FhirRequest;
 import com.b2international.snowowl.fhir.core.request.valueset.FhirValueSetExpander;
 import com.b2international.snowowl.snomed.core.SnomedDisplayTermType;
 import com.b2international.snowowl.snomed.core.domain.Acceptability;
-import com.b2international.snowowl.snomed.core.domain.SnomedConcept;
 import com.b2international.snowowl.snomed.core.domain.SnomedDescription;
-import com.b2international.snowowl.snomed.core.domain.SnomedDescriptions;
 
 /**
  * @since 9.5.0
@@ -69,11 +68,11 @@ public class SnomedFhirValueSetExpander implements FhirValueSetExpander {
 			// always return sorted results for consistency, in case of term filtering return by score otherwise by ID
 			.sortBy(!CompareUtils.isEmpty(termFilter) ? SearchIndexResourceRequest.SCORE : SearchResourceRequest.Sort.fieldAsc("id"));
 
-		final ValueSetComposeComponent compose = valueSet.getCompose();
 		
-		if (compose == null) {
+		if (!valueSet.hasCompose()) {
 			// do nothing, search all concepts
 		} else {
+			final ValueSetComposeComponent compose = valueSet.getCompose();
 			final ConceptSetComponent firstInclude = compose.getIncludeFirstRep();
 			final ConceptSetFilterComponent firstFilter = firstInclude.getFilterFirstRep();
 			
@@ -118,9 +117,17 @@ public class SnomedFhirValueSetExpander implements FhirValueSetExpander {
 	}
 
 	private void includeDesignations(final String baseUrl, Concept concept, ValueSetExpansionContainsComponent contains) {
-		final SnomedConcept snomedConcept = concept.getInternalConceptAs();
-		final SnomedDescriptions snomedDescriptions = snomedConcept.getDescriptions();
-
+		/*
+		 * XXX: We create multiple tooling-independent representations in the general
+		 * concept representation, these need to be collapsed back into a single
+		 * internal instance.
+		 */
+		final List<SnomedDescription> snomedDescriptions = concept.getDescriptions()
+			.stream()
+			.map(d -> (SnomedDescription) d.getInternalDescription())
+			.distinct()
+			.toList();
+			
 		for (final SnomedDescription snomedDescription : snomedDescriptions) {
 
 			/* 
@@ -174,12 +181,19 @@ public class SnomedFhirValueSetExpander implements FhirValueSetExpander {
 				designationExtensions.add(useContextExtension);
 			}
 			
+			/*
+			 * FIXME: Using "en" when the description's languageCode is not available. See also:
+			 * SnomedConceptSearchRequestEvaluator#generateGenericDescriptions(SnomedDescriptions)
+			 * - we are partially repeating/undoing the steps taken there
+			 */
+			final String languageCode = Optional.ofNullable(snomedDescription.getLanguageCode()).orElse("en");
+			
 			// Now convert the native SNOMED CT description into a FHIR designation
 			var designation = new ConceptReferenceDesignationComponent();
 			
 			designation
 				.setValue(snomedDescription.getTerm())
-				.setLanguage(snomedDescription.getLanguageCode())
+				.setLanguage(languageCode)
 				.setUse(typeCoding)
 				.setExtension(designationExtensions);
 			


### PR DESCRIPTION
This PR introduces the following changes:

- Transparently "compact" and "expand" a language tag in the FHIR request boundary (Snow Owl's internal requests will still work with private use extensions containing a complete language reference set ID &ndash; these can be changed later if required but will have a larger effect on the code base) 16d3021331263f8150f81cd9bbca7eb75db5cbaa
- Use the split private use extension when returning designations in the default `CodeSystem$lookup` converter e19ed44939f850902f8d7ed6b994c426eb5a76c8
- Use the most recently described behavior in IHTSDO Confluence: use the language code only and add an extension for SNOMED CT lookup operations 058c769196f44f49aeba8a0c01740f898e63d8c8
- Split SNOMED CT implicit VS support into a part that creates the virtual value set and another part that evaluates it; as this is now tooling-dependent, the same extension mechanism can be applied to the expanded concept designations 2f9b82b3782ba25145f9e4b04b64fe003e09753d
- Compact "in" parameters that carry a language tag c5c91a4f37cc0edc9732e354fd82f98104f3597c, 9669f70a2c160f612c69dc33dc82931ba86f6812, eabed899880db7324f3c0597344c05bdc5a8de32