### PR TITLE
fix(snomed): improve performance of component inactivation...

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/SnomedPlugin.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/SnomedPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2018-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,9 +109,11 @@ public final class SnomedPlugin extends TerminologyRepositoryPlugin {
 				// enhance all branch context by attaching the Synonyms cache to it
 				if (context instanceof BranchContext) {
 					BranchContext branchContext = (BranchContext) context;
-					branchContext.bind(Synonyms.class, new Synonyms(branchContext));
 					branchContext.bind(ModuleIdProvider.class, c -> c.getModuleId());
 					branchContext.bind(NamespaceIdProvider.class, NamespaceIdProvider.DEFAULT);
+					// bind request scoped content caches
+					branchContext.bind(Synonyms.class, new Synonyms(branchContext));
+					branchContext.bind(SnomedAssociationReferenceSets.class, new SnomedAssociationReferenceSets(branchContext));
 					return (C) branchContext;
 				} else {
 					return context;

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedAssociationReferenceSets.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedAssociationReferenceSets.java
@@ -22,9 +22,8 @@ import java.util.stream.Collectors;
 
 import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.domain.BranchContext;
-import com.b2international.snowowl.core.domain.IComponent;
-import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
-import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument;
+import com.b2international.snowowl.snomed.core.domain.refset.SnomedRefSetType;
+import com.b2international.snowowl.snomed.core.domain.refset.SnomedReferenceSet;
 
 /**
  * Fetches and memoizes SNOMED CT Association Reference Set IDs.
@@ -43,14 +42,15 @@ public final class SnomedAssociationReferenceSets {
 	
 	public Set<String> get() {
 		if (associationReferenceSets == null) {
-			associationReferenceSets = SnomedRequests.prepareSearchConcept()
+			associationReferenceSets = SnomedRequests.prepareSearchRefSet()
 					.all()
-					.filterByAncestor(Concepts.REFSET_ASSOCIATION_TYPE)
-					.setFields(SnomedConceptDocument.Fields.ID)
+					.filterByActive(true)
+					.filterByType(SnomedRefSetType.ASSOCIATION)
+					.setFields(SnomedReferenceSet.Fields.ID)
 					.build()
 					.execute(context)
 					.stream()
-					.map(IComponent::getId)
+					.map(SnomedReferenceSet::getId)
 					.collect(Collectors.toSet());
 		}
 		return associationReferenceSets;

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedAssociationReferenceSets.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedAssociationReferenceSets.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 B2i Healthcare, https://b2ihealthcare.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.snomed.datastore.request;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.b2international.snowowl.core.ServiceProvider;
+import com.b2international.snowowl.core.domain.BranchContext;
+import com.b2international.snowowl.core.domain.IComponent;
+import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument;
+
+/**
+ * Fetches and memoizes SNOMED CT Association Reference Set IDs.
+ * Works as a cache on top of multiple SNOMED CT specific requests. Requests can access this cache via {@link ServiceProvider#service(Class)} method.
+ * 
+ * @since 9.5
+ */
+public final class SnomedAssociationReferenceSets {
+
+	private final BranchContext context;
+	private Set<String> associationReferenceSets;
+
+	public SnomedAssociationReferenceSets(BranchContext context) {
+		this.context = checkNotNull(context, "context");
+	}
+	
+	public Set<String> get() {
+		if (associationReferenceSets == null) {
+			associationReferenceSets = SnomedRequests.prepareSearchConcept()
+					.all()
+					.filterByAncestor(Concepts.REFSET_ASSOCIATION_TYPE)
+					.setFields(SnomedConceptDocument.Fields.ID)
+					.build()
+					.execute(context)
+					.stream()
+					.map(IComponent::getId)
+					.collect(Collectors.toSet());
+		}
+		return associationReferenceSets;
+	}
+	
+}

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedAssociationTargetUpdateRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedAssociationTargetUpdateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2011-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,16 @@ package com.b2international.snowowl.snomed.datastore.request;
 
 import static com.google.common.collect.Lists.newArrayList;
 
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.b2international.snowowl.core.domain.TransactionContext;
-import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
 import com.b2international.snowowl.snomed.common.SnomedRf2Headers;
 import com.b2international.snowowl.snomed.core.domain.refset.SnomedReferenceSetMember;
 import com.b2international.snowowl.snomed.core.store.SnomedComponents;
@@ -35,6 +36,7 @@ import com.b2international.snowowl.snomed.datastore.index.entry.SnomedRefSetMemb
 import com.b2international.snowowl.snomed.datastore.request.ModuleRequest.ModuleIdProvider;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 
 /**
  * Updates association reference set members on a core component specified by identifier.
@@ -97,14 +99,7 @@ final class SnomedAssociationTargetUpdateRequest extends BaseComponentMemberUpda
 	
 	@Override
 	protected void doExecute(TransactionContext context, SnomedComponentDocument componentToUpdate) {
-		final List<SnomedReferenceSetMember> existingMembers = newArrayList(
-			SnomedRequests.prepareSearchMember()
-				.all()
-				.filterByReferencedComponent(componentToUpdate.getId())
-				.filterByRefSet("<" + Concepts.REFSET_ASSOCIATION_TYPE)
-				.build()
-				.execute(context)
-		);
+		final List<SnomedReferenceSetMember> existingMembers = fetchExistingMembers(context, componentToUpdate);
 		final Multimap<String, String> newAssociationTargetsToCreate = HashMultimap.create(newAssociationTargets);
 		final ModuleIdProvider moduleIdFunction = context.service(ModuleIdProvider.class);
 		final Iterator<SnomedReferenceSetMember> memberIterator = existingMembers.iterator();
@@ -180,6 +175,34 @@ final class SnomedAssociationTargetUpdateRequest extends BaseComponentMemberUpda
 					.withModuleId(moduleIdFunction.apply(componentToUpdate))
 					.addTo(context);
 		}
+	}
+
+	private List<SnomedReferenceSetMember> fetchExistingMembers(TransactionContext context, SnomedComponentDocument componentToUpdate) {
+		final Set<String> memberOf = new HashSet<>();
+		if (componentToUpdate.getMemberOf() != null) {
+			memberOf.addAll(componentToUpdate.getMemberOf());
+		}
+		if (componentToUpdate.getActiveMemberOf() != null) {
+			memberOf.addAll(componentToUpdate.getActiveMemberOf());
+		}
+		
+		if (memberOf.isEmpty()) {
+			return List.of();
+		}
+		
+		Set<String> associationReferenceSetIds = context.service(SnomedAssociationReferenceSets.class).get();
+		if (Sets.intersection(memberOf, associationReferenceSetIds).isEmpty()) {
+			return List.of();
+		}
+		
+		return newArrayList(
+			SnomedRequests.prepareSearchMember()
+				.all()
+				.filterByReferencedComponent(componentToUpdate.getId())
+				.filterByRefSet(associationReferenceSetIds)
+				.build()
+				.execute(context)
+		);
 	}
 	
 }


### PR DESCRIPTION
...by skipping existing historical association member search for a given inactivated component when there is no historical reference set identifier present in the current semantic network (memberOf fields).

Also, caching the current association reference set IDs in the scope of the request, so these can be reused which improves performance for those components where there are existing assoc. members.