### PR TITLE
INFRA-504: Fix memory leak issues with build pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,9 +44,9 @@ try {
 
 		stage('Checkout repository') {
 
-			scmVars = checkout scm
+			def scmVars = checkout scm
 
-			pom = readMavenPom file: 'pom.xml'
+			def pom = readMavenPom file: 'pom.xml'
 			currentVersion = pom.version
 
 			revision = sh(returnStdout: true, script: "git rev-parse --short HEAD").trim()


### PR DESCRIPTION
This PR fixes a memory leak warning with the build pipeline. Two vars in the `checkout` stage were missing the `def` keyword, making them global, and vulnerable to race conditions.
