### PR TITLE
SO-6550: Support "*" for preferred term and FSN resolution

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/datastore/CodeSystemResource.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/datastore/CodeSystemResource.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.TerminologyResource;
+import com.b2international.snowowl.core.TerminologyResource.CommonSettings;
 import com.b2international.snowowl.core.branch.Branch;
 import com.b2international.snowowl.core.codesystem.CodeSystem;
 import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
@@ -45,19 +46,30 @@ public class CodeSystemResource {
 			"languageTag", US_LOCALE.getLanguageTag(), 
 			"languageRefSetIds", List.of(Concepts.REFSET_LANGUAGE_TYPE_US))
 		);
+		
 		languageMap.add(Map.of(
 			"languageTag", GB_LOCALE.getLanguageTag(), 
 			"languageRefSetIds", List.of(Concepts.REFSET_LANGUAGE_TYPE_UK))
 		);
+		
 		languageMap.add(Map.of(
 			"languageTag", SG_LOCALE.getLanguageTag(), 
 			"languageRefSetIds", List.of(Concepts.REFSET_LANGUAGE_TYPE_SG))
 		);
 
+		final List<String> locales = Lists.newArrayList();
+		
+		locales.add(SG_LOCALE.toString());
+		locales.add(GB_LOCALE.toString());
+		locales.add(US_LOCALE.toString());
+		
 		final CodeSystem cs = new CodeSystem();
 		cs.setBranchPath(Branch.MAIN_PATH);
 		cs.setId(SnomedContentRule.SNOMEDCT_ID);
-		cs.setSettings(Map.of(Settings.LANGUAGES, languageMap));
+		cs.setSettings(Map.of(
+			Settings.LANGUAGES, languageMap,
+			CommonSettings.LOCALES, locales
+		));
 
 		context
 			.with(TerminologyResource.class, cs)

--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/datastore/SnomedDescriptionUtilsTest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/datastore/SnomedDescriptionUtilsTest.java
@@ -20,7 +20,6 @@ import static com.b2international.snowowl.snomed.datastore.CodeSystemResource.SG
 import static com.b2international.snowowl.snomed.datastore.CodeSystemResource.US_LOCALE;
 import static com.b2international.snowowl.snomed.datastore.SnomedDescriptionUtils.indexBestPreferredByConceptId;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 import java.util.List;
 import java.util.Map;
@@ -30,6 +29,7 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
+import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.snowowl.core.branch.Branch;
 import com.b2international.snowowl.core.domain.BranchContext;
@@ -48,139 +48,161 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class SnomedDescriptionUtilsTest {
 
+	private static final ExtendedLocale UNRECOGNIZED_LOCALE = new ExtendedLocale("en", "", "1234");
+	private static final ExtendedLocale WILDCARD_LOCALE = new ExtendedLocale(AcceptLanguageHeader.WILDCARD, "", "");
+
 	private static List<SnomedDescription> descriptions;
 
 	private static SnomedDescription gbPreferredDescription;
 	private static SnomedDescription usPreferredDescription;
 	private static SnomedDescription sgPreferredDescription;
-	private static SnomedDescription englishAdditionalDescription;
-	private static SnomedDescription sgAdditionalDescription;
+	private static SnomedDescription gbUsAcceptableDescription;
+	private static SnomedDescription sgAcceptableDescription;
 	private static BranchContext context;
 
 	@BeforeClass
 	public static void setup() {
 		Builder contextBuilder = TestBranchContext.on(Branch.MAIN_PATH)
-				.with(ClassLoader.class, SnomedDescriptionUtilsTest.class.getClassLoader())
-				.with(ObjectMapper.class, JsonSupport.getDefaultObjectMapper())
-				.with(TerminologyRegistry.class, TerminologyRegistry.INSTANCE);
+			.with(ClassLoader.class, SnomedDescriptionUtilsTest.class.getClassLoader())
+			.with(ObjectMapper.class, JsonSupport.getDefaultObjectMapper())
+			.with(TerminologyRegistry.class, TerminologyRegistry.INSTANCE);
 		
 		CodeSystemResource.configureCodeSystem(contextBuilder);
 		context = contextBuilder.build();
 		
-		gbPreferredDescription = createDescription("1", "first description",
-				Map.of(
-						Concepts.REFSET_LANGUAGE_TYPE_UK, Acceptability.PREFERRED,
-						Concepts.REFSET_LANGUAGE_TYPE_US, Acceptability.ACCEPTABLE
-						)
-				);
+		gbPreferredDescription = createDescription("1", "first description", Map.of(
+			Concepts.REFSET_LANGUAGE_TYPE_UK, Acceptability.PREFERRED,
+			Concepts.REFSET_LANGUAGE_TYPE_US, Acceptability.ACCEPTABLE
+		));
 
-		usPreferredDescription = createDescription("2", "second description",
-				Map.of(
-						Concepts.REFSET_LANGUAGE_TYPE_UK, Acceptability.ACCEPTABLE,
-						Concepts.REFSET_LANGUAGE_TYPE_US, Acceptability.PREFERRED
-						)
-				);
+		usPreferredDescription = createDescription("2", "second description", Map.of(
+			Concepts.REFSET_LANGUAGE_TYPE_UK, Acceptability.ACCEPTABLE,
+			Concepts.REFSET_LANGUAGE_TYPE_US, Acceptability.PREFERRED
+		));
 
-		sgPreferredDescription = createDescription("3", "third description",
-				Map.of(
-						Concepts.REFSET_LANGUAGE_TYPE_SG, Acceptability.PREFERRED
-						)
-				);
+		sgPreferredDescription = createDescription("3", "third description", Map.of(
+			Concepts.REFSET_LANGUAGE_TYPE_SG, Acceptability.PREFERRED
+		));
 
-		englishAdditionalDescription = createDescription("4", "fourth description",
-				Map.of(
-						Concepts.REFSET_LANGUAGE_TYPE_UK, Acceptability.ACCEPTABLE,
-						Concepts.REFSET_LANGUAGE_TYPE_US, Acceptability.ACCEPTABLE
-						)
-				);
+		gbUsAcceptableDescription = createDescription("4", "fourth description", Map.of(
+			Concepts.REFSET_LANGUAGE_TYPE_UK, Acceptability.ACCEPTABLE,
+			Concepts.REFSET_LANGUAGE_TYPE_US, Acceptability.ACCEPTABLE
+		));
 
-		sgAdditionalDescription = createDescription("5", "fifth description",
-				Map.of(
-						Concepts.REFSET_LANGUAGE_TYPE_SG, Acceptability.ACCEPTABLE
-						)
-				);
+		sgAcceptableDescription = createDescription("5", "fifth description", Map.of(
+			Concepts.REFSET_LANGUAGE_TYPE_SG, Acceptability.ACCEPTABLE
+		));
 
-		descriptions = List.of(gbPreferredDescription, usPreferredDescription, englishAdditionalDescription, sgPreferredDescription, sgAdditionalDescription);
+		descriptions = List.of(
+			gbPreferredDescription, 
+			usPreferredDescription, 
+			gbUsAcceptableDescription, 
+			sgPreferredDescription, 
+			sgAcceptableDescription
+		);
+	}
+
+	private static void assertBestPreferred(final SnomedDescription expected, final ExtendedLocale... locales) {
+		assertEquals(expected, indexBestPreferredByConceptId(context, descriptions, List.of(locales)).get(Concepts.ROOT_CONCEPT));
 	}
 
 	@Test
 	public void testGBEnglishOrdering1() {
-		assertEquals(gbPreferredDescription, indexBestPreferredByConceptId(context, descriptions, List.of(GB_LOCALE, US_LOCALE, SG_LOCALE)).get(Concepts.ROOT_CONCEPT));
+		assertBestPreferred(gbPreferredDescription, GB_LOCALE, US_LOCALE, SG_LOCALE);
 	}
 
+	
 	@Test
 	public void testGBEnglishOrdering2() {
-		assertEquals(gbPreferredDescription, indexBestPreferredByConceptId(context, descriptions, List.of(GB_LOCALE, SG_LOCALE)).get(Concepts.ROOT_CONCEPT));
+		assertBestPreferred(gbPreferredDescription, GB_LOCALE, SG_LOCALE);
 	}
 
 	@Test
 	public void testGBEnglishOrdering3() {
-		assertEquals(gbPreferredDescription, indexBestPreferredByConceptId(context, descriptions, List.of(GB_LOCALE, US_LOCALE)).get(Concepts.ROOT_CONCEPT));
+		assertBestPreferred(gbPreferredDescription, GB_LOCALE, US_LOCALE);
 	}
 
 	@Test
 	public void testGBEnglishOrdering4() {
-		assertEquals(gbPreferredDescription, indexBestPreferredByConceptId(context, descriptions, List.of(GB_LOCALE)).get(Concepts.ROOT_CONCEPT));
+		assertBestPreferred(gbPreferredDescription, GB_LOCALE);
 	}
 
 	@Test
 	public void testUSEnglishOrdering1() {
-		assertEquals(usPreferredDescription, indexBestPreferredByConceptId(context, descriptions, List.of(US_LOCALE, GB_LOCALE, SG_LOCALE)).get(Concepts.ROOT_CONCEPT));
+		assertBestPreferred(usPreferredDescription, US_LOCALE, GB_LOCALE, SG_LOCALE);
 	}
 
 	@Test
 	public void testUSEnglishOrdering2() {
-		assertEquals(usPreferredDescription, indexBestPreferredByConceptId(context, descriptions, List.of(US_LOCALE, GB_LOCALE)).get(Concepts.ROOT_CONCEPT));
+		assertBestPreferred(usPreferredDescription, US_LOCALE, GB_LOCALE);
 	}
 
 	@Test
 	public void testUSEnglishOrdering3() {
-		assertEquals(usPreferredDescription, indexBestPreferredByConceptId(context, descriptions, List.of(US_LOCALE, SG_LOCALE)).get(Concepts.ROOT_CONCEPT));
+		assertBestPreferred(usPreferredDescription, US_LOCALE, SG_LOCALE);
 	}
 
 	@Test
 	public void testUSEnglishOrdering4() {
-		assertEquals(usPreferredDescription, indexBestPreferredByConceptId(context, descriptions, List.of(US_LOCALE)).get(Concepts.ROOT_CONCEPT));
+		assertBestPreferred(usPreferredDescription, US_LOCALE);
 	}
 
 	@Test
 	public void testSgEnglishOrdering1() {
-		assertEquals(sgPreferredDescription, indexBestPreferredByConceptId(context, descriptions, List.of(SG_LOCALE, US_LOCALE, GB_LOCALE)).get(Concepts.ROOT_CONCEPT));
+		assertBestPreferred(sgPreferredDescription, SG_LOCALE, US_LOCALE, GB_LOCALE);
 	}
 
 	@Test
 	public void testSgEnglishOrdering2() {
-		assertEquals(sgPreferredDescription, indexBestPreferredByConceptId(context, descriptions, List.of(SG_LOCALE, GB_LOCALE)).get(Concepts.ROOT_CONCEPT));
+		assertBestPreferred(sgPreferredDescription, SG_LOCALE, GB_LOCALE);
 	}
 
 	@Test
 	public void testSgEnglishOrdering3() {
-		assertEquals(sgPreferredDescription, indexBestPreferredByConceptId(context, descriptions, List.of(SG_LOCALE, US_LOCALE)).get(Concepts.ROOT_CONCEPT));
+		assertBestPreferred(sgPreferredDescription, SG_LOCALE, US_LOCALE);
 	}
 
 	@Test
 	public void testSgEnglishOrdering4() {
-		assertEquals(sgPreferredDescription, indexBestPreferredByConceptId(context, descriptions, List.of(SG_LOCALE)).get(Concepts.ROOT_CONCEPT));
+		assertBestPreferred(sgPreferredDescription, SG_LOCALE);
 	}
 
 	@Test
 	public void testCustomLanguageRefsetOrdering1() {
-		assertEquals(sgPreferredDescription, indexBestPreferredByConceptId(context, descriptions, List.of(new ExtendedLocale("en", "", "1234"), SG_LOCALE)).get(Concepts.ROOT_CONCEPT));
+		assertBestPreferred(sgPreferredDescription, UNRECOGNIZED_LOCALE, SG_LOCALE);
 	}
 
 	@Test
 	public void testCustomLanguageRefsetOrdering2() {
-		assertEquals(usPreferredDescription, indexBestPreferredByConceptId(context, descriptions, List.of(new ExtendedLocale("en", "", "1234"), US_LOCALE, SG_LOCALE)).get(Concepts.ROOT_CONCEPT));
+		assertBestPreferred(usPreferredDescription, UNRECOGNIZED_LOCALE, US_LOCALE, SG_LOCALE);
 	}
 
 	@Test
 	public void testCustomLanguageRefsetOrdering3() {
-		assertEquals(gbPreferredDescription, indexBestPreferredByConceptId(context, descriptions, List.of(new ExtendedLocale("en", "", "1234"), GB_LOCALE, US_LOCALE, SG_LOCALE)).get(Concepts.ROOT_CONCEPT));
+		assertBestPreferred(gbPreferredDescription, UNRECOGNIZED_LOCALE, GB_LOCALE, US_LOCALE, SG_LOCALE);
 	}
 
 	@Test
 	public void testCustomLanguageRefsetOrdering4() {
-		assertNull(indexBestPreferredByConceptId(context, descriptions, List.of(new ExtendedLocale("en", "", "1234"))).get(Concepts.ROOT_CONCEPT));
+		assertBestPreferred(null, UNRECOGNIZED_LOCALE);
+	}
+
+	@Test
+	public void testWildcardOrdering1() {
+		// Ordering is established in CodeSystemResource#configureCodeSystem (SG, GB, US) - SG wins
+		assertBestPreferred(sgPreferredDescription, WILDCARD_LOCALE);
+	}
+
+	@Test
+	public void testWildcardOrdering2() {
+		// Custom locale first (unrecognized), then wildcard (which expands to SG, GB, US) - SG wins
+		assertBestPreferred(sgPreferredDescription, UNRECOGNIZED_LOCALE, WILDCARD_LOCALE);
+	}
+
+	@Test
+	public void testWildcardOrdering3() {
+		// Custom locale, then US, then wildcard (which expands to SG, GB, US without duplication) - US wins
+		assertBestPreferred(usPreferredDescription, UNRECOGNIZED_LOCALE, US_LOCALE, WILDCARD_LOCALE);
 	}
 
 	@SuppressWarnings("deprecation")
@@ -192,5 +214,4 @@ public class SnomedDescriptionUtilsTest {
 		description.setAcceptabilityMap(acceptabilityMap);
 		return description;
 	}
-
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDescriptionUtils.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDescriptionUtils.java
@@ -20,11 +20,14 @@ import static com.google.common.collect.Maps.newHashMap;
 
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.b2international.commons.CompareUtils;
 import com.b2international.commons.ExplicitFirstOrdering;
 import com.b2international.commons.exceptions.BadRequestException;
+import com.b2international.commons.http.AcceptLanguageHeader;
 import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.snowowl.core.TerminologyResource;
 import com.b2international.snowowl.core.domain.BranchContext;
@@ -33,6 +36,7 @@ import com.b2international.snowowl.snomed.core.domain.Acceptability;
 import com.b2international.snowowl.snomed.core.domain.SnomedDescription;
 import com.b2international.snowowl.snomed.datastore.config.SnomedLanguageConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.*;
 
 /**
@@ -116,7 +120,39 @@ public final class SnomedDescriptionUtils {
 	 * @return the converted language reference set identifiers or an empty {@link List}, never <code>null</code>
 	 */
 	public static List<String> getLanguageRefSetIds(final BranchContext context, final List<ExtendedLocale> locales) {
-		return getLanguageRefSetIds(getLanguageMapping(context), locales);
+		if (CompareUtils.isEmpty(locales)) {
+			return Collections.emptyList();
+		}
+
+		/*
+		 * Rewrite appearances of "*" to all locales available from the terminology
+		 * resource, avoiding duplicate entries. The first mention of a locale is
+		 * retained in the final list so the order of preference is preserved.
+		 */
+		final Supplier<List<ExtendedLocale>> resourceLocales = Suppliers.memoize(() -> getResourceLocales(context));
+		final List<ExtendedLocale> wildcardExpandedLocales = locales.stream().flatMap(locale -> {
+			if (AcceptLanguageHeader.WILDCARD.equals(locale.getLanguage())) {
+				return resourceLocales.get().stream();
+			} else {
+				return Stream.of(locale);
+			}
+		})
+		.distinct()
+		.collect(Collectors.toList());
+		
+		return getLanguageRefSetIds(getLanguageMapping(context), wildcardExpandedLocales);
+	}
+
+	private static List<ExtendedLocale> getResourceLocales(final BranchContext context) {
+		final TerminologyResource resource = context.service(TerminologyResource.class);
+		final List<String> locales = resource.getLocales();
+		if (locales == null) {
+			return List.of();
+		}
+		
+		return locales.stream()
+			.map(locale -> ExtendedLocale.valueOf(locale))
+			.collect(Collectors.toList());
 	}
 
 	public static List<String> getLanguageRefSetIds(final ListMultimap<String, String> languageMap, final List<ExtendedLocale> locales) {
@@ -128,13 +164,7 @@ public final class SnomedDescriptionUtils {
 		final List<ExtendedLocale> unconvertableLocales = new ArrayList<ExtendedLocale>();
 
 		for (final ExtendedLocale extendedLocale : locales) {
-			Collection<String> mappedRefSetIds;
-
-			if (!extendedLocale.getLanguageRefSetId().isEmpty()) {
-				mappedRefSetIds = Collections.singleton(extendedLocale.getLanguageRefSetId());
-			} else {
-				mappedRefSetIds = languageMap.get(extendedLocale.getLanguageTag());
-			}
+			Collection<String> mappedRefSetIds = mapToLanguageRefSetIds(languageMap, extendedLocale);
 
 			if (mappedRefSetIds.isEmpty()) {
 				unconvertableLocales.add(extendedLocale);
@@ -152,6 +182,15 @@ public final class SnomedDescriptionUtils {
 		}
 
 		return languageRefSetIds;
+	}
+
+	private static Collection<String> mapToLanguageRefSetIds(final ListMultimap<String, String> languageMap, final ExtendedLocale extendedLocale) {
+
+		if (!extendedLocale.getLanguageRefSetId().isEmpty()) {
+			return Collections.singleton(extendedLocale.getLanguageRefSetId());
+		} else {
+			return languageMap.get(extendedLocale.getLanguageTag());
+		}
 	}
 	
 	/**


### PR DESCRIPTION
This PR changes the "determine best matching description" step when expanding preferred terms and fully specified names for SNOMED CT concept to allow adding `*` to the list of locales. This symbol is replaced in the same position with the list of known locales stored in terminology metadata, filed under the `locales` key.

Related behavior like replacing a single `*` input in an HTTP request's `Accept-Language` header with a built-in value is not modified.