### PR TITLE
Add nested context descriptions to lock documents

### DIFF
--- a/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/locks/DatastoreLockTests.java
+++ b/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/locks/DatastoreLockTests.java
@@ -17,6 +17,8 @@ package com.b2international.snowowl.core.locks;
 
 import static org.junit.Assert.assertTrue;
 
+import java.util.Date;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -109,7 +111,7 @@ public class DatastoreLockTests {
 	private void checkIfLockExists(DatastoreLockContext context,  boolean expected, Lockable...targets) {
 		for (int i = 0; i < targets.length; i++) {
 			final Lockable target = targets[i];
-			final OperationLock operationLock = new OperationLock(i, target);
+			final OperationLock operationLock = new OperationLock(i, new Date(), target);
 			operationLock.acquire(context);
 			final OperationLockInfo info = new OperationLockInfo(i, operationLock.getLevel(), operationLock.getCreationDate(), target, context);
 			assertTrue(expected == manager.getLocks().contains(info));

--- a/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/locks/DatastoreLockTests.java
+++ b/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/locks/DatastoreLockTests.java
@@ -15,9 +15,10 @@
  */
 package com.b2international.snowowl.core.locks;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
-import java.util.Date;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -37,9 +38,30 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class DatastoreLockTests {
 
-	private static final long TIMEOUT = 10_000L;
+	private static final String USER1 = "user1@b2ihealthcare.com";
+	private static final String USER2 = "user2@b2ihealthcare.com";
 
-		private static final String USER = "snowowl";
+	private static final DatastoreLockContext CONTEXT_GRANTED = new DatastoreLockContext(
+		USER1, 
+		DatastoreLockContextDescriptions.MAINTENANCE
+	);
+	
+	private static final DatastoreLockContext CONTEXT_DIFFERENT_USER = new DatastoreLockContext(
+		USER2, 
+		DatastoreLockContextDescriptions.MAINTENANCE
+	);
+	
+	private static final DatastoreLockContext CONTEXT_NESTED = new DatastoreLockContext(
+		USER1, 
+		DatastoreLockContextDescriptions.COMMIT, 
+		DatastoreLockContextDescriptions.MAINTENANCE
+	);
+	
+	private static final Lockable TARGET_ALL = Lockable.ALL;
+	private static final Lockable TARGET_REPOSITORY = new Lockable("snomed", null);
+	private static final Lockable TARGET_REPOSITORY_BRANCH = new Lockable("snomed", "MAIN/a/b");
+
+	private static final long TIMEOUT = 100L;
 	
 	private DefaultOperationLockManager manager;
 
@@ -47,74 +69,72 @@ public class DatastoreLockTests {
 	public void setup() {
 		final ObjectMapper mapper = JsonSupport.getDefaultObjectMapper();
 		final Index index = Indexes.createIndex("locks", mapper, new Mappings(DatastoreLockIndexEntry.class));
+		
 		manager = new DefaultOperationLockManager(index);
 		manager.addLockTargetListener(new Slf4jOperationLockTargetListener());
 		manager.unlockAll();
 	}
 	
-	@Test
-	public void testLockAll() {
-		final DatastoreLockContext context = createContext(USER, DatastoreLockContextDescriptions.MAINTENANCE);
-		final Lockable allLockTarget = Lockable.ALL;
+	private void testLock(Lockable target) {
+		// Take the lock
+		manager.lock(CONTEXT_GRANTED, TIMEOUT, target);
+		checkIfLockExists(CONTEXT_GRANTED, true, target);
 		
-		manager.lock(context, TIMEOUT, allLockTarget);
-		checkIfLockExists(context, true, allLockTarget);
-		manager.unlockAll();
-	}
-	
-	@Test
-	public void testUnlock() {
-		final DatastoreLockContext context = createContext(USER, DatastoreLockContextDescriptions.MAINTENANCE);
-		final Lockable target = new Lockable("snomedStore", "MAIN");
+		// Different user, same target is rejected
+		assertThrows(LockedException.class, () -> manager.lock(CONTEXT_DIFFERENT_USER, TIMEOUT, target));
+		checkIfLockExists(CONTEXT_DIFFERENT_USER, false, target);
 		
-		manager.lock(context, TIMEOUT, target);
-		checkIfLockExists(context, true, target);
-
-		manager.unlock(context, target);
-		checkIfLockExists(context, false, target);
-	}
-	
-	@Test
-	public void testUnlockAll() {
-		final DatastoreLockContext context = createContext(USER, DatastoreLockContextDescriptions.MAINTENANCE);
-		final Lockable target1 = new Lockable("snomedStore", "MAIN");
-		final Lockable target2 = new Lockable("loincStore", "MAIN");
+		// Same user, improper nesting (same parent description) is also rejected
+		assertThrows(LockedException.class, () -> manager.lock(CONTEXT_GRANTED, TIMEOUT, target));
 		
-		manager.lock(context, TIMEOUT, target1, target2);
-		checkIfLockExists(context, true, target1, target2);
+		// Same user, proper nesting, same target is allowed
+		manager.lock(CONTEXT_NESTED, TIMEOUT, TARGET_ALL);
+		checkIfLockExists(CONTEXT_NESTED, true, TARGET_ALL);
+		manager.unlock(CONTEXT_NESTED, TARGET_ALL);
+		checkIfLockExists(CONTEXT_NESTED, false, TARGET_ALL);
 		
-		manager.unlockAll();
-		checkIfLockExists(context, false, target1, target2);
-	}
-	
-	@Test(expected = LockedException.class)
-	public void testLockAllNotAbleToLockAnother() {
-		final DatastoreLockContext context = createContext(USER, DatastoreLockContextDescriptions.MAINTENANCE);
-		final Lockable allLockTarget = Lockable.ALL;
-
-		manager.lock(context, 1_000L, allLockTarget);
-		manager.lock(context, 1_000L, allLockTarget);
+		// Same user, proper nesting, repository target is also allowed
+		manager.lock(CONTEXT_NESTED, TIMEOUT, TARGET_REPOSITORY);
+		checkIfLockExists(CONTEXT_NESTED, true, TARGET_REPOSITORY);
+		manager.unlock(CONTEXT_NESTED, TARGET_REPOSITORY);
+		checkIfLockExists(CONTEXT_NESTED, false, TARGET_REPOSITORY);
+		
+		// Same user, proper nesting, repository + branch target is, yet again, allowed
+		manager.lock(CONTEXT_NESTED, TIMEOUT, TARGET_REPOSITORY_BRANCH);
+		checkIfLockExists(CONTEXT_NESTED, true, TARGET_REPOSITORY_BRANCH);
+		manager.unlock(CONTEXT_NESTED, TARGET_REPOSITORY_BRANCH);
+		checkIfLockExists(CONTEXT_NESTED, false, TARGET_REPOSITORY_BRANCH);
+		
+		// Release the first lock
+		manager.unlock(CONTEXT_GRANTED, target);
+		checkIfLockExists(CONTEXT_GRANTED, false, target);
 	}
 	
 	@Test
-	public void testLockBranchAndRepository() {
-		final DatastoreLockContext context = createContext(USER, DatastoreLockContextDescriptions.CREATE_VERSION);
-		final Lockable target = new Lockable("snomedStore", "MAIN");
-		manager.lock(context, 10_000L, target);
-		checkIfLockExists(context, true, target);
+	public void testLockAll() {
+		testLock(TARGET_ALL);
 	}
 	
-	private DatastoreLockContext createContext(final String user, final String description) {
-		return new DatastoreLockContext(user, description);
+	@Test
+	public void testLockRepository() {
+		testLock(TARGET_REPOSITORY);
 	}
 	
-	private void checkIfLockExists(DatastoreLockContext context,  boolean expected, Lockable...targets) {
-		for (int i = 0; i < targets.length; i++) {
-			final Lockable target = targets[i];
-			final OperationLock operationLock = new OperationLock(i, new Date(), target);
-			operationLock.acquire(context);
-			final OperationLockInfo info = new OperationLockInfo(i, operationLock.getLevel(), operationLock.getCreationDate(), target, context);
-			assertTrue(expected == manager.getLocks().contains(info));
+	@Test
+	public void testLockRepositoryBranch() {
+		testLock(TARGET_REPOSITORY_BRANCH);
+	}
+	
+	private void checkIfLockExists(DatastoreLockContext context, boolean expected, Lockable...targets) {
+		final List<OperationLockInfo> locks = manager.getLocks();
+		
+		for (final Lockable target : targets) {
+			final boolean lockExists = locks.stream()
+				.filter(info -> info.getTarget().equals(target) && info.getContext().equals(context))
+				.findFirst()
+				.isPresent();
+			
+			assertEquals(expected, lockExists);
 		}
 	}
 	

--- a/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/locks/LockIndexTests.java
+++ b/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/locks/LockIndexTests.java
@@ -55,7 +55,7 @@ public class LockIndexTests {
 		final DatastoreLockIndexEntry lock = DatastoreLockIndexEntry.builder()
 			.id(lockId)
 			.userId(USER)
-			.description(DatastoreLockContextDescriptions.CLASSIFY)
+			.addContext(DatastoreLockContextDescriptions.CLASSIFY)
 			.repositoryId("repositoryUuid")
 			.branchPath("branchPath")
 			.build();

--- a/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/locks/LockIndexTests.java
+++ b/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/locks/LockIndexTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2019-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.b2international.snowowl.core.locks;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.lang.reflect.Field;
 
@@ -39,6 +40,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class LockIndexTests {
 
 	private static final String USER = "test@b2ihealthcare.com";
+
 	private Index index;
 	private ObjectMapper mapper;
 
@@ -48,10 +50,11 @@ public class LockIndexTests {
 		index = Indexes.createIndex("locks", mapper, new Mappings(DatastoreLockIndexEntry.class));
 		index.admin().create();
 	}
-	
+
 	@Test
 	public void indexLockEntry() {
 		final String lockId = "1";
+
 		final DatastoreLockIndexEntry lock = DatastoreLockIndexEntry.builder()
 			.id(lockId)
 			.userId(USER)
@@ -59,37 +62,89 @@ public class LockIndexTests {
 			.repositoryId("repositoryUuid")
 			.branchPath("branchPath")
 			.build();
-		
+
 		indexDocument(lock);
-		final DatastoreLockIndexEntry actual = get(lockId);
+
+		final DatastoreLockIndexEntry actual = getDocument(lockId);
 		assertDocEquals(lock, actual);
 	}
-	
-	private void indexDocument(DatastoreLockIndexEntry doc) {
+
+	@Test
+	public void updateLockEntry() {
+		final String lockId = "2";
+
+		final DatastoreLockIndexEntry lock = DatastoreLockIndexEntry.builder()
+			.id(lockId)
+			.userId(USER)
+			.addContext(DatastoreLockContextDescriptions.CREATE_VERSION)
+			.repositoryId("repositoryUuid")
+			.branchPath("branchPath")
+			.build();
+
+		indexDocument(lock);
+
+		final DatastoreLockIndexEntry updatedLock = DatastoreLockIndexEntry.from(lock)
+			.addContext(DatastoreLockContextDescriptions.COMMIT)
+			.build();
+
+		indexDocument(updatedLock);
+
+		final DatastoreLockIndexEntry actual = getDocument(lockId);
+		assertDocEquals(updatedLock, actual);
+	}
+
+	@Test
+	public void deleteLockEntry() {
+		final String lockId = "3";
+
+		final DatastoreLockIndexEntry lock = DatastoreLockIndexEntry.builder()
+			.id(lockId)
+			.userId(USER)
+			.addContext(DatastoreLockContextDescriptions.CREATE_VERSION)
+			.repositoryId("repositoryUuid")
+			.branchPath("branchPath")
+			.build();
+
+		indexDocument(lock);
+		deleteDocument(lockId);
+		
+		assertNull(getDocument(lockId));
+	}
+
+	private void indexDocument(final DatastoreLockIndexEntry doc) {
 		index.write(writer -> {
 			writer.put(doc);
 			writer.commit();
-			
 			return null;
 		});
 	}
-	
-	private DatastoreLockIndexEntry get(final String lockId) {
+
+	private DatastoreLockIndexEntry getDocument(final String lockId) {
 		return index.read(searcher -> searcher.get(DatastoreLockIndexEntry.class, lockId));
 	}
-	
-	private void assertDocEquals(DatastoreLockIndexEntry expected, DatastoreLockIndexEntry actual) {
+
+	private void deleteDocument(final String id) {
+		index.write(writer -> {
+			writer.remove(DatastoreLockIndexEntry.class, id);
+			writer.commit();
+			return null;
+		});
+	}
+
+	private void assertDocEquals(final DatastoreLockIndexEntry expected, final DatastoreLockIndexEntry actual) {
 		assertNotNull("Actual document is missing from index", actual);
-		for (Field f : index.admin().getIndexMapping().getMapping(expected.getClass()).getFields()) {
+
+		for (final Field f : index.admin().getIndexMapping().getMapping(expected.getClass()).getFields()) {
 			if (Revision.Fields.CREATED.equals(f.getName()) 
-					|| Revision.Fields.REVISED.equals(f.getName())
-					|| WithScore.SCORE.equals(f.getName())
-					) {
+				|| Revision.Fields.REVISED.equals(f.getName())
+				|| WithScore.SCORE.equals(f.getName())
+			) {
 				// skip revision fields from equality check
 				continue;
 			}
+
 			assertEquals(String.format("Field '%s' should be equal", f.getName()), Reflections.getValue(expected, f), Reflections.getValue(actual, f));
 		}
 	}
-	
+
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/AbstractOperationLock.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/AbstractOperationLock.java
@@ -15,14 +15,15 @@
  */
 package com.b2international.snowowl.core.locks;
 
-import java.util.ArrayDeque;
-import java.util.Collection;
+import static com.google.common.collect.Lists.newArrayList;
+
 import java.util.Date;
-import java.util.Deque;
+import java.util.List;
 
 import com.b2international.snowowl.core.internal.locks.DatastoreLockContext;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 
 /**
  * An abstract lock implementation which supports basic methods of {@link IOperationLock}.
@@ -35,7 +36,7 @@ public abstract class AbstractOperationLock implements IOperationLock {
 	
 	private final int id;
 	private final Date creationDate = new Date();
-	private final Deque<DatastoreLockContext> contextStack = new ArrayDeque<DatastoreLockContext>(); 
+	private final List<DatastoreLockContext> contexts = newArrayList(); 
 	private final Lockable target;
 
 	/**
@@ -52,11 +53,11 @@ public abstract class AbstractOperationLock implements IOperationLock {
 	}
 
 	private void pushContext(DatastoreLockContext context) {
-		contextStack.push(context);
+		contexts.add(context);
 	}
 
 	private void removeContext(DatastoreLockContext otherContext) {
-		if (!contextStack.remove(otherContext)) {
+		if (!contexts.remove(otherContext)) {
 			throw new IllegalArgumentException(CONTEXT_NOT_IN_STACK_MESSAGE);
 		}
 	}
@@ -73,12 +74,12 @@ public abstract class AbstractOperationLock implements IOperationLock {
 	
 	@Override
 	public DatastoreLockContext getContext() {
-		return contextStack.peek();
+		return Iterables.getLast(contexts, null);
 	}
 	
 	@Override
-	public Collection<DatastoreLockContext> getAllContexts() {
-		return ImmutableList.copyOf(contextStack);
+	public List<DatastoreLockContext> getAllContexts() {
+		return ImmutableList.copyOf(contexts);
 	}
 
 	@Override

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/AbstractOperationLock.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/AbstractOperationLock.java
@@ -35,7 +35,7 @@ public abstract class AbstractOperationLock implements IOperationLock {
 	private static final String CONTEXT_NOT_IN_STACK_MESSAGE = "Context is not registered as a lock owner.";
 	
 	private final int id;
-	private final Date creationDate = new Date();
+	private final Date creationDate;
 	private final List<DatastoreLockContext> contexts = newArrayList(); 
 	private final Lockable target;
 
@@ -43,12 +43,15 @@ public abstract class AbstractOperationLock implements IOperationLock {
 	 * Creates a new abstract lock instance.
 	 * 
 	 * @param id the lock identifier
+	 * @param creationDate the lock creation date (may not be {@code null})
 	 * @param target the lock target (may not be {@code null})
 	 */
-	protected AbstractOperationLock(final int id, final Lockable target) {
+	protected AbstractOperationLock(final int id, final Date creationDate, final Lockable target) {
 		Preconditions.checkNotNull(target, "Lock target may not be null.");
+		Preconditions.checkNotNull(creationDate, "Creation date may not be null.");
 		
 		this.id = id;
+		this.creationDate = creationDate;
 		this.target = target; 
 	}
 

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DatastoreLockIndexEntry.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DatastoreLockIndexEntry.java
@@ -39,12 +39,13 @@ import com.google.common.collect.ImmutableList;
 /**
  * @since 7.1.0
  */
-@Doc(type = "lock")
+@Doc(type = "lock", revisions = {
+	@SchemaRevision(version = 2L, description = "Introduce contexts and timestamp field", strategy = DocumentMappingMigrationStrategy.NO_REINDEX)
+})
 @JsonDeserialize(builder = DatastoreLockIndexEntry.Builder.class)
-@SchemaRevision(version = 2L, description = "Introduce contexts field", strategy = DocumentMappingMigrationStrategy.NO_REINDEX)
 public final class DatastoreLockIndexEntry implements Serializable {
 	
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 	
 	public static final class Fields {
 		public static final String ID = "id";

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DatastoreLockIndexEntry.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DatastoreLockIndexEntry.java
@@ -17,9 +17,9 @@ package com.b2international.snowowl.core.locks;
 
 import static com.b2international.index.query.Expressions.exactMatch;
 import static com.b2international.index.query.Expressions.matchAny;
-import static com.google.common.collect.Lists.newArrayList;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -30,6 +30,7 @@ import com.b2international.index.migrate.DocumentMappingMigrationStrategy;
 import com.b2international.index.migrate.SchemaRevision;
 import com.b2international.index.query.Expression;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.common.base.MoreObjects;
@@ -98,7 +99,7 @@ public final class DatastoreLockIndexEntry implements Serializable {
 		
 		private String id;
 		private String userId;
-		private List<String> contexts = newArrayList();
+		private List<String> contexts = new ArrayList<>(2);
 		private String repositoryId;
 		private String branchPath;
 		private Long timestamp;
@@ -141,6 +142,20 @@ public final class DatastoreLockIndexEntry implements Serializable {
 		
 		public Builder timestamp(final Long timestamp) {
 			this.timestamp = timestamp;
+			return this;
+		}
+	
+		@JsonSetter
+		Builder description(final String description) {
+			// lock documents with description value should propagate their values to contexts
+			addContext(description);
+			return this;
+		}
+		
+		@JsonSetter
+		Builder parentDescription(final String parentDescription) {
+			// lock documents with a parentDescription value should propagate their values to contexts
+			addContext(parentDescription);
 			return this;
 		}
 		

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DatastoreLockIndexEntry.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DatastoreLockIndexEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2019-2024 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,25 +17,31 @@ package com.b2international.snowowl.core.locks;
 
 import static com.b2international.index.query.Expressions.exactMatch;
 import static com.b2international.index.query.Expressions.matchAny;
+import static com.google.common.collect.Lists.newArrayList;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 
 import com.b2international.index.Doc;
 import com.b2international.index.ID;
+import com.b2international.index.migrate.DocumentMappingMigrationStrategy;
+import com.b2international.index.migrate.SchemaRevision;
 import com.b2international.index.query.Expression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 /**
  * @since 7.1.0
  */
 @Doc(type = "lock")
-@JsonDeserialize(builder=DatastoreLockIndexEntry.Builder.class)
+@JsonDeserialize(builder = DatastoreLockIndexEntry.Builder.class)
+@SchemaRevision(version = 2L, description = "Introduce contexts field", strategy = DocumentMappingMigrationStrategy.NO_REINDEX)
 public final class DatastoreLockIndexEntry implements Serializable {
 	
 	private static final long serialVersionUID = 1L;
@@ -43,10 +49,10 @@ public final class DatastoreLockIndexEntry implements Serializable {
 	public static final class Fields {
 		public static final String ID = "id";
 		public static final String USER_ID = "userId";
-		public static final String DESCRIPTION = "description";
-		public static final String PARENT_DESCRIPTION = "parentDescription";
-		public static final String REPOSITORY_ID= "repositoryId";
-		public static final String BRANCHPATH = "branchPath";
+		public static final String CONTEXTS = "contexts";
+		public static final String REPOSITORY_ID = "repositoryId";
+		public static final String BRANCH_PATH = "branchPath";
+		public static final String TIMESTAMP = "timestamp";
 	}
 	
 	public static class Expressions {
@@ -63,32 +69,23 @@ public final class DatastoreLockIndexEntry implements Serializable {
 			return exactMatch(Fields.USER_ID, userId);
 		}
 		
-		public static Expression description(final String description) {
-			return exactMatch(Fields.DESCRIPTION, description);
-		}
-		
-		public static Expression parentDescription(final String parentDescription) {
-			return exactMatch(Fields.PARENT_DESCRIPTION, parentDescription);
-		}
-		
 		public static Expression repositoryId(final String repositoryId) {
 			return exactMatch(Fields.REPOSITORY_ID, repositoryId);
 		}
 		
 		public static Expression branchPath(final String branchPath) {
-			return exactMatch(Fields.BRANCHPATH, branchPath);
+			return exactMatch(Fields.BRANCH_PATH, branchPath);
 		}
-		
 	}
 	 
 	public static DatastoreLockIndexEntry.Builder from(DatastoreLockIndexEntry source) {
 		return builder()
-				.id(source.getId())
-				.userId(source.getUserId())
-				.description(source.getDescription())
-				.parentDescription(source.getParentDescription())
-				.repositoryId(source.getRepositoryId())
-				.branchPath(source.getBranchPath());
+			.id(source.getId())
+			.userId(source.getUserId())
+			.contexts(source.getContexts())
+			.repositoryId(source.getRepositoryId())
+			.branchPath(source.getBranchPath())
+			.timestamp(source.getTimestamp());
 	}
 	
 	public static DatastoreLockIndexEntry.Builder builder() {
@@ -100,10 +97,10 @@ public final class DatastoreLockIndexEntry implements Serializable {
 		
 		private String id;
 		private String userId;
-		private String description;
-		private String parentDescription;
+		private List<String> contexts = newArrayList();
 		private String repositoryId;
 		private String branchPath;
+		private Long timestamp;
 		
 		@JsonCreator
 		private Builder() {
@@ -119,13 +116,14 @@ public final class DatastoreLockIndexEntry implements Serializable {
 			return this;
 		}
 		
-		public Builder parentDescription(final String parentDescription) {
-			this.parentDescription = parentDescription;
+		public Builder contexts(final Collection<String> contexts) {
+			this.contexts.clear();
+			this.contexts.addAll(contexts);
 			return this;
 		}
 		
-		public Builder description(final String description) {
-			this.description = description;
+		public Builder addContext(final String context) {
+			this.contexts.add(context);
 			return this;
 		}
 		
@@ -140,26 +138,47 @@ public final class DatastoreLockIndexEntry implements Serializable {
 			return this;
 		}
 		
+		public Builder timestamp(final Long timestamp) {
+			this.timestamp = timestamp;
+			return this;
+		}
+		
 		public DatastoreLockIndexEntry build() {
-			return new DatastoreLockIndexEntry(id, userId, description, parentDescription, repositoryId, branchPath);
+			return new DatastoreLockIndexEntry(id, userId, contexts, repositoryId, branchPath, timestamp);
 		}
 	}
 	
 	@ID
 	private final String id;
 	private final String userId;
-	private final String description;
-	private final String parentDescription;
 	private final String repositoryId;
 	private final String branchPath;
+	private final Long timestamp;
+	private final List<String> contexts;
+
+	// Only left in for backwards compatibility reasons
+	@Deprecated
+	private final String description = null;
+
+	// Only left in for backwards compatibility reasons
+	@Deprecated
+	private final String parentDescription = null;
 	
-	private DatastoreLockIndexEntry(final String id, final String userId, final String description, final String parentDescription, final String repositoryId, final String branchPath) {
+	
+	private DatastoreLockIndexEntry(
+		final String id, 
+		final String userId, 
+		final List<String> contexts, 
+		final String repositoryId, 
+		final String branchPath, 
+		final Long timestamp
+	) {
 		this.id = id;
 		this.userId = userId;
-		this.description = description;
-		this.parentDescription = parentDescription;
+		this.contexts = ImmutableList.copyOf(contexts);
 		this.repositoryId = repositoryId;
 		this.branchPath = branchPath;
+		this.timestamp = timestamp;
 	}
 	
 	public String getId() {
@@ -170,12 +189,8 @@ public final class DatastoreLockIndexEntry implements Serializable {
 		return userId;
 	}
 	
-	public String getDescription() {
-		return description;
-	}
-	
-	public String getParentDescription() {
-		return parentDescription;
+	public List<String> getContexts() {
+		return contexts;
 	}
 	
 	public String getRepositoryId() {
@@ -186,9 +201,13 @@ public final class DatastoreLockIndexEntry implements Serializable {
 		return branchPath;
 	}
 	
+	public Long getTimestamp() {
+		return timestamp;
+	}
+	
 	@Override
 	public int hashCode() {
-		return Objects.hash(id, description, parentDescription, branchPath, repositoryId, userId);
+		return Objects.hash(id, contexts, branchPath, repositoryId, userId, timestamp);
 	}
 	
 	@Override
@@ -207,24 +226,22 @@ public final class DatastoreLockIndexEntry implements Serializable {
 		
 		final DatastoreLockIndexEntry otherEntry = (DatastoreLockIndexEntry) other;
 		return Objects.equals(id, otherEntry.getId()) 
-				&& Objects.equals(userId, otherEntry.getUserId())
-				&& Objects.equals(description, otherEntry.getDescription())
-				&& Objects.equals(parentDescription, otherEntry.getParentDescription())
-				&& Objects.equals(repositoryId, otherEntry.getRepositoryId())
-				&& Objects.equals(branchPath, otherEntry.getBranchPath());
+			&& Objects.equals(userId, otherEntry.getUserId())
+			&& Objects.equals(contexts, otherEntry.getContexts())
+			&& Objects.equals(repositoryId, otherEntry.getRepositoryId())
+			&& Objects.equals(branchPath, otherEntry.getBranchPath())
+			&& Objects.equals(timestamp, otherEntry.getTimestamp());
 	}
 	
 	@Override
 	public String toString() {
 		return MoreObjects.toStringHelper(this)
-				.add("id", id)
-				.add("userId", userId)
-				.add("description", description)
-				.add("parentDescription", parentDescription)
-				.add("repositoryId", repositoryId)
-				.add("branchPath", branchPath)
-				.toString();
+			.add("id", id)
+			.add("userId", userId)
+			.add("contexts", contexts)
+			.add("repositoryId", repositoryId)
+			.add("branchPath", branchPath)
+			.add("timestamp", timestamp)
+			.toString();
 	}
-	
- 
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DefaultOperationLockManager.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DefaultOperationLockManager.java
@@ -356,19 +356,31 @@ public final class DefaultOperationLockManager implements IOperationLockManager,
 	}
 
 	private void reconstructContexts(final DatastoreLockIndexEntry lockDocument, final IOperationLock lock) {
-		String parentDescription = DatastoreLockContextDescriptions.ROOT;
+		String parentDescription = null;
 		
 		for (final String description : lockDocument.getContexts()) {
+			if (parentDescription == null) {
+				// Consume the first item as it is the parent description
+				parentDescription = description;
+				continue;
+			}
+			
 			lock.acquire(new DatastoreLockContext(lockDocument.getUserId(), description, parentDescription));
 			parentDescription = description;
 		}
 	}
 
 	private void updateLock(final IOperationLock existingLock) {
-		final List<String> contextDescriptions = existingLock.getAllContexts()
-			.stream()
+		final List<DatastoreLockContext> allContexts = existingLock.getAllContexts();
+		
+		final List<String> contextDescriptions = allContexts.stream()
 			.map(c -> c.getDescription())
-			.toList();
+			.collect(Collectors.toList());
+		
+		if (!allContexts.isEmpty()) {
+			// Start the list with the first context's parent description (this will not always be "<<root>>")
+			contextDescriptions.add(0, allContexts.get(0).getParentDescription());
+		}
 		
 		final DatastoreLockIndexEntry entry = DatastoreLockIndexEntry.builder()
 			.id(Integer.toString(existingLock.getId()))

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DefaultOperationLockManager.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DefaultOperationLockManager.java
@@ -38,9 +38,7 @@ import com.b2international.snowowl.core.api.SnowowlRuntimeException;
 import com.b2international.snowowl.core.identity.User;
 import com.b2international.snowowl.core.internal.locks.DatastoreLockContext;
 import com.b2international.snowowl.core.internal.locks.DatastoreLockContextDescriptions;
-import com.b2international.snowowl.core.locks.DatastoreLockIndexEntry.Builder;
 import com.google.common.base.Optional;
-import com.google.common.base.Strings;
 import com.google.common.collect.*;
 
 /**
@@ -97,7 +95,13 @@ public final class DefaultOperationLockManager implements IOperationLockManager,
 					if (alreadyLockedTargets.isEmpty()) {
 						for (final Lockable newTarget : targets) {
 							final IOperationLock existingLock = getOrCreateLock(context, newTarget);
-							fireTargetAcquired(existingLock.getTarget(), context);
+							
+							try {
+								existingLock.acquire(context);
+								fireTargetAcquired(existingLock.getTarget(), context);
+							} finally {
+								updateLock(existingLock);
+							}
 						}
 						
 						syncObject.notifyAll();
@@ -147,7 +151,6 @@ public final class DefaultOperationLockManager implements IOperationLockManager,
 			}
 
 			for (final Lockable targetToUnlock : targets) {
-				
 				final IOperationLock existingLock = getOrCreateLock(context, targetToUnlock);
 				
 				try {
@@ -156,6 +159,8 @@ public final class DefaultOperationLockManager implements IOperationLockManager,
 				} finally {
 					if (!existingLock.isLocked()) {
 						removeLock(existingLock);
+					} else {
+						updateLock(existingLock);
 					}
 				}
 			}
@@ -255,7 +260,7 @@ public final class DefaultOperationLockManager implements IOperationLockManager,
 				}
 			}
 		} else {
-			final DatastoreLockContext disposedContext = createLockContext(User.SYSTEM.getUserId(), DatastoreLockContextDescriptions.DISPOSE_LOCK_MANAGER, null);
+			final DatastoreLockContext disposedContext = new DatastoreLockContext(User.SYSTEM.getUserId(), DatastoreLockContextDescriptions.DISPOSE_LOCK_MANAGER);
 			for (final Lockable target : targets) {
 				alreadyLockedTargets.put(target, disposedContext);
 			}
@@ -311,49 +316,64 @@ public final class DefaultOperationLockManager implements IOperationLockManager,
 			final String branchPath = target.branchPath();
 			
 			final Expression searchExpression = Expressions.bool()
-					.filter(DatastoreLockIndexEntry.Expressions.repositoryId(repositoryId))
-					.filter(DatastoreLockIndexEntry.Expressions.branchPath(branchPath))
-					.build();
+				.filter(DatastoreLockIndexEntry.Expressions.repositoryId(repositoryId))
+				.filter(DatastoreLockIndexEntry.Expressions.branchPath(branchPath))
+				.build();
 			
 			final DatastoreLockIndexEntry existingLockEntry = Iterables.getOnlyElement(search(searchExpression, 2), null);
 			final IOperationLock lock;
+			
 			if (existingLockEntry == null) {
 				lastAssignedId = assignedIds.nextClearBit(lastAssignedId);
-				final String lockId = Integer.toString(lastAssignedId);
 				lock = createLock(lastAssignedId, target);
-				final DatastoreLockIndexEntry newEntry = buildIndexEntry(lockId, branchPath, repositoryId, context);
-				put(newEntry);
 				
-				assignedIds.set(lastAssignedId);
 				/* 
 				 * XXX (apeteri): this makes the lock manager revisit low IDs after every 128 issued locks, but 
 				 * it can still assign a number over 128 if all of the early ones are in use, since the BitSet grows unbounded. 
 				 */
+				assignedIds.set(lastAssignedId);
 				lastAssignedId = lastAssignedId % EXPECTED_LOCKS;
 			} else {
-				lock = new OperationLock(Integer.parseInt(existingLockEntry.getId()), target);
+				lock = new OperationLock(
+					Integer.parseInt(existingLockEntry.getId()), 
+					new Date(existingLockEntry.getTimestamp()),
+					target
+				);
+				
+				reconstructContexts(existingLockEntry, lock);
 			}
-			
-			lock.acquire(context);
+
 			return lock;
 		}
 	}
 
-	private DatastoreLockIndexEntry buildIndexEntry(final String lockId, final String branchPath, final String repositoryId, final DatastoreLockContext context) {
-		final Builder entryBuilder = DatastoreLockIndexEntry.builder()
-			.id(lockId)
-			.userId(context.getUserId())
-			.description(context.getDescription())
-			.parentDescription(context.getParentDescription())
-			.repositoryId(repositoryId);
+	private void reconstructContexts(final DatastoreLockIndexEntry lockDocument, final IOperationLock lock) {
+		String parentDescription = DatastoreLockContextDescriptions.ROOT;
 		
-		if (!Strings.isNullOrEmpty(branchPath)) {
-			entryBuilder.branchPath(branchPath);
+		for (final String description : lockDocument.getContexts()) {
+			lock.acquire(new DatastoreLockContext(lockDocument.getUserId(), description, parentDescription));
+			parentDescription = description;
 		}
-		
-		return entryBuilder.build();
 	}
 
+	private void updateLock(final IOperationLock existingLock) {
+		final List<String> contextDescriptions = existingLock.getAllContexts()
+			.stream()
+			.map(c -> c.getDescription())
+			.toList();
+		
+		final DatastoreLockIndexEntry entry = DatastoreLockIndexEntry.builder()
+			.id(Integer.toString(existingLock.getId()))
+			.userId(existingLock.getContext().getUserId()) // using the most recently pushed context's user
+			.contexts(contextDescriptions)
+			.repositoryId(existingLock.getTarget().repositoryId())
+			.branchPath(existingLock.getTarget().branchPath())
+			.timestamp(existingLock.getCreationDate().getTime())
+			.build();
+		
+		put(entry);
+	}
+	
 	private void removeLock(final IOperationLock existingLock) {
 		final DatastoreLockIndexEntry entry = Iterables.getOnlyElement(search(DatastoreLockIndexEntry.Expressions.id(Integer.toString(existingLock.getId())), 2), null);
 		if (entry != null) {
@@ -376,7 +396,7 @@ public final class DefaultOperationLockManager implements IOperationLockManager,
 	}
 	
 	private OperationLock createLock(final int id, final Lockable target) {
-		return new OperationLock(id, target);
+		return new OperationLock(id, new Date(), target);
 	}
 
 	private OperationLockInfo createLockInfo(final IOperationLock existingLock) {
@@ -386,19 +406,15 @@ public final class DefaultOperationLockManager implements IOperationLockManager,
 	
 	private Collection<IOperationLock> getExistingLocks() {
 		return search(Expressions.matchAll(), Integer.MAX_VALUE).stream().map(entry -> {
-			final DatastoreLockContext context = createLockContext(entry.getUserId(), entry.getDescription(), entry.getParentDescription());
-			final OperationLock lock = new OperationLock(Integer.parseInt(entry.getId()), new Lockable(entry.getRepositoryId(), entry.getBranchPath()));
-			lock.acquire(context);
+			final OperationLock lock = new OperationLock(
+				Integer.parseInt(entry.getId()), 
+				new Date(entry.getTimestamp()), 
+				new Lockable(entry.getRepositoryId(), entry.getBranchPath())
+			);
+			
+			reconstructContexts(entry, lock);
 			return lock;
 		}).collect(Collectors.toSet());
-	}
-	
-	private DatastoreLockContext createLockContext(String userId, String description, String parentDescription) {
-		if (Strings.isNullOrEmpty(parentDescription)) {
-			return new DatastoreLockContext(userId, description);
-		}
-		
-		return new DatastoreLockContext(userId, description, parentDescription);
 	}
 	
 	private DatastoreLocks search(Expression query, int limit) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DefaultOperationLockManager.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DefaultOperationLockManager.java
@@ -94,7 +94,7 @@ public final class DefaultOperationLockManager implements IOperationLockManager,
 					
 					if (alreadyLockedTargets.isEmpty()) {
 						for (final Lockable newTarget : targets) {
-							final IOperationLock existingLock = getOrCreateLock(context, newTarget);
+							final IOperationLock existingLock = getOrCreateLock(newTarget);
 							
 							try {
 								existingLock.acquire(context);
@@ -151,7 +151,7 @@ public final class DefaultOperationLockManager implements IOperationLockManager,
 			}
 
 			for (final Lockable targetToUnlock : targets) {
-				final IOperationLock existingLock = getOrCreateLock(context, targetToUnlock);
+				final IOperationLock existingLock = getOrCreateLock(targetToUnlock);
 				
 				try {
 					existingLock.release(context);
@@ -318,7 +318,7 @@ public final class DefaultOperationLockManager implements IOperationLockManager,
 		return System.nanoTime() / (1000L * 1000L);
 	}
 
-	private IOperationLock getOrCreateLock(DatastoreLockContext context, final Lockable target) {
+	private IOperationLock getOrCreateLock(final Lockable target) {
 		synchronized (syncObject) {
 			final String repositoryId = target.repositoryId();
 			final String branchPath = target.branchPath();

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DefaultOperationLockManager.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DefaultOperationLockManager.java
@@ -254,7 +254,7 @@ public final class DefaultOperationLockManager implements IOperationLockManager,
 		if (!isDisposed()) {
 			for (final Lockable newTarget : targets) {
 				for (final IOperationLock existingLock : getExistingLocks()) {
-					if (existingLock.targetConflicts(newTarget) && !canContextLock(context, existingLock)) {
+					if (existingLock.targetConflicts(newTarget) || !canContextLock(context, existingLock)) {
 						alreadyLockedTargets.put(newTarget, existingLock.getContext());
 					}
 				}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DefaultOperationLockManager.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/DefaultOperationLockManager.java
@@ -254,7 +254,15 @@ public final class DefaultOperationLockManager implements IOperationLockManager,
 		if (!isDisposed()) {
 			for (final Lockable newTarget : targets) {
 				for (final IOperationLock existingLock : getExistingLocks()) {
-					if (existingLock.targetConflicts(newTarget) || !canContextLock(context, existingLock)) {
+					/*
+					 * Conflicting targets _are_ allowed provided the contexts are nested properly.
+					 * For example, the following sequence is allowed:
+					 * 
+					 * - first lock locks all content with description "maintenance" 
+					 * - second lock locks a single repository with description "commit", 
+					 *   parent description "maintenance", same user
+					 */
+					if (existingLock.targetConflicts(newTarget) && !canContextLock(context, existingLock)) {
 						alreadyLockedTargets.put(newTarget, existingLock.getContext());
 					}
 				}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/IOperationLock.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/IOperationLock.java
@@ -15,8 +15,8 @@
  */
 package com.b2international.snowowl.core.locks;
 
-import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import com.b2international.snowowl.core.internal.locks.DatastoreLockContext;
 
@@ -33,7 +33,7 @@ public interface IOperationLock {
 	
 	DatastoreLockContext getContext();
 
-	Collection<DatastoreLockContext> getAllContexts();
+	List<DatastoreLockContext> getAllContexts();
 	
 	Lockable getTarget();
 	

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/Lockable.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/Lockable.java
@@ -18,7 +18,7 @@ package com.b2international.snowowl.core.locks;
 import java.io.Serializable;
 import java.util.Objects;
 
-import com.google.common.base.Strings;
+import com.b2international.commons.StringUtils;
 
 /**
  * @since 9.0.0
@@ -31,7 +31,7 @@ public record Lockable(String repositoryId, String branchPath) implements Serial
 	
 	public Lockable(String repositoryId, String branchPath) {
 		this.repositoryId = Objects.requireNonNull(repositoryId, "RepositoryId may not be null");
-		this.branchPath = branchPath == null ? _ALL : branchPath;
+		this.branchPath = StringUtils.isEmpty(branchPath) ? _ALL : branchPath;
     }
 	
 	public boolean conflicts(final Lockable other) {
@@ -39,7 +39,7 @@ public record Lockable(String repositoryId, String branchPath) implements Serial
 			return true;
 		}
 		
-		if (Strings.isNullOrEmpty(branchPath()) || Strings.isNullOrEmpty(other.branchPath())) {
+		if (branchPath().equals(_ALL) || other.branchPath().equals(_ALL)) {
 			return repositoryId().equals(other.repositoryId());
 		}
 		

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/Lockable.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/Lockable.java
@@ -39,11 +39,21 @@ public record Lockable(String repositoryId, String branchPath) implements Serial
 			return true;
 		}
 		
-		if (branchPath().equals(_ALL) || other.branchPath().equals(_ALL)) {
+		if (_ALL.equals(branchPath()) || _ALL.equals(other.branchPath())) {
 			return repositoryId().equals(other.repositoryId());
 		}
 		
 		return equals(other);
 	}
 	
+	@Override
+	public String toString() {
+		if (ALL.equals(this)) {
+			return "all repositories";
+		} else if (_ALL.equals(branchPath)) {
+			return "repository '" + repositoryId + "'";
+		} else {
+			return "repository '" + repositoryId + "' and branch '" + branchPath + "'";
+		}
+	}
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/OperationLock.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/locks/OperationLock.java
@@ -16,6 +16,7 @@
 package com.b2international.snowowl.core.locks;
 
 import java.text.MessageFormat;
+import java.util.Date;
 
 /**
  * Represents a reentrant lock that can be acquired and released in a balanced fashion multiple times by the same context.
@@ -33,8 +34,8 @@ public class OperationLock extends AbstractOperationLock {
 	 * @param id the lock identifier
 	 * @param target the lock target (may not be {@code null})
 	 */
-	public OperationLock(final int id, final Lockable target) {
-		super(id, target);
+	public OperationLock(final int id, final Date creationDate, final Lockable target) {
+		super(id, creationDate, target);
 	}
 
 	@Override

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryTransactionContext.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryTransactionContext.java
@@ -265,8 +265,11 @@ public final class RepositoryTransactionContext extends DelegatingBranchContext 
 		final Lockable lockTarget = new Lockable(info().id(), path());
 		IOperationLockManager locks = service(IOperationLockManager.class);
 		Commit commit = null;
+		
+		// Commit can be attempted later if an exception is thrown from this call
+		locks.lock(lockContext, 1000L, lockTarget);
+		
 		try {
-			locks.lock(lockContext, 1000L, lockTarget);
 			final long timestamp = service(TimestampProvider.class).getTimestamp();
 			log().info("Checking transaction content before commit to {}@{}", path(), timestamp);
 			checkTransaction();

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/io/ImportRequestBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/io/ImportRequestBuilder.java
@@ -23,6 +23,7 @@ import com.b2international.snowowl.core.domain.TransactionContext;
 import com.b2international.snowowl.core.events.AsyncRequest;
 import com.b2international.snowowl.core.events.BaseRequestBuilder;
 import com.b2international.snowowl.core.events.Request;
+import com.b2international.snowowl.core.internal.locks.DatastoreLockContextDescriptions;
 import com.b2international.snowowl.core.request.CommitResult;
 import com.b2international.snowowl.core.request.TerminologyResourceCommitRequestBuilder;
 
@@ -59,9 +60,11 @@ public abstract class ImportRequestBuilder<T extends ImportRequestBuilder<T>>
 	
 	public AsyncRequest<CommitResult> build(ResourceURI codeSystemUri) {
 		return new TerminologyResourceCommitRequestBuilder()
-				.setBody(build())
-				.setCommitComment(String.format("Imported components from source file '%s'", attachment.getFileName()))
-				.build(codeSystemUri);
+			.setBody(build())
+			.setCommitComment(String.format("Imported components from source file '%s'", attachment.getFileName()))
+			// ImportRequest will take care of acquiring this lock before commits are run
+			.setParentContextDescription(DatastoreLockContextDescriptions.IMPORT)
+			.build(codeSystemUri);
 	}
 	
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/version/VersionCreateRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/version/VersionCreateRequest.java
@@ -42,7 +42,6 @@ import com.b2international.snowowl.core.domain.RepositoryContext;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.identity.Permission;
 import com.b2international.snowowl.core.identity.User;
-import com.b2international.snowowl.core.internal.locks.DatastoreLockContextDescriptions;
 import com.b2international.snowowl.core.locks.Locks;
 import com.b2international.snowowl.core.repository.RepositoryRequests;
 import com.b2international.snowowl.core.request.*;
@@ -220,7 +219,6 @@ public final class VersionCreateRequest implements Request<RepositoryContext, Bo
 						});
 						return Boolean.TRUE;
 					})
-					.setParentContextDescription(DatastoreLockContextDescriptions.ROOT) // don't use "creating a version" for the parent context, explicitly set root
 					.setCommitComment(CompareUtils.isEmpty(commitComment)? String.format("Version '%s' as of '%s'", resource, version) : commitComment)
 					.setAuthor(author)
 					.build()

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/version/VersionCreateRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/version/VersionCreateRequest.java
@@ -151,7 +151,7 @@ public final class VersionCreateRequest implements Request<RepositoryContext, Bo
 			}
 		}
 		
-		final IProgressMonitor monitor = SubMonitor.convert(context.service(IProgressMonitor.class), TASK_WORK_STEP);
+		final IProgressMonitor monitor = SubMonitor.convert(context.monitor(), TASK_WORK_STEP);
 
 		try (Locks<RepositoryContext> locks = Locks.forContext(CREATE_VERSION).by(submitter).on(resourcesToVersion).lock(context)) {
 			// inject a custom TimestampProvider instance into the ctx so we use the same timestamp across all repositories when versioning

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/version/VersionCreateRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/version/VersionCreateRequest.java
@@ -42,6 +42,7 @@ import com.b2international.snowowl.core.domain.RepositoryContext;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.identity.Permission;
 import com.b2international.snowowl.core.identity.User;
+import com.b2international.snowowl.core.internal.locks.DatastoreLockContextDescriptions;
 import com.b2international.snowowl.core.locks.Locks;
 import com.b2international.snowowl.core.repository.RepositoryRequests;
 import com.b2international.snowowl.core.request.*;
@@ -219,6 +220,7 @@ public final class VersionCreateRequest implements Request<RepositoryContext, Bo
 						});
 						return Boolean.TRUE;
 					})
+					.setParentContextDescription(DatastoreLockContextDescriptions.ROOT) // don't use "creating a version" for the parent context, explicitly set root
 					.setCommitComment(CompareUtils.isEmpty(commitComment)? String.format("Version '%s' as of '%s'", resource, version) : commitComment)
 					.setAuthor(author)
 					.build()

--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/.launch/snomed-core-unit-tests.launch
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/.launch/snomed-core-unit-tests.launch
@@ -111,7 +111,6 @@
         <setEntry value="org.apache.commons.commons-compress@default:default"/>
         <setEntry value="org.apache.commons.commons-io@default:default"/>
         <setEntry value="org.apache.commons.lang3@default:default"/>
-        <setEntry value="org.apache.commons.logging@default:default"/>
         <setEntry value="org.apache.commons.text@default:default"/>
         <setEntry value="org.apache.felix.scr@1:true"/>
         <setEntry value="org.apache.httpcomponents.httpasyncclient@default:default"/>


### PR DESCRIPTION
This is required to track re-entrant locks that go more than two levels deep.