### PR TITLE
refactor(core): Move evaluation of ECL filter conjunctions and disjunctions to superclass

### DIFF
--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/ecl/EclEvaluationRequest.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/ecl/EclEvaluationRequest.java
@@ -521,6 +521,30 @@ public abstract class EclEvaluationRequest<C extends ServiceProvider> implements
 		return filterExpression;
 	}
 	
+	protected Promise<Expression> eval(C context, final ConjunctionFilter conjunction) {
+		return Promise.all(evaluate(context, conjunction.getLeft()), evaluate(context, conjunction.getRight()))
+			.then(results -> {
+				Expression left = (Expression) results.get(0);
+				Expression right = (Expression) results.get(1);
+				return Expressions.bool()
+					.filter(left)
+					.filter(right)
+					.build();
+			});
+	}
+	
+	protected Promise<Expression> eval(C context, final DisjunctionFilter disjunction) {
+		return Promise.all(evaluate(context, disjunction.getLeft()), evaluate(context, disjunction.getRight()))
+			.then(results -> {
+				Expression left = (Expression) results.get(0);
+				Expression right = (Expression) results.get(1);
+				return Expressions.bool()
+					.should(left)
+					.should(right)
+					.build();
+			});
+	}
+	
 	protected Promise<Expression> eval(C context, final IdFilter idFilter) {
 		final Operator op = Operator.fromString(idFilter.getOp());
 		Expression expression = RevisionDocument.Expressions.ids(idFilter.getIds());

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequest.java
@@ -361,30 +361,6 @@ final class SnomedEclEvaluationRequest extends EclEvaluationRequest<BranchContex
 		return Promise.immediate(SnomedDescriptionIndexEntry.Expressions.languageCodes(languageCodeFilter.getLanguageCodes()));
 	}
 	
-	protected Promise<Expression> eval(BranchContext context, final ConjunctionFilter conjunction) {
-		return Promise.all(evaluate(context, conjunction.getLeft()), evaluate(context, conjunction.getRight()))
-				.then(results -> {
-					Expression left = (Expression) results.get(0);
-					Expression right = (Expression) results.get(1);
-					return Expressions.bool()
-							.filter(left)
-							.filter(right)
-							.build();
-				});
-	}
-	
-	protected Promise<Expression> eval(BranchContext context, final DisjunctionFilter disjunction) {
-		return Promise.all(evaluate(context, disjunction.getLeft()), evaluate(context, disjunction.getRight()))
-				.then(results -> {
-					Expression left = (Expression) results.get(0);
-					Expression right = (Expression) results.get(1);
-					return Expressions.bool()
-							.should(left)
-							.should(right)
-							.build();
-				});
-	}
-	
 	protected Promise<Expression> eval(BranchContext context, final DialectAliasFilter dialectAliasFilter) {
 		final ListMultimap<String, String> languageMapping = SnomedDescriptionUtils.getLanguageMapping(context);
 		final Multimap<String, String> languageRefSetsByAcceptabilityField = HashMultimap.create();


### PR DESCRIPTION
Previously this was only supported in `SnomedEclEvaluationRequest` but all subclasses should be able to make use of this functionality.