### PR TITLE
SO-6543: Port query optimization changes from later major versions

### DIFF
--- a/commons/com.b2international.index.tests/src/com/b2international/index/BoolQueryTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/BoolQueryTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022-2026 B2i Healthcare, https://b2ihealthcare.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.index;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.BiFunction;
+
+import org.junit.Test;
+
+import com.b2international.index.query.Expression;
+import com.b2international.index.query.Expressions;
+import com.b2international.index.query.Expressions.ExpressionBuilder;
+import com.b2international.index.query.Query;
+
+/**
+ * @since 8.1
+ */
+public class BoolQueryTest extends BaseIndexTest {
+
+	@Override
+	protected Collection<Class<?>> getTypes() {
+		return List.of(Fixtures.Data.class);
+	}
+	
+	@Test
+	public void deepShouldOnlyBooleanQueryShouldBeFlattenedToPreventError() throws Exception {
+		// this kind of deep boolean query throws an error in both HTTP and TCP ES clients (flattening solves it for certain searches)
+		search(Query.select(Fixtures.Data.class).where(generateDeepBooleanClause(1000, ExpressionBuilder::should)).build());
+	}
+	
+	@Test
+	public void deepFilterOnlyBooleanQueryShouldBeFlattenedToPreventError() throws Exception {
+		// this kind of deep boolean query throws an error in both HTTP and TCP ES clients (flattening solves it for certain searches)
+		search(Query.select(Fixtures.Data.class).where(generateDeepBooleanClause(1000, ExpressionBuilder::filter)).build());
+	}
+	
+	@Test
+	public void mergeMultipleSingleTermShouldClauses() throws Exception {
+		String id1 = UUID.randomUUID().toString();
+		String id2 = UUID.randomUUID().toString();
+		String id3 = UUID.randomUUID().toString();
+		Expression actual = Expressions.bool()
+			.should(Expressions.exactMatch("id", id1))
+			.should(Expressions.exactMatch("id", id2))
+			.should(Expressions.exactMatch("id", id3))
+			.build();
+		assertEquals(Expressions.matchAny("id", Set.of(id1, id2, id3)), actual);
+	}
+	
+	@Test
+	public void mergeMultipleSingleAndMultiTermShouldClauses() throws Exception {
+		String id1 = UUID.randomUUID().toString();
+		String id2 = UUID.randomUUID().toString();
+		String id3 = UUID.randomUUID().toString();
+		String id4 = UUID.randomUUID().toString();
+		Expression actual = Expressions.bool()
+			.should(Expressions.exactMatch("id", id1))
+			.should(Expressions.exactMatch("id", id2))
+			.should(Expressions.matchAny("id", Set.of(id3, id4)))
+			.build();
+		assertEquals(Expressions.matchAny("id", Set.of(id1, id2, id3, id4)), actual);
+	}
+
+	private Expression generateDeepBooleanClause(int depth, BiFunction<ExpressionBuilder, Expression, ExpressionBuilder> boolClause) {
+		ExpressionBuilder root = Expressions.bool();
+		ExpressionBuilder current = root;
+		boolClause.apply(current, Expressions.exactMatch("id", UUID.randomUUID().toString()));
+		for (int i = 0; i < depth; i++) {
+			ExpressionBuilder nested = Expressions.bool();
+			boolClause.apply(nested, Expressions.exactMatch("id", UUID.randomUUID().toString()));
+			current.should(nested.build());
+			current = nested;
+		}
+		return root.build();
+	}
+
+}

--- a/commons/com.b2international.index.tests/src/com/b2international/index/BoolQueryTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/BoolQueryTest.java
@@ -17,14 +17,21 @@ package com.b2international.index;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.function.BiFunction;
 
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.b2international.index.Fixtures.Data;
+import com.b2international.index.admin.IndexAdmin;
+import com.b2international.index.es.query.EsQueryBuilder;
+import com.b2international.index.mapping.DocumentMapping;
+import com.b2international.index.query.BoolExpression;
 import com.b2international.index.query.Expression;
 import com.b2international.index.query.Expressions;
 import com.b2international.index.query.Expressions.ExpressionBuilder;
@@ -34,6 +41,8 @@ import com.b2international.index.query.Query;
  * @since 8.1
  */
 public class BoolQueryTest extends BaseIndexTest {
+
+	private static final Logger LOG = LoggerFactory.getLogger(BoolQueryTest.class);
 
 	@Override
 	protected Collection<Class<?>> getTypes() {
@@ -77,6 +86,78 @@ public class BoolQueryTest extends BaseIndexTest {
 			.should(Expressions.matchAny("id", Set.of(id3, id4)))
 			.build();
 		assertEquals(Expressions.matchAny("id", Set.of(id1, id2, id3, id4)), actual);
+	}
+	
+	@Test
+	public void mergeSingleAndMultiTermFilterClauses() throws Exception {
+		String id1 = UUID.randomUUID().toString();
+		String id2 = UUID.randomUUID().toString();
+		String id3 = UUID.randomUUID().toString();
+		String id4 = UUID.randomUUID().toString();
+		Expression actual = Expressions.bool()
+			.filter(Expressions.exactMatch("id", id1))
+			.filter(Expressions.matchAny("id", Set.of(id1, id2)))
+			.filter(Expressions.matchAny("id", Set.of(id1, id3, id4)))
+			.build();
+		
+		IndexAdmin indexAdmin = index().admin();
+		DocumentMapping mapping = indexAdmin.mappings().getMapping(Data.class);
+		Map<String, Object> settings = indexAdmin.settings();
+		
+		// Single filter matching "id1" should be preserved
+		QueryBuilder esQueryBuilder = new EsQueryBuilder(mapping, settings, LOG).build(actual);
+		assertEquals(BoolQueryBuilder.NAME, esQueryBuilder.getName());
+		assertEquals(1, ((BoolQueryBuilder) esQueryBuilder).filter().size());
+	}
+	
+	@Test
+	public void mergeDisjunctTermFilterClauses() throws Exception {
+		String id1 = UUID.randomUUID().toString();
+		String id2 = UUID.randomUUID().toString();
+		String id3 = UUID.randomUUID().toString();
+		String id4 = UUID.randomUUID().toString();
+		Expression actual = Expressions.bool()
+			.filter(Expressions.exactMatch("id", id1))
+			.filter(Expressions.matchAny("id", Set.of(id2, id3)))
+			.filter(Expressions.matchAny("id", Set.of(id3, id4)))
+			.build();
+		
+		IndexAdmin indexAdmin = index().admin();
+		DocumentMapping mapping = indexAdmin.mappings().getMapping(Data.class);
+		Map<String, Object> settings = indexAdmin.settings();
+		
+		QueryBuilder esQueryBuilder = new EsQueryBuilder(mapping, settings, LOG).build(actual);
+
+		// All three clauses should be eliminated as a single field can not take up 3-4 different values required by the filter
+		assertEquals(BoolQueryBuilder.NAME, esQueryBuilder.getName());
+		assertEquals(1, ((BoolQueryBuilder) esQueryBuilder).filter().size());
+		
+		QueryBuilder firstFilter = ((BoolQueryBuilder) esQueryBuilder).filter().get(0);
+		assertEquals(TermQueryBuilder.NAME, firstFilter.getName());
+		assertEquals("match_none", ((TermQueryBuilder) firstFilter).fieldName());
+	}
+	
+	@Test
+	public void mergeDisjunctTermFilterClausesOnCollection() throws Exception {
+		String id1 = UUID.randomUUID().toString();
+		String id2 = UUID.randomUUID().toString();
+		String id3 = UUID.randomUUID().toString();
+		String id4 = UUID.randomUUID().toString();
+		BoolExpression actual = (BoolExpression) Expressions.bool()
+			.filter(Expressions.exactMatch("longSortedSet", id1))
+			.filter(Expressions.matchAny("longSortedSet", Set.of(id2, id3)))
+			.filter(Expressions.matchAny("longSortedSet", Set.of(id3, id4)))
+			.build();
+
+		IndexAdmin indexAdmin = index().admin();
+		DocumentMapping mapping = indexAdmin.mappings().getMapping(Data.class);
+		Map<String, Object> settings = indexAdmin.settings();
+		
+		QueryBuilder esQueryBuilder = new EsQueryBuilder(mapping, settings, LOG).build(actual);
+		
+		// All three clauses should be preserved as longSortedSet might contain [id1, id2, id4] and thus satisfy all three constraints
+		assertEquals(BoolQueryBuilder.NAME, esQueryBuilder.getName());
+		assertEquals(3, ((BoolQueryBuilder) esQueryBuilder).filter().size());
 	}
 
 	private Expression generateDeepBooleanClause(int depth, BiFunction<ExpressionBuilder, Expression, ExpressionBuilder> boolClause) {

--- a/commons/com.b2international.index.tests/src/com/b2international/index/BoolQueryTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/BoolQueryTest.java
@@ -16,6 +16,7 @@
 package com.b2international.index;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.*;
 import java.util.function.BiFunction;
@@ -28,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.b2international.index.Fixtures.Data;
+import com.b2international.index.Fixtures.ParentData;
 import com.b2international.index.admin.IndexAdmin;
 import com.b2international.index.es.query.EsQueryBuilder;
 import com.b2international.index.mapping.DocumentMapping;
@@ -46,7 +48,7 @@ public class BoolQueryTest extends BaseIndexTest {
 
 	@Override
 	protected Collection<Class<?>> getTypes() {
-		return List.of(Fixtures.Data.class);
+		return List.of(Fixtures.Data.class, Fixtures.ParentData.class);
 	}
 	
 	@Test
@@ -158,6 +160,26 @@ public class BoolQueryTest extends BaseIndexTest {
 		// All three clauses should be preserved as longSortedSet might contain [id1, id2, id4] and thus satisfy all three constraints
 		assertEquals(BoolQueryBuilder.NAME, esQueryBuilder.getName());
 		assertEquals(3, ((BoolQueryBuilder) esQueryBuilder).filter().size());
+	}
+	
+	@Test
+	public void nestedScoringQuery() throws Exception {
+		Expression actual = Expressions.bool()
+			// This clause requires scoring
+			.should(Expressions.nestedMatch("nestedData", Expressions.matchTextAll("nestedData.analyzedField", "multi term query")))
+			// This one does not
+			.should(Expressions.nestedMatch("nestedData", Expressions.exactMatch("nestedData.field2", "field2value")))
+			.build();
+		
+		IndexAdmin indexAdmin = index().admin();
+		DocumentMapping mapping = indexAdmin.mappings().getMapping(ParentData.class);
+		Map<String, Object> settings = indexAdmin.settings();
+		
+		EsQueryBuilder esQueryBuilder = new EsQueryBuilder(mapping, settings, LOG);
+		esQueryBuilder.build(actual);
+		
+		// We are only interested in the value of the flag, not the actual query
+		assertTrue(esQueryBuilder.needsScoring());
 	}
 
 	private Expression generateDeepBooleanClause(int depth, BiFunction<ExpressionBuilder, Expression, ExpressionBuilder> boolClause) {

--- a/commons/com.b2international.index.tests/src/com/b2international/index/BoolQueryTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/BoolQueryTest.java
@@ -69,11 +69,11 @@ public class BoolQueryTest extends BaseIndexTest {
 		String id2 = UUID.randomUUID().toString();
 		String id3 = UUID.randomUUID().toString();
 		Expression actual = Expressions.bool()
-			.should(Expressions.exactMatch("id", id1))
-			.should(Expressions.exactMatch("id", id2))
-			.should(Expressions.exactMatch("id", id3))
+			.should(Expressions.exactMatch("field1", id1))
+			.should(Expressions.exactMatch("field1", id2))
+			.should(Expressions.exactMatch("field1", id3))
 			.build();
-		assertEquals(Expressions.matchAny("id", Set.of(id1, id2, id3)), actual);
+		assertEquals(Expressions.matchAny("field1", Set.of(id1, id2, id3)), actual);
 	}
 	
 	@Test
@@ -83,11 +83,11 @@ public class BoolQueryTest extends BaseIndexTest {
 		String id3 = UUID.randomUUID().toString();
 		String id4 = UUID.randomUUID().toString();
 		Expression actual = Expressions.bool()
-			.should(Expressions.exactMatch("id", id1))
-			.should(Expressions.exactMatch("id", id2))
-			.should(Expressions.matchAny("id", Set.of(id3, id4)))
+			.should(Expressions.exactMatch("field1", id1))
+			.should(Expressions.exactMatch("field1", id2))
+			.should(Expressions.matchAny("field1", Set.of(id3, id4)))
 			.build();
-		assertEquals(Expressions.matchAny("id", Set.of(id1, id2, id3, id4)), actual);
+		assertEquals(Expressions.matchAny("field1", Set.of(id1, id2, id3, id4)), actual);
 	}
 	
 	@Test
@@ -97,9 +97,9 @@ public class BoolQueryTest extends BaseIndexTest {
 		String id3 = UUID.randomUUID().toString();
 		String id4 = UUID.randomUUID().toString();
 		Expression actual = Expressions.bool()
-			.filter(Expressions.exactMatch("id", id1))
-			.filter(Expressions.matchAny("id", Set.of(id1, id2)))
-			.filter(Expressions.matchAny("id", Set.of(id1, id3, id4)))
+			.filter(Expressions.exactMatch("field1", id1))
+			.filter(Expressions.matchAny("field1", Set.of(id1, id2)))
+			.filter(Expressions.matchAny("field1", Set.of(id1, id3, id4)))
 			.build();
 		
 		IndexAdmin indexAdmin = index().admin();
@@ -119,9 +119,9 @@ public class BoolQueryTest extends BaseIndexTest {
 		String id3 = UUID.randomUUID().toString();
 		String id4 = UUID.randomUUID().toString();
 		Expression actual = Expressions.bool()
-			.filter(Expressions.exactMatch("id", id1))
-			.filter(Expressions.matchAny("id", Set.of(id2, id3)))
-			.filter(Expressions.matchAny("id", Set.of(id3, id4)))
+			.filter(Expressions.exactMatch("field1", id1))
+			.filter(Expressions.matchAny("field1", Set.of(id2, id3)))
+			.filter(Expressions.matchAny("field1", Set.of(id3, id4)))
 			.build();
 		
 		IndexAdmin indexAdmin = index().admin();
@@ -185,10 +185,10 @@ public class BoolQueryTest extends BaseIndexTest {
 	private Expression generateDeepBooleanClause(int depth, BiFunction<ExpressionBuilder, Expression, ExpressionBuilder> boolClause) {
 		ExpressionBuilder root = Expressions.bool();
 		ExpressionBuilder current = root;
-		boolClause.apply(current, Expressions.exactMatch("id", UUID.randomUUID().toString()));
+		boolClause.apply(current, Expressions.exactMatch("field1", UUID.randomUUID().toString()));
 		for (int i = 0; i < depth; i++) {
 			ExpressionBuilder nested = Expressions.bool();
-			boolClause.apply(nested, Expressions.exactMatch("id", UUID.randomUUID().toString()));
+			boolClause.apply(nested, Expressions.exactMatch("field1", UUID.randomUUID().toString()));
 			current.should(nested.build());
 			current = nested;
 		}

--- a/commons/com.b2international.index.tests/src/com/b2international/index/BoolQueryTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/BoolQueryTest.java
@@ -64,7 +64,7 @@ public class BoolQueryTest extends BaseIndexTest {
 	}
 	
 	@Test
-	public void mergeMultipleSingleTermShouldClauses() throws Exception {
+	public void mergeSingleTermShouldClauses() throws Exception {
 		String id1 = UUID.randomUUID().toString();
 		String id2 = UUID.randomUUID().toString();
 		String id3 = UUID.randomUUID().toString();
@@ -77,7 +77,7 @@ public class BoolQueryTest extends BaseIndexTest {
 	}
 	
 	@Test
-	public void mergeMultipleSingleAndMultiTermShouldClauses() throws Exception {
+	public void mergeSingleAndMultiTermShouldClauses() throws Exception {
 		String id1 = UUID.randomUUID().toString();
 		String id2 = UUID.randomUUID().toString();
 		String id3 = UUID.randomUUID().toString();

--- a/commons/com.b2international.index.tests/src/com/b2international/index/Fixtures.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/Fixtures.java
@@ -22,11 +22,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.b2international.collections.longs.LongSortedSet;
+import com.fasterxml.jackson.annotation.*;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Maps;
 
@@ -60,6 +57,8 @@ public class Fixtures {
 		private Integer intWrapper;
 		private short shortField;
 		private Short shortWrapper;
+		
+		private LongSortedSet longSortedSet;
 
 		@JsonProperty
 		public String getAnalyzedField() {
@@ -168,6 +167,14 @@ public class Fixtures {
 		public void setShortWrapper(Short shortWrapper) {
 			this.shortWrapper = shortWrapper;
 		}
+		
+		public LongSortedSet getLongSortedSet() {
+			return longSortedSet;
+		}
+		
+		public void setLongSortedSet(LongSortedSet longSortedSet) {
+			this.longSortedSet = longSortedSet;
+		}
 
 		@Override
 		public boolean equals(Object obj) {
@@ -184,6 +191,7 @@ public class Fixtures {
 					&& Objects.equals(longWrapper, other.longWrapper) 
 					&& Objects.equals(intWrapper, other.intWrapper) 
 					&& Objects.equals(shortWrapper, other.shortWrapper)
+					&& Objects.equals(longSortedSet, other.longSortedSet)
 					&& floatField == other.floatField 
 					&& longField == other.longField
 					&& intField == other.intField 
@@ -192,14 +200,17 @@ public class Fixtures {
 		
 		@Override
 		public int hashCode() {
-			return Objects.hash(analyzedField, 
-					field1, 
-					field2, 
-					bigDecimalField, 
-					floatWrapper, 
-					longWrapper, 
-					intWrapper, 
-					shortWrapper);
+			return Objects.hash(
+				analyzedField, 
+				field1, 
+				field2, 
+				bigDecimalField, 
+				floatWrapper, 
+				longWrapper, 
+				intWrapper, 
+				shortWrapper,
+				longSortedSet
+			);
 		}
 		
 		@Override
@@ -217,6 +228,7 @@ public class Fixtures {
 					.add("longWrapper", longWrapper)
 					.add("shortField", shortField)
 					.add("shortWrapper", shortWrapper)
+					.add("longSortedSet", longSortedSet)
 					.toString();
 		}
 		

--- a/commons/com.b2international.index/src/com/b2international/index/es/query/EsQueryBuilder.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/query/EsQueryBuilder.java
@@ -72,6 +72,10 @@ public final class EsQueryBuilder {
 		return needsScoring;
 	}
 	
+	public void enableScoring() {
+		needsScoring = true;
+	}
+	
 	public QueryBuilder build(Expression expression) {
 		checkNotNull(expression, "expression");
 		visit(expression);
@@ -154,7 +158,7 @@ public final class EsQueryBuilder {
 		visit(inner);
 		final QueryBuilder innerQuery = deque.pop();
 		
-		needsScoring = true;
+		enableScoring();
 		deque.push(QueryBuilders
 				.functionScoreQuery(innerQuery, ScoreFunctionBuilders.scriptFunction(expression.toEsScript(mapping)))
 				.boostMode(CombineFunction.REPLACE));
@@ -171,8 +175,8 @@ public final class EsQueryBuilder {
 			// visit the item and immediately pop the deque item back
 			final EsQueryBuilder innerQueryBuilder = new EsQueryBuilder(mapping, settings, log);
 			innerQueryBuilder.visit(must);
-			if (innerQueryBuilder.needsScoring) {
-				needsScoring = innerQueryBuilder.needsScoring;
+			if (innerQueryBuilder.needsScoring()) {
+				enableScoring();
 				query.must(innerQueryBuilder.deque.pop());
 			} else {
 				query.filter(innerQueryBuilder.deque.pop());
@@ -257,9 +261,17 @@ public final class EsQueryBuilder {
 		final DocumentMapping nestedMapping = mapping.getNestedMapping(predicate.getField());
 		final EsQueryBuilder nestedQueryBuilder = new EsQueryBuilder(nestedMapping, settings, log, nestedPath);
 		nestedQueryBuilder.visit(predicate.getExpression());
-		needsScoring = nestedQueryBuilder.needsScoring;
+		
+		final ScoreMode scoreMode;
+		if (nestedQueryBuilder.needsScoring()) {
+			enableScoring();
+			scoreMode = ScoreMode.Max;
+		} else {
+			scoreMode = ScoreMode.None;
+		}
+		
 		final QueryBuilder nestedQuery = nestedQueryBuilder.deque.pop();
-		deque.push(QueryBuilders.nestedQuery(nestedPath, nestedQuery, ScoreMode.None));
+		deque.push(QueryBuilders.nestedQuery(nestedPath, nestedQuery, scoreMode));
 	}
 
 	private String toFieldPath(Predicate predicate) {
@@ -279,51 +291,62 @@ public final class EsQueryBuilder {
 		final String term = predicate.term();
 		final MatchType type = predicate.type();
 		final int minShouldMatch = predicate.minShouldMatch();
+
 		QueryBuilder query;
+
 		switch (type) {
-		case BOOLEAN_PREFIX:
-			query = QueryBuilders.matchBoolPrefixQuery(field, term)
-				.analyzer(predicate.analyzer())
-				.operator(Operator.AND);
+			case BOOLEAN_PREFIX:
+				query = QueryBuilders.matchBoolPrefixQuery(field, term)
+					.analyzer(predicate.analyzer())
+					.operator(Operator.AND);
+					break;
+			
+			case PHRASE:
+				query = QueryBuilders.matchPhraseQuery(field, term)
+					.analyzer(predicate.analyzer());
 				break;
-		case PHRASE:
-			query = QueryBuilders.matchPhraseQuery(field, term)
-						.analyzer(predicate.analyzer());
-			break;
-		case ALL:
-			query = QueryBuilders.matchQuery(field, term)
-						.analyzer(predicate.analyzer())
-						.operator(Operator.AND);
-			break;
-		case ANY:
-			query = QueryBuilders.matchQuery(field, term)
-						.analyzer(predicate.analyzer())
-						.operator(Operator.OR)
-						.minimumShouldMatch(Integer.toString(minShouldMatch));
-			break;
-		case FUZZY:
-			query = QueryBuilders.matchQuery(field, term)
-						.analyzer(predicate.analyzer())
-						.fuzziness(Fuzziness.ONE)
-						.prefixLength(1)
-						.operator(Operator.AND)
-						.maxExpansions(10);
-			break;
-		case PARSED:
-			query = QueryBuilders.queryStringQuery(TextConstants.escape(term))
-						.analyzer(predicate.analyzer())
-						.field(field)
-						.escape(false)
-						.allowLeadingWildcard(true)
-						.defaultOperator(Operator.AND);
-			break;
-		default: throw new UnsupportedOperationException("Unexpected text match type: " + type);
+			
+			case ALL:
+				query = QueryBuilders.matchQuery(field, term)
+					.analyzer(predicate.analyzer())
+					.operator(Operator.AND);
+				break;
+			
+			case ANY:
+				query = QueryBuilders.matchQuery(field, term)
+					.analyzer(predicate.analyzer())
+					.operator(Operator.OR)
+					.minimumShouldMatch(Integer.toString(minShouldMatch));
+				break;
+			
+			case FUZZY:
+				query = QueryBuilders.matchQuery(field, term)
+					.analyzer(predicate.analyzer())
+					.fuzziness(Fuzziness.ONE)
+					.prefixLength(1)
+					.operator(Operator.AND)
+					.maxExpansions(10);
+				break;
+			
+			case PARSED:
+				query = QueryBuilders.queryStringQuery(TextConstants.escape(term))
+					.analyzer(predicate.analyzer())
+					.field(field)
+					.escape(false)
+					.allowLeadingWildcard(true)
+					.defaultOperator(Operator.AND);
+				break;
+			
+			default: 
+				throw new UnsupportedOperationException("Unexpected text match type: " + type);
 		}
+		
 		if (query == null) {
 			query = MATCH_NONE;
 		} else {
-			needsScoring = true;
+			enableScoring();
 		}
+		
 		deque.push(query);
 	}
 	

--- a/commons/com.b2international.index/src/com/b2international/index/es/query/EsQueryBuilder.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/query/EsQueryBuilder.java
@@ -222,20 +222,20 @@ public final class EsQueryBuilder {
 		for (String field : Set.copyOf(termExpressionsByField.keySet())) {
 			Collection<Expression> termExpressions = termExpressionsByField.removeAll(field);
 			if (termExpressions.size() > 1) {
-				Set<Object> values = null;
+				SortedSet<Comparable<?>> values = null;
 				for (Expression expression : termExpressions) {
 					if (values != null && values.isEmpty()) {
 						break;
 					}
-					Set<Object> expressionValues;
+					SortedSet<Comparable<?>> expressionValues;
 					if (expression instanceof SingleArgumentPredicate<?>) {
-						expressionValues = Set.of(((SingleArgumentPredicate<?>) expression).getArgument());
+						expressionValues = ImmutableSortedSet.copyOf(Set.of(((SingleArgumentPredicate<?>) expression).getArgument()));
 					} else if (expression instanceof SetPredicate<?>) {
-						expressionValues = Set.copyOf(((SetPredicate<?>) expression).values());
+						expressionValues = ImmutableSortedSet.copyOf(((SetPredicate<?>) expression).values());
 					} else {
 						throw new IllegalStateException("Invalid clause detected when processing term/terms clauses: " + expression);
 					}
-					values = values == null ? expressionValues : Set.copyOf(Sets.intersection(values, expressionValues));
+					values = values == null ? expressionValues : ImmutableSortedSet.copyOf(Sets.intersection(values, expressionValues));
 				}
 				// remove all matching clauses first
 				clauses.removeAll(termExpressions);
@@ -343,7 +343,7 @@ public final class EsQueryBuilder {
 		deque.push(QueryBuilders.termQuery(toFieldPath(predicate), DecimalUtils.encode(predicate.getArgument())));
 	}
 	
-	private <T> void visit(SetPredicate<T> predicate) {
+	private <T extends Comparable<T>> void visit(SetPredicate<T> predicate) {
 		toTermsQuery(predicate, predicate.values(), null);
 	}
 
@@ -352,14 +352,14 @@ public final class EsQueryBuilder {
 	}
 	
 	// consider max terms count and break into multiple terms queries if number of terms are greater than that value
-	private <T> void toTermsQuery(SetPredicate<T> predicate, final Set<T> terms, final Function<T, ?> valueConverter) {
+	private <T extends Comparable<T>> void toTermsQuery(SetPredicate<T> predicate, final Set<T> terms, final Function<T, ?> valueConverter) {
 		final int maxTermsCount = Integer.parseInt((String) settings.get(IndexClientFactory.MAX_TERMS_COUNT_KEY));
 		if (terms.size() > maxTermsCount) {
 			log.warn("More than currently configured max_terms_count ({}) filter values on field query: {}.{}", maxTermsCount, mapping.typeAsString(), toFieldPath(predicate));
 			final BoolQueryBuilder bool = QueryBuilders.boolQuery().minimumShouldMatch(1);
 			Iterables.partition(terms, maxTermsCount).forEach(partition -> {
 				if (valueConverter != null) {
-					bool.should(QueryBuilders.termsQuery(toFieldPath(predicate), partition.stream().map(valueConverter).collect(Collectors.toSet())));	
+					bool.should(QueryBuilders.termsQuery(toFieldPath(predicate), partition.stream().map(valueConverter).collect(Collectors.toCollection(TreeSet::new))));	
 				} else {
 					bool.should(QueryBuilders.termsQuery(toFieldPath(predicate), partition));
 				}
@@ -368,7 +368,7 @@ public final class EsQueryBuilder {
 		} else {
 			// push the terms query directly
 			if (valueConverter != null) {
-				deque.push(QueryBuilders.termsQuery(toFieldPath(predicate), terms.stream().map(valueConverter).collect(Collectors.toSet())));
+				deque.push(QueryBuilders.termsQuery(toFieldPath(predicate), terms.stream().map(valueConverter).collect(Collectors.toCollection(TreeSet::new))));
 			} else {
 				deque.push(QueryBuilders.termsQuery(toFieldPath(predicate), terms));
 			}

--- a/commons/com.b2international.index/src/com/b2international/index/es/query/EsQueryBuilder.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/query/EsQueryBuilder.java
@@ -17,9 +17,8 @@ package com.b2international.index.es.query;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.Deque;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.lucene.search.join.ScoreMode;
@@ -36,9 +35,7 @@ import com.b2international.index.mapping.DocumentMapping;
 import com.b2international.index.query.*;
 import com.b2international.index.query.TextPredicate.MatchType;
 import com.b2international.index.util.DecimalUtils;
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Queues;
+import com.google.common.collect.*;
 
 /**
  * @since 4.7
@@ -173,6 +170,11 @@ public final class EsQueryBuilder {
 	
 	private void visit(BoolExpression bool) {
 		final BoolQueryBuilder query = QueryBuilders.boolQuery();
+
+		// Assumes that BoolExpression clauses are stored in writable array lists
+		reduceTermFilters(bool.mustClauses());
+		reduceTermFilters(bool.filterClauses());
+		
 		for (Expression must : bool.mustClauses()) {
 			// visit the item and immediately pop the deque item back
 			final EsQueryBuilder innerQueryBuilder = new EsQueryBuilder(mapping, settings, log);
@@ -194,7 +196,7 @@ public final class EsQueryBuilder {
 			visit(should);
 			query.should(deque.pop());
 		}
-		
+
 		for (Expression filter : bool.filterClauses()) {
 			visit(filter);
 			query.filter(deque.pop());
@@ -207,6 +209,52 @@ public final class EsQueryBuilder {
 		deque.push(query);
 	}
 	
+	private void reduceTermFilters(List<Expression> clauses) {
+		Multimap<String, Expression> termExpressionsByField = HashMultimap.create();
+		for (Expression expression : List.copyOf(clauses)) {
+			if (shouldMergeSingleArgumentPredicate(expression)) {
+				termExpressionsByField.put(((SingleArgumentPredicate<?>) expression).getField(), expression);
+			} else if (shouldMergeSetPredicate(expression)) {
+				termExpressionsByField.put(((SetPredicate<?>) expression).getField(), expression);
+			}
+		}
+		
+		for (String field : Set.copyOf(termExpressionsByField.keySet())) {
+			Collection<Expression> termExpressions = termExpressionsByField.removeAll(field);
+			if (termExpressions.size() > 1) {
+				Set<Object> values = null;
+				for (Expression expression : termExpressions) {
+					if (values != null && values.isEmpty()) {
+						break;
+					}
+					Set<Object> expressionValues;
+					if (expression instanceof SingleArgumentPredicate<?>) {
+						expressionValues = Set.of(((SingleArgumentPredicate<?>) expression).getArgument());
+					} else if (expression instanceof SetPredicate<?>) {
+						expressionValues = Set.copyOf(((SetPredicate<?>) expression).values());
+					} else {
+						throw new IllegalStateException("Invalid clause detected when processing term/terms clauses: " + expression);
+					}
+					values = values == null ? expressionValues : Set.copyOf(Sets.intersection(values, expressionValues));
+				}
+				// remove all matching clauses first
+				clauses.removeAll(termExpressions);
+				// add the new merged expression
+				clauses.add(Expressions.matchAnyObject(field, values));
+			}
+		}
+	}
+	
+	private boolean shouldMergeSingleArgumentPredicate(Expression expression) {
+		// Single argument predicates should not be eliminated if the field is a collection type
+		return AbstractExpressionBuilder.shouldMergeSingleArgumentPredicate(expression) && !mapping.isCollection(((Predicate) expression).getField());
+	}
+	
+	private boolean shouldMergeSetPredicate(Expression expression) {
+		// Set predicates should not be eliminated if the field is a collection type
+		return AbstractExpressionBuilder.shouldMergeSetPredicate(expression) && !mapping.isCollection(((Predicate) expression).getField());
+	}
+
 	private void visit(NestedPredicate predicate) {
 		final String nestedPath = toFieldPath(predicate);
 		final DocumentMapping nestedMapping = mapping.getNestedMapping(predicate.getField());

--- a/commons/com.b2international.index/src/com/b2international/index/es/query/EsQueryBuilder.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/query/EsQueryBuilder.java
@@ -243,16 +243,21 @@ public final class EsQueryBuilder {
 				clauses.add(Expressions.matchAnyObject(field, values));
 			}
 		}
+
 	}
 	
 	private boolean shouldMergeSingleArgumentPredicate(Expression expression) {
-		// Single argument predicates should not be eliminated if the field is a collection type
-		return AbstractExpressionBuilder.shouldMergeSingleArgumentPredicate(expression) && !mapping.isCollection(((Predicate) expression).getField());
+		return AbstractExpressionBuilder.shouldMergeSingleArgumentPredicate(expression) && referencesScalarField(expression);
 	}
 	
 	private boolean shouldMergeSetPredicate(Expression expression) {
-		// Set predicates should not be eliminated if the field is a collection type
-		return AbstractExpressionBuilder.shouldMergeSetPredicate(expression) && !mapping.isCollection(((Predicate) expression).getField());
+		return AbstractExpressionBuilder.shouldMergeSetPredicate(expression) && referencesScalarField(expression);
+	}
+
+	// Predicates should not be eliminated if the field is a collection type
+	private boolean referencesScalarField(Expression expression) {
+		final String fieldName = ((Predicate) expression).getField();
+		return mapping.getSelectableFields().contains(fieldName) && !mapping.isCollection(fieldName);
 	}
 
 	private void visit(NestedPredicate predicate) {

--- a/commons/com.b2international.index/src/com/b2international/index/es/query/EsQueryBuilder.java
+++ b/commons/com.b2international.index/src/com/b2international/index/es/query/EsQueryBuilder.java
@@ -74,17 +74,9 @@ public final class EsQueryBuilder {
 	
 	public QueryBuilder build(Expression expression) {
 		checkNotNull(expression, "expression");
-		// always filter by type
 		visit(expression);
 		if (deque.size() == 1) {
-			QueryBuilder queryBuilder = deque.pop();
-			if (needsScoring) {
-				return queryBuilder;
-			} else {
-				return QueryBuilders.boolQuery()
-					.must(QueryBuilders.matchAllQuery())
-					.filter(queryBuilder);
-			}
+			return deque.pop();
 		} else {
 			throw newIllegalStateException();
 		}

--- a/commons/com.b2international.index/src/com/b2international/index/mapping/DocumentMapping.java
+++ b/commons/com.b2international.index/src/com/b2international/index/mapping/DocumentMapping.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.util.*;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -69,7 +70,8 @@ public final class DocumentMapping {
 	private final Map<String, Script> scripts;
 	private final SortedSet<String> trackedRevisionFields;
 	private final String idField;
-
+	private final SortedSet<String> selectableFields;
+	
 	public DocumentMapping(Class<?> type) {
 		this(null, type);
 	}
@@ -163,6 +165,23 @@ public final class DocumentMapping {
 				}
 			});
 		}
+		
+		final ImmutableSortedSet.Builder<String> selectableFields = ImmutableSortedSet.naturalOrder();
+
+		for (Entry<String, Field> field : fieldMap.entrySet()) {
+			final String fieldName = field.getKey();
+			
+			// exclude internal Revision fields
+			if (Revision.class.isAssignableFrom(this.type) 
+					&& Revision.Fields.CREATED.equals(fieldName)
+					&& Revision.Fields.REVISED.equals(fieldName)) {
+				continue;
+			}
+			
+			selectableFields.add(fieldName);
+		}
+		
+		this.selectableFields = selectableFields.build();		
 	}
 
 	private void checkRevisionType() {
@@ -247,6 +266,10 @@ public final class DocumentMapping {
 	
 	public Collection<Field> getFields() {
 		return ImmutableList.copyOf(fieldMap.values());
+	}
+	
+	public Set<String> getSelectableFields() {
+		return selectableFields;
 	}
 	
 	public boolean isText(String field) {

--- a/commons/com.b2international.index/src/com/b2international/index/query/AbstractExpressionBuilder.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/AbstractExpressionBuilder.java
@@ -126,7 +126,7 @@ public abstract class AbstractExpressionBuilder<B extends AbstractExpressionBuil
 			if (expression instanceof BoolExpression) {
 				BoolExpression bool = (BoolExpression) expression;
 				if (bool.isShouldOnly() && bool.minShouldMatch() == 1) {
-					shouldClauses.addAll(bool.filterClauses());
+					shouldClauses.addAll(bool.shouldClauses());
 					shouldClauses.remove(bool);
 				}
 			}

--- a/commons/com.b2international.index/src/com/b2international/index/query/AbstractExpressionBuilder.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/AbstractExpressionBuilder.java
@@ -15,12 +15,7 @@
  */
 package com.b2international.index.query;
 
-import static com.google.common.collect.Lists.newArrayList;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-import java.util.SortedSet;
+import java.util.*;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
@@ -33,10 +28,10 @@ import com.google.common.collect.Sets;
  */
 public abstract class AbstractExpressionBuilder<B extends AbstractExpressionBuilder<B>>{
 
-	protected final List<Expression> mustClauses = newArrayList();
-	protected final List<Expression> mustNotClauses = newArrayList();
-	protected final List<Expression> shouldClauses = newArrayList();
-	protected final List<Expression> filterClauses = newArrayList();
+	protected final List<Expression> mustClauses = new ArrayList<>(1);
+	protected final List<Expression> mustNotClauses = new ArrayList<>(1);
+	protected final List<Expression> shouldClauses = new ArrayList<>(3);
+	protected final List<Expression> filterClauses = new ArrayList<>(3);
 	protected int minShouldMatch = 1;
 	
 	protected AbstractExpressionBuilder() {}
@@ -103,9 +98,15 @@ public abstract class AbstractExpressionBuilder<B extends AbstractExpressionBuil
 				return shouldClauses.get(0);
 			}
 			
-			final BoolExpression be = new BoolExpression(mustClauses, mustNotClauses, shouldClauses, filterClauses);
-			be.setMinShouldMatch(minShouldMatch);
-			return be;
+			// if after the optimization the resulting bool clauses are empty, then return a MatchNone expression
+			if (mustClauses.isEmpty() && mustNotClauses.isEmpty() && shouldClauses.isEmpty() && filterClauses.isEmpty()) {
+				return Expressions.matchNone();
+			} else {
+				// otherwise create the bool expression as usual
+				final BoolExpression be = new BoolExpression(mustClauses, mustNotClauses, shouldClauses, filterClauses);
+				be.setMinShouldMatch(minShouldMatch);
+				return be;
+			}
 		}
 	}
 
@@ -160,9 +161,10 @@ public abstract class AbstractExpressionBuilder<B extends AbstractExpressionBuil
 						values.addAll(((SetPredicate<?>) expression).values());
 					}
 				}
-				// replace all clauses with a single expression
-				clauses.add(Expressions.matchAnyObject(field, values));
+				// remove all matching clauses first
 				clauses.removeAll(termExpressions);
+				// add the new merged expression
+				clauses.add(Expressions.matchAnyObject(field, values));
 			}
 		}
 	}

--- a/commons/com.b2international.index/src/com/b2international/index/query/AbstractExpressionBuilder.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/AbstractExpressionBuilder.java
@@ -136,12 +136,48 @@ public abstract class AbstractExpressionBuilder<B extends AbstractExpressionBuil
 		mergeTermFilters(filterClauses);
 	}
 	
+	private void reduceTermFilters(List<Expression> clauses) {
+		Multimap<String, Expression> termExpressionsByField = HashMultimap.create();
+		for (Expression expression : List.copyOf(clauses)) {
+			if (shouldMergeSingleArgumentPredicate(expression)) {
+				termExpressionsByField.put(((SingleArgumentPredicate<?>) expression).getField(), expression);
+			} else if (shouldMergeSetPredicate(expression)) {
+				termExpressionsByField.put(((SetPredicate<?>) expression).getField(), expression);
+			}
+		}
+		
+		for (String field : Set.copyOf(termExpressionsByField.keySet())) {
+			Collection<Expression> termExpressions = termExpressionsByField.removeAll(field);
+			if (termExpressions.size() > 1) {
+				Set<Object> values = null;
+				for (Expression expression : termExpressions) {
+					if (values != null && values.isEmpty()) {
+						break;
+					}
+					Set<Object> expressionValues;
+					if (expression instanceof SingleArgumentPredicate<?>) {
+						expressionValues = Set.of(((SingleArgumentPredicate<?>) expression).getArgument());
+					} else if (expression instanceof SetPredicate<?>) {
+						expressionValues = Set.copyOf(((SetPredicate<?>) expression).values());
+					} else {
+						throw new IllegalStateException("Invalid clause detected when processing term/terms clauses: " + expression);
+					}
+					values = values == null ? expressionValues : Set.copyOf(Sets.intersection(values, expressionValues));
+				}
+				// remove all matching clauses first
+				clauses.removeAll(termExpressions);
+				// add the new merged expression
+				clauses.add(Expressions.matchAnyObject(field, values));
+			}
+		}
+	}
+
 	private void mergeTermFilters(List<Expression> clauses) {
 		Multimap<String, Expression> termExpressionsByField = HashMultimap.create();
 		for (Expression expression : List.copyOf(clauses)) {
-			if (expression instanceof SingleArgumentPredicate<?>) {
+			if (shouldMergeSingleArgumentPredicate(expression)) {
 				termExpressionsByField.put(((SingleArgumentPredicate<?>) expression).getField(), expression);
-			} else if (expression instanceof SetPredicate<?>) {
+			} else if (shouldMergeSetPredicate(expression)) {
 				termExpressionsByField.put(((SetPredicate<?>) expression).getField(), expression);
 			}
 		}
@@ -162,6 +198,14 @@ public abstract class AbstractExpressionBuilder<B extends AbstractExpressionBuil
 				clauses.removeAll(termExpressions);
 			}
 		}
+	}
+	
+	private boolean shouldMergeSingleArgumentPredicate(Expression expression) {
+		return expression instanceof SingleArgumentPredicate<?> && !(expression instanceof RegexpPredicate);
+	}
+
+	private boolean shouldMergeSetPredicate(Expression expression) {
+		return expression instanceof SetPredicate<?> && !(expression instanceof PrefixPredicate);
 	}
 	
 }

--- a/commons/com.b2international.index/src/com/b2international/index/query/AbstractExpressionBuilder.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/AbstractExpressionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2011-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,13 @@ package com.b2international.index.query;
 
 import static com.google.common.collect.Lists.newArrayList;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 
 /**
  * Abstract superclass for building query {@link Expression}s.
@@ -72,13 +78,90 @@ public abstract class AbstractExpressionBuilder<B extends AbstractExpressionBuil
 	public Expression build() {
 		if (mustClauses.isEmpty() && mustNotClauses.isEmpty() && shouldClauses.isEmpty() && filterClauses.isEmpty()) {
 			return Expressions.matchAll();
-		} else if (mustClauses.isEmpty() && mustNotClauses.isEmpty() && shouldClauses.isEmpty() && filterClauses.size() == 1) {
+		} else if (isSingleFilter()) {
 			// shortcut to reduce number of nested Boolean clauses
 			return filterClauses.get(0);
 		} else {
+			// before creating the boolean query make sure we flatten the query as much as possible
+			
+			// or(A=B, or(A=C, or(A=D))) - should only clauses deeply nested inside bool queries (and the minShouldMatch is 1 on all levels)
+			flattenShoulds();
+			
+			// then optimize term filters that match the same field, field1=A or field1=B or field1=C should be converted to field1=any(A, B, C)
+			// during EsQueryBuilder the system will optimize it again to fit into the max term count ES setting, see EsQueryBuilder
+			mergeTermFilters();
+			
+			if (isSingleFilter()) {
+				return filterClauses.get(0);
+			}
+			
+			if (isSingleShould()) {
+				return shouldClauses.get(0);
+			}
+			
 			final BoolExpression be = new BoolExpression(mustClauses, mustNotClauses, shouldClauses, filterClauses);
 			be.setMinShouldMatch(minShouldMatch);
 			return be;
 		}
 	}
+
+	private boolean isSingleFilter() {
+		return mustClauses.isEmpty() && mustNotClauses.isEmpty() && shouldClauses.isEmpty() && filterClauses.size() == 1;
+	}
+	
+	private boolean isSingleShould() {
+		return mustClauses.isEmpty() && mustNotClauses.isEmpty() && shouldClauses.size() == 1 && filterClauses.isEmpty();
+	}
+
+	protected final void flattenShoulds() {
+		if (!mustClauses.isEmpty() || !mustNotClauses.isEmpty() || !filterClauses.isEmpty() || minShouldMatch != 1) {
+			return;
+		}
+		for (Expression expression : List.copyOf(shouldClauses)) {
+			if (expression instanceof BoolExpression) {
+				BoolExpression bool = (BoolExpression) expression;
+				if (bool.isShouldOnly() && bool.minShouldMatch() == 1) {
+					shouldClauses.addAll(bool.filterClauses());
+					shouldClauses.remove(bool);
+				}
+			}
+		}
+	}
+
+	protected final void mergeTermFilters() {
+		// check each must, mustNot, should and filter clause and merge term/terms queries into a single terms query, targeting the same field
+		mergeTermFilters(mustClauses);
+		mergeTermFilters(mustNotClauses);
+		mergeTermFilters(shouldClauses);
+		mergeTermFilters(filterClauses);
+	}
+	
+	private void mergeTermFilters(List<Expression> clauses) {
+		Multimap<String, Expression> termExpressionsByField = HashMultimap.create();
+		for (Expression expression : List.copyOf(clauses)) {
+			if (expression instanceof SingleArgumentPredicate<?>) {
+				termExpressionsByField.put(((SingleArgumentPredicate<?>) expression).getField(), expression);
+			} else if (expression instanceof SetPredicate<?>) {
+				termExpressionsByField.put(((SetPredicate<?>) expression).getField(), expression);
+			}
+		}
+		
+		for (String field : Set.copyOf(termExpressionsByField.keySet())) {
+			Collection<Expression> termExpressions = termExpressionsByField.removeAll(field);
+			if (termExpressions.size() > 1) {
+				Set<Object> values = Sets.newHashSet();
+				for (Expression expression : termExpressions) {
+					if (expression instanceof SingleArgumentPredicate<?>) {
+						values.add(((SingleArgumentPredicate<?>) expression).getArgument());
+					} else if (expression instanceof SetPredicate<?>) {
+						values.addAll(((SetPredicate<?>) expression).values());
+					}
+				}
+				// replace all clauses with a single expression
+				clauses.add(Expressions.matchAnyObject(field, values));
+				clauses.removeAll(termExpressions);
+			}
+		}
+	}
+	
 }

--- a/commons/com.b2international.index/src/com/b2international/index/query/AbstractExpressionBuilder.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/AbstractExpressionBuilder.java
@@ -129,47 +129,10 @@ public abstract class AbstractExpressionBuilder<B extends AbstractExpressionBuil
 	}
 
 	protected final void mergeTermFilters() {
-		// check each must, mustNot, should and filter clause and merge term/terms queries into a single terms query, targeting the same field
-		mergeTermFilters(mustClauses);
+		// check each "mustNot" and "should" clause list and merge term/terms queries into a single terms query, targeting the same field
+		// "must" and "filter" clauses will be reduced at a later time in EsQueryBuilder#visit(BoolExpression)
 		mergeTermFilters(mustNotClauses);
 		mergeTermFilters(shouldClauses);
-		mergeTermFilters(filterClauses);
-	}
-	
-	private void reduceTermFilters(List<Expression> clauses) {
-		Multimap<String, Expression> termExpressionsByField = HashMultimap.create();
-		for (Expression expression : List.copyOf(clauses)) {
-			if (shouldMergeSingleArgumentPredicate(expression)) {
-				termExpressionsByField.put(((SingleArgumentPredicate<?>) expression).getField(), expression);
-			} else if (shouldMergeSetPredicate(expression)) {
-				termExpressionsByField.put(((SetPredicate<?>) expression).getField(), expression);
-			}
-		}
-		
-		for (String field : Set.copyOf(termExpressionsByField.keySet())) {
-			Collection<Expression> termExpressions = termExpressionsByField.removeAll(field);
-			if (termExpressions.size() > 1) {
-				Set<Object> values = null;
-				for (Expression expression : termExpressions) {
-					if (values != null && values.isEmpty()) {
-						break;
-					}
-					Set<Object> expressionValues;
-					if (expression instanceof SingleArgumentPredicate<?>) {
-						expressionValues = Set.of(((SingleArgumentPredicate<?>) expression).getArgument());
-					} else if (expression instanceof SetPredicate<?>) {
-						expressionValues = Set.copyOf(((SetPredicate<?>) expression).values());
-					} else {
-						throw new IllegalStateException("Invalid clause detected when processing term/terms clauses: " + expression);
-					}
-					values = values == null ? expressionValues : Set.copyOf(Sets.intersection(values, expressionValues));
-				}
-				// remove all matching clauses first
-				clauses.removeAll(termExpressions);
-				// add the new merged expression
-				clauses.add(Expressions.matchAnyObject(field, values));
-			}
-		}
 	}
 
 	private void mergeTermFilters(List<Expression> clauses) {
@@ -200,11 +163,11 @@ public abstract class AbstractExpressionBuilder<B extends AbstractExpressionBuil
 		}
 	}
 	
-	private boolean shouldMergeSingleArgumentPredicate(Expression expression) {
+	public static boolean shouldMergeSingleArgumentPredicate(Expression expression) {
 		return expression instanceof SingleArgumentPredicate<?> && !(expression instanceof RegexpPredicate);
 	}
 
-	private boolean shouldMergeSetPredicate(Expression expression) {
+	public static boolean shouldMergeSetPredicate(Expression expression) {
 		return expression instanceof SetPredicate<?> && !(expression instanceof PrefixPredicate);
 	}
 	

--- a/commons/com.b2international.index/src/com/b2international/index/query/AbstractExpressionBuilder.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/AbstractExpressionBuilder.java
@@ -82,6 +82,9 @@ public abstract class AbstractExpressionBuilder<B extends AbstractExpressionBuil
 		} else if (isSingleFilter()) {
 			// shortcut to reduce number of nested Boolean clauses
 			return filterClauses.get(0);
+		} else if (isSingleShould()) {
+			// shortcut to reduce number of nested Boolean clauses
+			return shouldClauses.get(0);
 		} else {
 			// before creating the boolean query make sure we flatten the query as much as possible
 			

--- a/commons/com.b2international.index/src/com/b2international/index/query/AbstractExpressionBuilder.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/AbstractExpressionBuilder.java
@@ -20,6 +20,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.SortedSet;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
@@ -148,7 +149,7 @@ public abstract class AbstractExpressionBuilder<B extends AbstractExpressionBuil
 		for (String field : Set.copyOf(termExpressionsByField.keySet())) {
 			Collection<Expression> termExpressions = termExpressionsByField.removeAll(field);
 			if (termExpressions.size() > 1) {
-				Set<Object> values = Sets.newHashSet();
+				SortedSet<Comparable<?>> values = Sets.newTreeSet();
 				for (Expression expression : termExpressions) {
 					if (expression instanceof SingleArgumentPredicate<?>) {
 						values.add(((SingleArgumentPredicate<?>) expression).getArgument());

--- a/commons/com.b2international.index/src/com/b2international/index/query/BoolExpression.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/BoolExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2011-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,14 @@ public final class BoolExpression implements Expression {
 			
 			builder.append(")");
 		}
+	}
+
+	public boolean isFilterOnly() {
+		return mustClauses.isEmpty() && mustNotClauses.isEmpty() && shouldClauses.isEmpty() && !filterClauses.isEmpty();
+	}
+	
+	public boolean isShouldOnly() {
+		return mustClauses.isEmpty() && mustNotClauses.isEmpty() && !shouldClauses.isEmpty() && filterClauses.isEmpty();
 	}
 	
 }

--- a/commons/com.b2international.index/src/com/b2international/index/query/Expressions.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/Expressions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2011-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,18 @@ public class Expressions {
 
 	}
 	
+	/**
+	 * @return a new boolean query expression builder
+	 * @deprecated - use {@link Expressions#bool()} instead
+	 */
 	public static ExpressionBuilder builder() {
+		return bool();
+	}
+	
+	/**
+	 * @return a new boolean query expression builder
+	 */
+	public static ExpressionBuilder bool() {
 		return new ExpressionBuilder();
 	}
 	
@@ -246,6 +257,27 @@ public class Expressions {
 	
 	public static Expression scriptQuery(String script, Map<String, Object> params) {
 		return new ScriptQueryExpression(script, params);
+	}
+
+	public static Expression matchAnyObject(String field, Iterable<?> values) {
+		Object firstValue = Iterables.getFirst(values, null);
+		if (firstValue == null) {
+			return matchNone();
+		} else if (firstValue instanceof String) {
+			return matchAny(field, (Iterable<String>) values);
+		} else if (firstValue instanceof Long) {
+			return matchAnyLong(field, (Iterable<Long>) values);
+		} else if (firstValue instanceof BigDecimal) {
+			return matchAnyDecimal(field, (Iterable<BigDecimal>) values);
+		} else if (firstValue instanceof Double) {
+			return matchAnyDouble(field, (Iterable<Double>) values);
+		} else if (firstValue instanceof Enum<?>) {
+			return matchAnyEnum(field, (Iterable<Enum<?>>) values);
+		} else if (firstValue instanceof Integer) {
+			return matchAnyInt(field, (Iterable<Integer>) values);
+		} else {
+			throw new UnsupportedOperationException("Unsupported term expression value type: " + firstValue);
+		}
 	}
 
 }

--- a/commons/com.b2international.index/src/com/b2international/index/query/SetPredicate.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/SetPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2011-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,21 @@
 package com.b2international.index.query;
 
 import java.util.Objects;
-import java.util.Set;
+import java.util.SortedSet;
 
 import com.b2international.commons.StringUtils;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 
 /**
  * @since 5.0
  */
-public abstract class SetPredicate<T> extends Predicate {
+public abstract class SetPredicate<T extends Comparable<T>> extends Predicate {
 	
-	private final Set<T> values;
+	private final SortedSet<T> values;
 
 	SetPredicate(String field, Iterable<T> values) {
 		super(field);
-		this.values = ImmutableSet.copyOf(values);
+		this.values = ImmutableSortedSet.copyOf(values);
 	}
 	
 	@Override
@@ -47,7 +47,7 @@ public abstract class SetPredicate<T> extends Predicate {
 		return false;
 	}
 	
-	public Set<T> values() {
+	public SortedSet<T> values() {
 		return values;
 	}
 	

--- a/commons/com.b2international.index/src/com/b2international/index/query/SingleArgumentPredicate.java
+++ b/commons/com.b2international.index/src/com/b2international/index/query/SingleArgumentPredicate.java
@@ -25,7 +25,7 @@ import java.util.Objects;
  * @since 4.7
  * @param <A> the argument type
  */
-public abstract class SingleArgumentPredicate<A> extends Predicate {
+public abstract class SingleArgumentPredicate<A extends Comparable<A>> extends Predicate {
 
 	private final A argument;
 

--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequestTest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequestTest.java
@@ -24,6 +24,7 @@ import static com.b2international.snowowl.snomed.datastore.index.entry.SnomedCon
 import static com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument.Expressions.statedAncestors;
 import static com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument.Expressions.statedParents;
 import static com.b2international.snowowl.test.commons.snomed.DocumentBuilders.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -32,6 +33,7 @@ import static org.junit.Assume.assumeFalse;
 import java.math.BigDecimal;
 import java.util.*;
 
+import org.assertj.core.api.ListAssert;
 import org.eclipse.xtext.parser.IParser;
 import org.eclipse.xtext.serializer.ISerializer;
 import org.eclipse.xtext.validation.IResourceValidator;
@@ -45,12 +47,12 @@ import org.junit.runners.Parameterized.Parameters;
 import com.b2international.collections.PrimitiveCollectionModule;
 import com.b2international.commons.exceptions.BadRequestException;
 import com.b2international.index.Index;
-import com.b2international.index.query.Expression;
-import com.b2international.index.query.Expressions;
-import com.b2international.index.query.MatchNone;
+import com.b2international.index.query.*;
 import com.b2international.index.revision.BaseRevisionIndexTest;
+import com.b2international.index.revision.Revision;
 import com.b2international.index.revision.RevisionIndex;
 import com.b2international.index.revision.StagingArea;
+import com.b2international.snomed.ecl.Ecl;
 import com.b2international.snomed.ecl.EclStandaloneSetup;
 import com.b2international.snowowl.core.api.SnowowlRuntimeException;
 import com.b2international.snowowl.core.domain.BranchContext;
@@ -274,6 +276,70 @@ public class SnomedEclEvaluationRequestTest extends BaseRevisionIndexTest {
 					.build();
 		}
 		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void descendantOrSelfList() throws Exception {
+		final Expression actual = eval(Ecl.or(
+			"<<" + Concepts.ACCEPTABILITY,
+			"<<" + Concepts.FINDING_SITE,
+			"<<" + Concepts.SYNONYM,
+			"<<" + Concepts.DEFINING_RELATIONSHIP
+		));
+		
+		/*
+		 * The output should have:
+		 * 
+		 * 1. ID sets should be consolidated into a single SetPredicate query 
+		 * 2. A single boolean expression with multiple "should" clauses instead of a nested bool-should-bool-should... structure
+		 */
+		if (actual instanceof BoolExpression) {
+			final BoolExpression expected = (BoolExpression) actual;
+			assertEquals(3, expected.shouldClauses().size());
+
+			final ListAssert<Expression> shouldClauses = assertThat(expected.shouldClauses());
+			final ListAssert<Expression> stringPredicates = shouldClauses.filteredOn(e -> e instanceof StringSetPredicate);
+			final ListAssert<Expression> longPredicates = shouldClauses.filteredOn(e -> e instanceof LongSetPredicate);
+			
+			stringPredicates.extracting(e -> ((StringSetPredicate) e).values())
+				.allMatch(values -> values.equals(Set.of(
+					Concepts.ACCEPTABILITY,
+					Concepts.FINDING_SITE,
+					Concepts.SYNONYM,
+					Concepts.DEFINING_RELATIONSHIP
+				)));
+
+			longPredicates.extracting(e -> ((LongSetPredicate) e).values())
+				.allMatch(values -> values.equals(Set.of(
+					Long.parseLong(Concepts.ACCEPTABILITY),
+					Long.parseLong(Concepts.FINDING_SITE),
+					Long.parseLong(Concepts.SYNONYM),
+					Long.parseLong(Concepts.DEFINING_RELATIONSHIP)
+				)));
+
+			stringPredicates.extracting(e -> ((StringSetPredicate) e).getField())
+				.containsExactlyInAnyOrder(Revision.Fields.ID);
+			
+			if (isInferred()) {
+				
+				longPredicates.extracting(e -> ((LongSetPredicate) e).getField())
+					.containsExactlyInAnyOrder(
+						SnomedConceptDocument.Fields.PARENTS,
+						SnomedConceptDocument.Fields.ANCESTORS
+					);
+				
+			} else {
+				
+				longPredicates.extracting(e -> ((LongSetPredicate) e).getField())
+					.containsExactlyInAnyOrder(
+						SnomedConceptDocument.Fields.STATED_PARENTS, 
+						SnomedConceptDocument.Fields.STATED_ANCESTORS
+					);
+			}
+			
+		} else {
+			fail("Expected a BoolExpression but got: " + actual);
+		}
 	}
 	
 	@Test


### PR DESCRIPTION
This PR contains partial cherry-picks of the following commits to resolve a query evaluation issue where nesting of boolean query clauses reaches the limits defined by ES:

- 1cae6cbe3628a53868f39a97f125601e76197c5b
- 23e2861096404fcf12059bb17f27058360ec6570
- eb0a188a3cf85763fc835787086e2e2b207093b3
- 966f8315771c798c24b8ff3d3f88856ba738e526
- 24d57c55663e4731778934f1f88e0ba336b76a08
- df0c594556bddfc8671b29629b78fbb4e202ac36
- 9196e970f5cbfdced7884e7c82f2b5a1e75db7d2
- 874300e71bf064a2bd55176501463df239ab5bc6
- 8b9c489f5228898c92e9f627a7cbae8bff564de6
- 8d679a1c89f866b30be3edb7818cf891e835bfa5
- 1642f5a90092f1ab64ba04fcf8ea9210f1d1d4d2
- 546cb2e23359297bb1d01875febc13bb90c0e7a1