### PR TITLE
SO-6555: remove CNC indicator generation for descriptions when inactivating concepts

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.common/src/com/b2international/snowowl/snomed/common/SnomedConstants.java
+++ b/snomed/com.b2international.snowowl.snomed.common/src/com/b2international/snowowl/snomed/common/SnomedConstants.java
@@ -235,6 +235,10 @@ public abstract class SnomedConstants {
 		public static final String MOVED_ELSEWHERE = "900000000000487009";
 		public static final String INAPPROPRIATE = "900000000000494007";
 		public static final String PENDING_MOVE = "900000000000492006";
+		
+		/**
+		 * @deprecated - no longer in use after 2026 January SNOMED International Edition release, kept here only for historical reasons, and if any logic requires the exclusion of this concept for any reason
+		 */
 		public static final String CONCEPT_NON_CURRENT = "900000000000495008";
 		public static final String NONCONFORMANCE_TO_EDITORIAL_POLICY = "723277005";
 		public static final String NOT_SEMANTICALLY_EQUIVALENT = "723278000";

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedComponentInactivationApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedComponentInactivationApiTest.java
@@ -18,7 +18,6 @@ package com.b2international.snowowl.snomed.core.rest.components;
 import static com.b2international.snowowl.snomed.core.rest.SnomedComponentRestRequests.updateComponent;
 import static com.b2international.snowowl.snomed.core.rest.SnomedRestFixtures.createNewConcept;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.util.List;
@@ -111,11 +110,16 @@ public class SnomedComponentInactivationApiTest extends AbstractSnomedApiTest {
 		assertEquals(Concepts.DUPLICATE, afterInactivationConceptInactivationIndicatorMember.getProperties().get(SnomedRf2Headers.FIELD_VALUE_ID));
 
 		// assert that as of 2026 Jan, CNC indicators are not generated/reactivated/managed
-		assertNull(fsnInactivationIndicatorMember);
-		assertNull(afterInactivationFsnInactivationIndicatorMember);
-		
-		assertNull(ptInactivationIndicatorMember);
-		assertNull(afterInactivationPtInactivationIndicatorMember);
+		// meaning that original inactivation indicators saved for each component will be kept as is when the concept gets inactivated
+		assertEquals(fsnInactivationIndicatorMember.getId(), afterInactivationFsnInactivationIndicatorMember.getId());
+		assertEquals(null, afterInactivationFsnInactivationIndicatorMember.getEffectiveTime());
+		assertEquals(false, afterInactivationFsnInactivationIndicatorMember.isReleased());
+		assertEquals(Concepts.PENDING_MOVE, afterInactivationFsnInactivationIndicatorMember.getProperties().get(SnomedRf2Headers.FIELD_VALUE_ID));
+				
+		assertEquals(ptInactivationIndicatorMember.getId(), afterInactivationPtInactivationIndicatorMember.getId());
+		assertEquals(null, afterInactivationPtInactivationIndicatorMember.getEffectiveTime());
+		assertEquals(false, afterInactivationPtInactivationIndicatorMember.isReleased());
+		assertEquals(Concepts.PENDING_MOVE, afterInactivationPtInactivationIndicatorMember.getProperties().get(SnomedRf2Headers.FIELD_VALUE_ID));
 	}
 
 	private SnomedReferenceSetMember getIndicatorMember(SnomedCoreComponent component, String inactivationIndicatorRefSetId) {

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedComponentInactivationApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedComponentInactivationApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2020-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.b2international.snowowl.snomed.core.rest.components;
 import static com.b2international.snowowl.snomed.core.rest.SnomedComponentRestRequests.updateComponent;
 import static com.b2international.snowowl.snomed.core.rest.SnomedRestFixtures.createNewConcept;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.util.List;
@@ -44,7 +45,7 @@ import com.google.common.collect.Iterables;
 public class SnomedComponentInactivationApiTest extends AbstractSnomedApiTest {
 
 	@Test
-	public void reuseConceptAndDescriptionInactivationIndicators() throws Exception {
+	public void reuseConceptInactivationIndicators() throws Exception {
 		// create a concept
 		String conceptId = createNewConcept(branchPath);
 		SnomedConcept concept = getConcept(conceptId, "descriptions()");
@@ -108,17 +109,13 @@ public class SnomedComponentInactivationApiTest extends AbstractSnomedApiTest {
 		assertEquals(null, afterInactivationConceptInactivationIndicatorMember.getEffectiveTime());
 		assertEquals(false, afterInactivationConceptInactivationIndicatorMember.isReleased());
 		assertEquals(Concepts.DUPLICATE, afterInactivationConceptInactivationIndicatorMember.getProperties().get(SnomedRf2Headers.FIELD_VALUE_ID));
+
+		// assert that as of 2026 Jan, CNC indicators are not generated/reactivated/managed
+		assertNull(fsnInactivationIndicatorMember);
+		assertNull(afterInactivationFsnInactivationIndicatorMember);
 		
-		assertEquals(fsnInactivationIndicatorMember.getId(), afterInactivationFsnInactivationIndicatorMember.getId());
-		assertEquals(null, afterInactivationFsnInactivationIndicatorMember.getEffectiveTime());
-		assertEquals(false, afterInactivationFsnInactivationIndicatorMember.isReleased());
-		assertEquals(Concepts.CONCEPT_NON_CURRENT, afterInactivationFsnInactivationIndicatorMember.getProperties().get(SnomedRf2Headers.FIELD_VALUE_ID));
-		
-		assertEquals(ptInactivationIndicatorMember.getId(), afterInactivationPtInactivationIndicatorMember.getId());
-		assertEquals(null, afterInactivationPtInactivationIndicatorMember.getEffectiveTime());
-		assertEquals(false, afterInactivationPtInactivationIndicatorMember.isReleased());
-		assertEquals(Concepts.CONCEPT_NON_CURRENT, afterInactivationPtInactivationIndicatorMember.getProperties().get(SnomedRf2Headers.FIELD_VALUE_ID));
-		
+		assertNull(ptInactivationIndicatorMember);
+		assertNull(afterInactivationPtInactivationIndicatorMember);
 	}
 
 	private SnomedReferenceSetMember getIndicatorMember(SnomedCoreComponent component, String inactivationIndicatorRefSetId) {

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptInactivationApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptInactivationApiTest.java
@@ -308,6 +308,10 @@ public class SnomedConceptInactivationApiTest extends AbstractSnomedApiTest {
 			.body("inactivationProperties.associationTargets", equalTo(List.of()));
 	}
 	
+	/**
+	 * Keeping this test case here, even if SI inactivated all CNC indicators in the INT Edition as of 2026 Jan
+	 * The indicator itself can still be used and if added for any reason it should be removed upon reactivation
+	 */
 	@Test
 	public void reactivateConceptShouldRemoveConceptNonCurrentIndicatorsFromDescriptions() throws Exception {
 		final String inactiveConceptId = createNewConcept(branchPath, createConceptRequestBody(ROOT_CONCEPT, Concepts.MODULE_SCT_CORE, SnomedApiTestConstants.UK_PREFERRED_MAP, false)

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptInactivationApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptInactivationApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2020-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ import com.b2international.snowowl.snomed.core.rest.AbstractSnomedApiTest;
 import com.b2international.snowowl.snomed.core.rest.SnomedApiTestConstants;
 import com.b2international.snowowl.snomed.core.rest.SnomedComponentRestRequests;
 import com.b2international.snowowl.snomed.core.rest.SnomedComponentType;
-import com.google.common.collect.Maps;
 
 /**
  * @since 7.7
@@ -61,7 +60,8 @@ public class SnomedConceptInactivationApiTest extends AbstractSnomedApiTest {
 			.body("statedParentIds", equalTo(List.of(IComponent.ROOT_ID)))
 			.body("statedAncestorIds", equalTo(List.of()))
 			.body("descriptions.items.active", everyItem(equalTo(true)))
-			.body("descriptions.items.inactivationProperties.inactivationIndicator.id", everyItem(equalTo(Concepts.CONCEPT_NON_CURRENT)));
+			// as of 2026 Jan, CNC indicators should not be generated anymore, so expecting this path to be a null value in all cases
+			.body("descriptions.items.inactivationProperties.inactivationIndicator.id", nullValue());
 	}
 	
 	@Test
@@ -308,35 +308,35 @@ public class SnomedConceptInactivationApiTest extends AbstractSnomedApiTest {
 			.body("inactivationProperties.associationTargets", equalTo(List.of()));
 	}
 	
-	@Test
-	public void reactivateConceptShouldRemoveConceptNonCurrentIndicatorsFromDescriptions() throws Exception {
-		final String inactiveConceptId = createNewConcept(branchPath, createConceptRequestBody(ROOT_CONCEPT, Concepts.MODULE_SCT_CORE, SnomedApiTestConstants.UK_PREFERRED_MAP, false)
-				.with("commitComment", "Created inactive concept"));
-		
-		// create non-current indicators for the pre-inactivated concept's descriptions 
-		getConcept(inactiveConceptId, "descriptions()").getDescriptions().forEach(description -> {
-			Map<?, ?> requestBody = createRefSetMemberRequestBody(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR, description.getId())
-					.with(SnomedRf2Headers.FIELD_VALUE_ID, Concepts.CONCEPT_NON_CURRENT)
-					.with("commitComment", "Created new indicator member for description: " + description.getId());
-
-			createComponent(branchPath, SnomedComponentType.MEMBER, requestBody).statusCode(201);
-		});
-		
-		reactivateConcept(branchPath, inactiveConceptId);
-		
-		assertGetConcept(inactiveConceptId, "inactivationProperties(),descriptions(expand(inactivationProperties()))")
-			.statusCode(200)
-			.body("active", equalTo(true))
-			.body("parentIds", equalTo(List.of(IComponent.ROOT_ID)))
-			.body("statedParentIds", equalTo(List.of(Concepts.ROOT_CONCEPT)))
-			.body("ancestorIds", equalTo(List.of()))
-			.body("statedAncestorIds", equalTo(List.of(IComponent.ROOT_ID)))
-			.body("inactivationProperties.inactivationIndicator", nullValue())
-			.body("inactivationProperties.associationTargets", equalTo(List.of()))
-			.body("descriptions.items.active", everyItem(equalTo(true)))
-			.body("descriptions.items.inactivationProperties.inactivationIndicator[0].id", nullValue())
-			.body("descriptions.items.inactivationProperties.inactivationIndicator[1].id", nullValue());
-	}
+//	@Test
+//	public void reactivateConceptShouldRemoveConceptNonCurrentIndicatorsFromDescriptions() throws Exception {
+//		final String inactiveConceptId = createNewConcept(branchPath, createConceptRequestBody(ROOT_CONCEPT, Concepts.MODULE_SCT_CORE, SnomedApiTestConstants.UK_PREFERRED_MAP, false)
+//				.with("commitComment", "Created inactive concept"));
+//		
+//		// create non-current indicators for the pre-inactivated concept's descriptions
+//		getConcept(inactiveConceptId, "descriptions()").getDescriptions().forEach(description -> {
+//			Map<?, ?> requestBody = createRefSetMemberRequestBody(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR, description.getId())
+//					.with(SnomedRf2Headers.FIELD_VALUE_ID, Concepts.CONCEPT_NON_CURRENT)
+//					.with("commitComment", "Created new indicator member for description: " + description.getId());
+//
+//			createComponent(branchPath, SnomedComponentType.MEMBER, requestBody).statusCode(201);
+//		});
+//		
+//		reactivateConcept(branchPath, inactiveConceptId);
+//		
+//		assertGetConcept(inactiveConceptId, "inactivationProperties(),descriptions(expand(inactivationProperties()))")
+//			.statusCode(200)
+//			.body("active", equalTo(true))
+//			.body("parentIds", equalTo(List.of(IComponent.ROOT_ID)))
+//			.body("statedParentIds", equalTo(List.of(Concepts.ROOT_CONCEPT)))
+//			.body("ancestorIds", equalTo(List.of()))
+//			.body("statedAncestorIds", equalTo(List.of(IComponent.ROOT_ID)))
+//			.body("inactivationProperties.inactivationIndicator", nullValue())
+//			.body("inactivationProperties.associationTargets", equalTo(List.of()))
+//			.body("descriptions.items.active", everyItem(equalTo(true)))
+//			.body("descriptions.items.inactivationProperties.inactivationIndicator[0].id", nullValue())
+//			.body("descriptions.items.inactivationProperties.inactivationIndicator[1].id", nullValue());
+//	}
 	
 	@Test
 	public void inactivateConceptDefinitionStatusRemainsPrimitive() {

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptInactivationApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptInactivationApiTest.java
@@ -308,35 +308,35 @@ public class SnomedConceptInactivationApiTest extends AbstractSnomedApiTest {
 			.body("inactivationProperties.associationTargets", equalTo(List.of()));
 	}
 	
-//	@Test
-//	public void reactivateConceptShouldRemoveConceptNonCurrentIndicatorsFromDescriptions() throws Exception {
-//		final String inactiveConceptId = createNewConcept(branchPath, createConceptRequestBody(ROOT_CONCEPT, Concepts.MODULE_SCT_CORE, SnomedApiTestConstants.UK_PREFERRED_MAP, false)
-//				.with("commitComment", "Created inactive concept"));
-//		
-//		// create non-current indicators for the pre-inactivated concept's descriptions
-//		getConcept(inactiveConceptId, "descriptions()").getDescriptions().forEach(description -> {
-//			Map<?, ?> requestBody = createRefSetMemberRequestBody(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR, description.getId())
-//					.with(SnomedRf2Headers.FIELD_VALUE_ID, Concepts.CONCEPT_NON_CURRENT)
-//					.with("commitComment", "Created new indicator member for description: " + description.getId());
-//
-//			createComponent(branchPath, SnomedComponentType.MEMBER, requestBody).statusCode(201);
-//		});
-//		
-//		reactivateConcept(branchPath, inactiveConceptId);
-//		
-//		assertGetConcept(inactiveConceptId, "inactivationProperties(),descriptions(expand(inactivationProperties()))")
-//			.statusCode(200)
-//			.body("active", equalTo(true))
-//			.body("parentIds", equalTo(List.of(IComponent.ROOT_ID)))
-//			.body("statedParentIds", equalTo(List.of(Concepts.ROOT_CONCEPT)))
-//			.body("ancestorIds", equalTo(List.of()))
-//			.body("statedAncestorIds", equalTo(List.of(IComponent.ROOT_ID)))
-//			.body("inactivationProperties.inactivationIndicator", nullValue())
-//			.body("inactivationProperties.associationTargets", equalTo(List.of()))
-//			.body("descriptions.items.active", everyItem(equalTo(true)))
-//			.body("descriptions.items.inactivationProperties.inactivationIndicator[0].id", nullValue())
-//			.body("descriptions.items.inactivationProperties.inactivationIndicator[1].id", nullValue());
-//	}
+	@Test
+	public void reactivateConceptShouldRemoveConceptNonCurrentIndicatorsFromDescriptions() throws Exception {
+		final String inactiveConceptId = createNewConcept(branchPath, createConceptRequestBody(ROOT_CONCEPT, Concepts.MODULE_SCT_CORE, SnomedApiTestConstants.UK_PREFERRED_MAP, false)
+				.with("commitComment", "Created inactive concept"));
+		
+		// create non-current indicators for the pre-inactivated concept's descriptions
+		getConcept(inactiveConceptId, "descriptions()").getDescriptions().forEach(description -> {
+			Map<?, ?> requestBody = createRefSetMemberRequestBody(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR, description.getId())
+					.with(SnomedRf2Headers.FIELD_VALUE_ID, Concepts.CONCEPT_NON_CURRENT)
+					.with("commitComment", "Created new indicator member for description: " + description.getId());
+
+			createComponent(branchPath, SnomedComponentType.MEMBER, requestBody).statusCode(201);
+		});
+		
+		reactivateConcept(branchPath, inactiveConceptId);
+		
+		assertGetConcept(inactiveConceptId, "inactivationProperties(),descriptions(expand(inactivationProperties()))")
+			.statusCode(200)
+			.body("active", equalTo(true))
+			.body("parentIds", equalTo(List.of(IComponent.ROOT_ID)))
+			.body("statedParentIds", equalTo(List.of(Concepts.ROOT_CONCEPT)))
+			.body("ancestorIds", equalTo(List.of()))
+			.body("statedAncestorIds", equalTo(List.of(IComponent.ROOT_ID)))
+			.body("inactivationProperties.inactivationIndicator", nullValue())
+			.body("inactivationProperties.associationTargets", equalTo(List.of()))
+			.body("descriptions.items.active", everyItem(equalTo(true)))
+			.body("descriptions.items.inactivationProperties.inactivationIndicator[0].id", nullValue())
+			.body("descriptions.items.inactivationProperties.inactivationIndicator[1].id", nullValue());
+	}
 	
 	@Test
 	public void inactivateConceptDefinitionStatusRemainsPrimitive() {

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptInactivationApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/components/SnomedConceptInactivationApiTest.java
@@ -61,7 +61,7 @@ public class SnomedConceptInactivationApiTest extends AbstractSnomedApiTest {
 			.body("statedAncestorIds", equalTo(List.of()))
 			.body("descriptions.items.active", everyItem(equalTo(true)))
 			// as of 2026 Jan, CNC indicators should not be generated anymore, so expecting this path to be a null value in all cases
-			.body("descriptions.items.inactivationProperties.inactivationIndicator.id", nullValue());
+			.body("descriptions.items.inactivationProperties.inactivationIndicator.id", equalTo(List.of()));
 	}
 	
 	@Test

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedRefSetUtil.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedRefSetUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2011-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ import com.google.common.collect.*;
 public abstract class SnomedRefSetUtil {
 
 	public static final Set<String> ATTRIBUTE_VALUES_FOR_ACTIVE_CONCEPTS = ImmutableSet.of(Concepts.PENDING_MOVE);
-	public static final Set<String> ATTRIBUTE_VALUES_FOR_ACTIVE_DESCRIPTIONS = ImmutableSet.of(Concepts.CONCEPT_NON_CURRENT, Concepts.PENDING_MOVE);
+	public static final Set<String> ATTRIBUTE_VALUES_FOR_ACTIVE_DESCRIPTIONS = ImmutableSet.of(Concepts.PENDING_MOVE);
 	
 	/**
 	 * @return

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/ComponentInactivationChangeProcessor.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/ComponentInactivationChangeProcessor.java
@@ -39,7 +39,6 @@ import com.b2international.snowowl.snomed.common.SnomedRf2Headers;
 import com.b2international.snowowl.snomed.datastore.index.entry.*;
 import com.b2international.snowowl.snomed.datastore.request.ModuleRequest.ModuleIdProvider;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
 /**
@@ -182,10 +181,76 @@ final class ComponentInactivationChangeProcessor extends ChangeSetProcessorBase 
 	}
 
 	private void processReactivations(StagingArea staging, RevisionSearcher searcher, Set<String> reactivatedConceptIds, Set<String> reactivatedComponentIds) throws IOException {
-		// active descriptions, with active membership in the indicator refset with a CNC indicator value on reactivated concepts
-		// XXX as of 2026 Jan, CNC indicators are no longer maintained and they should remain inactive in all cases (or non-existent if they got removed)
-		
-		// NOTE: if new reactivation logic needs to be added
+		ServiceProvider context = (ServiceProvider) staging.getContext();
+		ModuleIdProvider moduleIdProvider = context.service(ModuleIdProvider.class);
+
+		try {
+			Query.select(String.class)
+				.from(SnomedDescriptionIndexEntry.class)
+				.fields(SnomedDescriptionIndexEntry.Fields.ID)
+				// active descriptions, with active membership in the indicator refset on reactivated concepts
+				.where(Expressions.bool()
+					.filter(SnomedDescriptionIndexEntry.Expressions.active())
+					.filter(SnomedDescriptionIndexEntry.Expressions.concepts(reactivatedConceptIds))
+					.filter(SnomedDescriptionIndexEntry.Expressions.activeMemberOf(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR))
+					.build())
+				.limit(context.getPageSize())
+				.build()
+				.stream(searcher)
+				.forEachOrdered(hits -> {
+					try {
+						reactivateDescriptions(staging, searcher, moduleIdProvider, hits);
+					} catch (IOException e) {
+						throw new UndeclaredThrowableException(e);
+					}
+				});
+		} catch (UndeclaredThrowableException ute) {
+			// Unwrap and throw checked exception from lambda above
+			throw (IOException) ute.getCause();
+		}
 	}
+	
+	private void reactivateDescriptions(
+			final StagingArea staging, 
+			final RevisionSearcher searcher, 
+			final ModuleIdProvider moduleIdProvider,
+			final Hits<String> hits) throws IOException {
+			
+			final Set<String> descriptionIds = Set.copyOf(hits.getHits());
+			
+			final Set<String> stagedDescriptionIndicators = staging.getChangedObjects(SnomedRefSetMemberIndexEntry.class)
+				.filter(member -> Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR.equals(member.getRefsetId()))
+				.filter(member -> descriptionIds.contains(member.getReferencedComponentId()))
+				.map(SnomedRefSetMemberIndexEntry::getId)
+				.collect(Collectors.toSet());
+			
+			// XXX although as of 2026 Jan, CNC indicators got deprecated and inactivated in the SI release, this does not mean that the platform will not handle them during concept reactivations as it did before
+			// to ensure smooth transition and handling of these indicators this logic must be kept enabled, while the system won't generate new CNC indicators, it will automatically get rid of them when needed, if for any reason the indicator would be there
+			// NOTE: this does not mean that the system will immediately remove indicators when it sees them, this only happens during concept reactivation
+			
+			// search for all active indicator refset members with concept non-current
+			Hits<SnomedRefSetMemberIndexEntry> members = searcher.search(Query.select(SnomedRefSetMemberIndexEntry.class)
+				.where(Expressions.bool()
+					.mustNot(SnomedRefSetMemberIndexEntry.Expressions.ids(stagedDescriptionIndicators))
+					.filter(SnomedRefSetMemberIndexEntry.Expressions.active())
+					.filter(SnomedRefSetMemberIndexEntry.Expressions.refsetId(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR))
+					.filter(SnomedRefSetMemberIndexEntry.Expressions.valueIds(Set.of(Concepts.CONCEPT_NON_CURRENT)))
+					.filter(SnomedRefSetMemberIndexEntry.Expressions.referencedComponentIds(descriptionIds))
+					.build())
+				.limit(Integer.MAX_VALUE) // we limit the number of possible members with the above query, even with duplicates we should not get more than 20k
+				.build());
+			
+			for (SnomedRefSetMemberIndexEntry indicatorMember : members) {
+				// check if this member is present in the transaction, if yes, do not auto-update/delete it
+				if (indicatorMember.isReleased() != null && indicatorMember.isReleased()) {
+					stageChange(indicatorMember, SnomedRefSetMemberIndexEntry.builder(indicatorMember).active(false)
+						.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME)
+						.moduleId(moduleIdProvider.apply(indicatorMember))
+						.build());
+				} else {
+					stageRemove(indicatorMember);
+				}
+			}
+		}
 
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/ComponentInactivationChangeProcessor.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/ComponentInactivationChangeProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2018-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,8 @@ import static com.google.common.collect.Sets.newHashSet;
 
 import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.b2international.index.Hits;
@@ -38,8 +36,6 @@ import com.b2international.snowowl.core.date.EffectiveTimes;
 import com.b2international.snowowl.core.repository.ChangeSetProcessorBase;
 import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts;
 import com.b2international.snowowl.snomed.common.SnomedRf2Headers;
-import com.b2international.snowowl.snomed.core.domain.refset.SnomedRefSetType;
-import com.b2international.snowowl.snomed.datastore.SnomedRefSetUtil;
 import com.b2international.snowowl.snomed.datastore.index.entry.*;
 import com.b2international.snowowl.snomed.datastore.request.ModuleRequest.ModuleIdProvider;
 import com.google.common.collect.HashMultimap;
@@ -103,33 +99,12 @@ final class ComponentInactivationChangeProcessor extends ChangeSetProcessorBase 
 				changedMembersByReferencedComponentId.put(((SnomedRefSetMemberIndexEntry) diff.newRevision).getReferencedComponentId(), diff);
 			});
 			
-			// Inactivate active descriptions on inactive concepts
-			try {
-				Query.select(SnomedDescriptionIndexEntry.class)
-					.from(SnomedDescriptionIndexEntry.class)
-					.fields(SnomedDescriptionIndexEntry.Fields.ID, SnomedDescriptionIndexEntry.Fields.MODULE_ID)
-					.where(Expressions.bool()
-						.filter(SnomedDescriptionIndexEntry.Expressions.active())
-						.filter(SnomedDescriptionIndexEntry.Expressions.concepts(inactivatedConceptIds))
-						.build())
-					.limit(pageSize)
-					.build()
-					.stream(searcher)
-					.forEachOrdered(hits -> {
-						try {
-							inactivateDescriptions(searcher, moduleIdProvider, changedMembersByReferencedComponentId, hits);
-						} catch (IOException e) {
-							throw new UndeclaredThrowableException(e);
-						}
-					});
-			} catch (UndeclaredThrowableException ute) {
-				// Unwrap and throw checked exception from lambda above
-				throw (IOException) ute.getCause();
-			}
+			// Step: Inactivate active descriptions on inactive concepts
+			// XXX as of 2026 Jan, concept inactivation does not involve any change on contained descriptions, no CNC indicators need to be generated
 			
 			final Map<ObjectId, RevisionDiff> changedRevisions = staging.getChangedRevisions();
 			
-			// Inactivate active relationships on inactive concepts
+			// Step: Inactivate active relationships on inactive concepts
 			Query.select(SnomedRelationshipIndexEntry.class)
 				.where(Expressions.bool()
 					.filter(SnomedRelationshipIndexEntry.Expressions.active())
@@ -161,77 +136,6 @@ final class ComponentInactivationChangeProcessor extends ChangeSetProcessorBase 
 			.stream(searcher)
 			.flatMap(Hits::stream)
 			.forEachOrdered(member -> inactivateReferenceSetMember(moduleIdProvider, changedRevisions, member));
-		}
-
-	private void inactivateDescriptions(
-		RevisionSearcher searcher, 
-		ModuleIdProvider moduleIdProvider,
-		Multimap<String, RevisionDiff> changedMembersByReferencedComponentId,
-		Hits<SnomedDescriptionIndexEntry> hits) throws IOException {
-		
-		final Set<String> descriptionIds = hits.stream().map(description -> description.getId()).collect(Collectors.toSet());
-		
-		// load existing indicator reference set members from index
-		final Multimap<String, SnomedRefSetMemberIndexEntry> existingIndicatorReferenceSetMembers = HashMultimap.create();
-		searcher.search(Query.select(SnomedRefSetMemberIndexEntry.class)
-				.where(Expressions.bool()
-						.filter(SnomedRefSetMemberIndexEntry.Expressions.refsetId(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR))
-						.filter(SnomedRefSetMemberIndexEntry.Expressions.referencedComponentIds(descriptionIds))
-						.build())
-				.limit(Integer.MAX_VALUE)
-				.build())
-				.forEach(existingIndicatorMember -> {
-					existingIndicatorReferenceSetMembers.put(existingIndicatorMember.getReferencedComponentId(), existingIndicatorMember);
-				});
-		
-		// override members with the ones that present in the staging area
-		for (SnomedDescriptionIndexEntry descriptionToCheck : hits) {
-			final String descriptionId = descriptionToCheck.getId();
-			// get the persisted, existing members
-			// get the current members from the tx
-			final Collection<SnomedRefSetMemberIndexEntry> transactionMembers = changedMembersByReferencedComponentId.get(descriptionId).stream()
-					.map(diff -> diff.newRevision)
-					.map(SnomedRefSetMemberIndexEntry.class::cast)
-					.filter(member -> Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR.equals(member.getRefsetId()))
-					.collect(Collectors.toList());
-			// if there were no registered member changes to this description
-			if (transactionMembers.isEmpty()) {
-				// apply CONCEPT_NON_CURRENT to all existing members or generate a new one 
-				final SnomedRefSetMemberIndexEntry existingMember = existingIndicatorReferenceSetMembers.get(descriptionId)
-						.stream()
-						.filter(member -> {
-							// reusable member, if it was inactivated earlier
-							// was active and used one of the active description attribute values
-							return !member.isActive() 
-									|| SnomedRefSetUtil.ATTRIBUTE_VALUES_FOR_ACTIVE_DESCRIPTIONS.contains(member.getValueId());
-						})
-						.findFirst()
-						.orElse(null);
-				if (existingMember == null) {
-					SnomedRefSetMemberIndexEntry inactivationMember = SnomedRefSetMemberIndexEntry.builder()
-						.id(UUID.randomUUID().toString())
-						.active(true)
-						.released(false)
-						.refsetId(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR)
-						.referenceSetType(SnomedRefSetType.ATTRIBUTE_VALUE)
-						.referencedComponentId(descriptionId)
-						.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME)
-						.moduleId(moduleIdProvider.apply(descriptionToCheck))
-						.field(SnomedRf2Headers.FIELD_VALUE_ID, Concepts.CONCEPT_NON_CURRENT)
-						.build();
-					stageNew(inactivationMember);
-				} else {
-					// update the existing member only, if it was active, registered as PENDING_MOVE
-					final SnomedRefSetMemberIndexEntry updated = SnomedRefSetMemberIndexEntry.builder(existingMember)
-							.active(true) // ensure active
-							.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME) // ensure unpublished
-							.field(SnomedRf2Headers.FIELD_VALUE_ID, Concepts.CONCEPT_NON_CURRENT) // ensure non-current
-							.moduleId(moduleIdProvider.apply(descriptionToCheck))
-							.build();
-					stageChange(existingMember, updated);
-				}
-			}
-		}
 	}
 	
 	private void inactivateRelationship(
@@ -278,71 +182,10 @@ final class ComponentInactivationChangeProcessor extends ChangeSetProcessorBase 
 	}
 
 	private void processReactivations(StagingArea staging, RevisionSearcher searcher, Set<String> reactivatedConceptIds, Set<String> reactivatedComponentIds) throws IOException {
-		ServiceProvider context = (ServiceProvider) staging.getContext();
-		ModuleIdProvider moduleIdProvider = context.service(ModuleIdProvider.class);
+		// active descriptions, with active membership in the indicator refset with a CNC indicator value on reactivated concepts
+		// XXX as of 2026 Jan, CNC indicators are no longer maintained and they should remain inactive in all cases (or non-existent if they got removed)
 		
-		try {
-			Query.select(String.class)
-				.from(SnomedDescriptionIndexEntry.class)
-				.fields(SnomedDescriptionIndexEntry.Fields.ID)
-				// active descriptions, with active membership in the indicator refset on reactivated concepts
-				.where(Expressions.bool()
-					.filter(SnomedDescriptionIndexEntry.Expressions.active())
-					.filter(SnomedDescriptionIndexEntry.Expressions.concepts(reactivatedConceptIds))
-					.filter(SnomedDescriptionIndexEntry.Expressions.activeMemberOf(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR))
-					.build())
-				.limit(context.getPageSize())
-				.build()
-				.stream(searcher)
-				.forEachOrdered(hits -> {
-					try {
-						reactivateDescriptions(staging, searcher, moduleIdProvider, hits);
-					} catch (IOException e) {
-						throw new UndeclaredThrowableException(e);
-					}
-				});
-		} catch (UndeclaredThrowableException ute) {
-			// Unwrap and throw checked exception from lambda above
-			throw (IOException) ute.getCause();
-		}
+		// NOTE: if new reactivation logic needs to be added
 	}
 
-	private void reactivateDescriptions(
-		final StagingArea staging, 
-		final RevisionSearcher searcher, 
-		final ModuleIdProvider moduleIdProvider,
-		final Hits<String> hits) throws IOException {
-		
-		final Set<String> descriptionIds = ImmutableSet.copyOf(hits.getHits());
-		
-		final Set<String> stagedDescriptionIndicators = staging.getChangedObjects(SnomedRefSetMemberIndexEntry.class)
-			.filter(member -> Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR.equals(member.getRefsetId()))
-			.filter(member -> descriptionIds.contains(member.getReferencedComponentId()))
-			.map(SnomedRefSetMemberIndexEntry::getId)
-			.collect(Collectors.toSet());
-		
-		// search for all active indicator refset members with concept non-current
-		Hits<SnomedRefSetMemberIndexEntry> members = searcher.search(Query.select(SnomedRefSetMemberIndexEntry.class)
-			.where(Expressions.bool()
-				.mustNot(SnomedRefSetMemberIndexEntry.Expressions.ids(stagedDescriptionIndicators))
-				.filter(SnomedRefSetMemberIndexEntry.Expressions.active())
-				.filter(SnomedRefSetMemberIndexEntry.Expressions.refsetId(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR))
-				.filter(SnomedRefSetMemberIndexEntry.Expressions.valueIds(ImmutableSet.of(Concepts.CONCEPT_NON_CURRENT)))
-				.filter(SnomedRefSetMemberIndexEntry.Expressions.referencedComponentIds(descriptionIds))
-				.build())
-			.limit(Integer.MAX_VALUE) // we limit the number of possible members with the above query, even with duplicates we should not get more than 20k
-			.build());
-		
-		for (SnomedRefSetMemberIndexEntry indicatorMember : members) {
-			// check if this member is present in the transaction, if yes, do not auto-update/delete it
-			if (indicatorMember.isReleased() != null && indicatorMember.isReleased()) {
-				stageChange(indicatorMember, SnomedRefSetMemberIndexEntry.builder(indicatorMember).active(false)
-					.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME)
-					.moduleId(moduleIdProvider.apply(indicatorMember))
-					.build());
-			} else {
-				stageRemove(indicatorMember);
-			}
-		}
-	}
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/ComponentInactivationChangeProcessor.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/index/change/ComponentInactivationChangeProcessor.java
@@ -231,6 +231,7 @@ final class ComponentInactivationChangeProcessor extends ChangeSetProcessorBase 
 			// search for all active indicator refset members with concept non-current
 			Hits<SnomedRefSetMemberIndexEntry> members = searcher.search(Query.select(SnomedRefSetMemberIndexEntry.class)
 				.where(Expressions.bool()
+					// exclude already modified/updated indicators
 					.mustNot(SnomedRefSetMemberIndexEntry.Expressions.ids(stagedDescriptionIndicators))
 					.filter(SnomedRefSetMemberIndexEntry.Expressions.active())
 					.filter(SnomedRefSetMemberIndexEntry.Expressions.refsetId(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR))
@@ -241,12 +242,12 @@ final class ComponentInactivationChangeProcessor extends ChangeSetProcessorBase 
 				.build());
 			
 			for (SnomedRefSetMemberIndexEntry indicatorMember : members) {
-				// check if this member is present in the transaction, if yes, do not auto-update/delete it
 				if (indicatorMember.isReleased() != null && indicatorMember.isReleased()) {
-					stageChange(indicatorMember, SnomedRefSetMemberIndexEntry.builder(indicatorMember).active(false)
-						.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME)
-						.moduleId(moduleIdProvider.apply(indicatorMember))
-						.build());
+					stageChange(indicatorMember, SnomedRefSetMemberIndexEntry.builder(indicatorMember)
+							.active(false)
+							.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME)
+							.moduleId(moduleIdProvider.apply(indicatorMember))
+							.build());
 				} else {
 					stageRemove(indicatorMember);
 				}

--- a/snomed/com.b2international.snowowl.validation.snomed/src/main/resources/scripts/rule532a.groovy
+++ b/snomed/com.b2international.snowowl.validation.snomed/src/main/resources/scripts/rule532a.groovy
@@ -8,27 +8,44 @@ import com.b2international.index.query.Expressions.ExpressionBuilder
 import com.b2international.index.revision.RevisionSearcher
 import com.b2international.snowowl.core.ComponentIdentifier
 import com.b2international.snowowl.core.date.EffectiveTimes
+import com.b2international.snowowl.core.domain.BranchContext
 import com.b2international.snowowl.snomed.common.SnomedRf2Headers
 import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts
 import com.b2international.snowowl.snomed.core.domain.SnomedConcept
+import com.b2international.snowowl.snomed.core.domain.SnomedConcepts
 import com.b2international.snowowl.snomed.core.domain.SnomedDescription
 import com.b2international.snowowl.snomed.core.domain.refset.SnomedReferenceSetMember
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument
 import com.b2international.snowowl.snomed.datastore.index.entry.SnomedDescriptionIndexEntry
 import com.b2international.snowowl.snomed.datastore.request.SnomedRequests
 import com.google.common.collect.Lists
 
 //FSN terms should not duplicate other FSN terms, regardless of case
 
+BranchContext ctx = ctx
 RevisionSearcher searcher = ctx.service(RevisionSearcher.class)
 
 List<ComponentIdentifier> issues = Lists.newArrayList()
 
 Set<String> extensionModules = SnomedRequests.prepareSearchConcept()
 	.filterByEcl(params.modules)
-	.all()
-	.build()
-	.execute(ctx)
-	.collect({ SnomedConcept c -> c.getId() })
+	.setFields(SnomedConceptDocument.Fields.ID)
+	.setLimit(ctx.getPageSize())
+	.stream(ctx)
+	.flatMap({ SnomedConcepts c -> c.stream() })
+	.map({ SnomedConcept c -> c.getId() })
+	.toSet()
+	
+Set<String> inactiveConceptIds = SnomedRequests.prepareSearchConcept()
+	.filterByActive(false)
+	.setFields(SnomedConceptDocument.Fields.ID)
+	.setLimit(ctx.getPageSize())
+	.stream(ctx)
+	.flatMap({ SnomedConcepts c -> c.stream() })
+	.map({ SnomedConcept c -> c.getId() })
+	.toSet()
+	
+println inactiveConceptIds
 	
 def pendingMoveDescriptions = SnomedRequests.prepareSearchMember()
 	.filterByRefSet(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR)
@@ -44,13 +61,15 @@ def pendingMoveDescriptions = SnomedRequests.prepareSearchMember()
 ExpressionBuilder filterExpressionBuilder = Expressions.bool()
 		.filter(SnomedDescriptionIndexEntry.Expressions.active())
 		.filter(SnomedDescriptionIndexEntry.Expressions.type(Concepts.FULLY_SPECIFIED_NAME))
-		.should(SnomedDescriptionIndexEntry.Expressions.ids(pendingMoveDescriptions)) // either pending move or no description inactivity indicator
+		// allow pending move indicators in any cases, regardless of whether the concept is active or not
+		.should(SnomedDescriptionIndexEntry.Expressions.ids(pendingMoveDescriptions))
+		// disallow any other description to be reported from inactive concepts
 		.should(Expressions.bool()
-			.mustNot(SnomedDescriptionIndexEntry.Expressions.activeMemberOf(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR))
+			.mustNot(SnomedDescriptionIndexEntry.Expressions.concepts(inactiveConceptIds))
 			.build())
 
 Aggregation<String[]> activeDescriptionsByExactTerm = searcher.aggregate(
-		AggregationBuilder.bucket("rule532a", String[].class, SnomedDescriptionIndexEntry.class)
+		AggregationBuilder.bucket("rule532a_" + ctx.path(), String[].class, SnomedDescriptionIndexEntry.class)
 			.query(filterExpressionBuilder.build())
 			.onFieldValue(SnomedDescriptionIndexEntry.Fields.TERM_EXACT)
 			.fields(SnomedDescriptionIndexEntry.Fields.ID,

--- a/snomed/com.b2international.snowowl.validation.snomed/src/main/resources/scripts/rule532a.groovy
+++ b/snomed/com.b2international.snowowl.validation.snomed/src/main/resources/scripts/rule532a.groovy
@@ -45,8 +45,6 @@ Set<String> inactiveConceptIds = SnomedRequests.prepareSearchConcept()
 	.map({ SnomedConcept c -> c.getId() })
 	.toSet()
 	
-println inactiveConceptIds
-	
 def pendingMoveDescriptions = SnomedRequests.prepareSearchMember()
 	.filterByRefSet(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR)
 	.filterByProps(OptionsBuilder.newBuilder()

--- a/snomed/com.b2international.snowowl.validation.snomed/src/main/resources/scripts/rule532b.groovy
+++ b/snomed/com.b2international.snowowl.validation.snomed/src/main/resources/scripts/rule532b.groovy
@@ -10,28 +10,43 @@ import com.b2international.index.query.Expressions.ExpressionBuilder
 import com.b2international.index.revision.RevisionSearcher
 import com.b2international.snowowl.core.ComponentIdentifier
 import com.b2international.snowowl.core.date.EffectiveTimes
+import com.b2international.snowowl.core.domain.BranchContext
 import com.b2international.snowowl.snomed.common.SnomedRf2Headers
 import com.b2international.snowowl.snomed.common.SnomedConstants.Concepts
 import com.b2international.snowowl.snomed.core.domain.SnomedConcept
+import com.b2international.snowowl.snomed.core.domain.SnomedConcepts
 import com.b2international.snowowl.snomed.core.domain.SnomedDescription
 import com.b2international.snowowl.snomed.core.domain.refset.SnomedReferenceSetMember
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument
 import com.b2international.snowowl.snomed.datastore.index.entry.SnomedDescriptionIndexEntry
 import com.b2international.snowowl.snomed.datastore.request.SnomedRequests
 import com.google.common.collect.Lists
 
 //Synonyms should not duplicate other synonyms, regardless of case
 
+BranchContext ctx = ctx
 RevisionSearcher searcher = ctx.service(RevisionSearcher.class)
 
 List<ComponentIdentifier> issues = Lists.newArrayList()
 
 Set<String> extensionModules = SnomedRequests.prepareSearchConcept()
 	.filterByEcl(params.modules)
-	.all()
-	.build()
-	.execute(ctx)
-	.collect({ SnomedConcept c -> c.getId() })
+	.setFields(SnomedConceptDocument.Fields.ID)
+	.setLimit(ctx.getPageSize())
+	.stream(ctx)
+	.flatMap({ SnomedConcepts c -> c.stream() })
+	.map({ SnomedConcept c -> c.getId() })
+	.toSet()
 
+Set<String> inactiveConceptIds = SnomedRequests.prepareSearchConcept()
+	.filterByActive(false)
+	.setFields(SnomedConceptDocument.Fields.ID)
+	.setLimit(ctx.getPageSize())
+	.stream(ctx)
+	.flatMap({ SnomedConcepts c -> c.stream() })
+	.map({ SnomedConcept c -> c.getId() })
+	.toSet()
+	
 Set<String> synonymAndSubtypesIds = SnomedRequests.prepareGetSynonyms()
 	.build()
 	.execute(ctx)
@@ -54,13 +69,15 @@ def pendingMoveDescriptions = SnomedRequests.prepareSearchMember()
 ExpressionBuilder filterExpressionBuilder = Expressions.bool()
 		.filter(SnomedDescriptionIndexEntry.Expressions.active())
 		.filter(SnomedDescriptionIndexEntry.Expressions.types(synonymAndSubtypesIds))
-		.should(SnomedDescriptionIndexEntry.Expressions.ids(pendingMoveDescriptions)) // either pending move or no description inactivity indicator
+		// allow pending move indicators in any cases, regardless of whether the concept is active or not
+		.should(SnomedDescriptionIndexEntry.Expressions.ids(pendingMoveDescriptions))
+		// disallow any other description to be reported from inactive concepts
 		.should(Expressions.bool()
-			.mustNot(SnomedDescriptionIndexEntry.Expressions.activeMemberOf(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR))
+			.mustNot(SnomedDescriptionIndexEntry.Expressions.concepts(inactiveConceptIds))
 			.build())
 		
 Aggregation<String[]> activeDescriptionsByExactTerm = searcher.aggregate(
-		AggregationBuilder.bucket("rule532b", String[].class, SnomedDescriptionIndexEntry.class)
+		AggregationBuilder.bucket("rule532b_" + ctx.path(), String[].class, SnomedDescriptionIndexEntry.class)
 		.query(filterExpressionBuilder.build())
 		.onFieldValue(SnomedDescriptionIndexEntry.Fields.TERM_EXACT)
 		.fields(SnomedDescriptionIndexEntry.Fields.ID,

--- a/snomed/com.b2international.snowowl.validation.snomed/src/main/resources/scripts/rule671.groovy
+++ b/snomed/com.b2international.snowowl.validation.snomed/src/main/resources/scripts/rule671.groovy
@@ -16,7 +16,7 @@ import com.google.common.collect.Sets
 
 def Set<ComponentIdentifier> issues = []
 def RevisionSearcher searcher = ctx.service(RevisionSearcher.class)
-def activeDescriptionIndicatorIds = [Concepts.PENDING_MOVE, Concepts.LIMITED]
+def activeDescriptionIndicatorIds = [Concepts.PENDING_MOVE, Concepts.CONCEPT_NON_CURRENT, Concepts.LIMITED]
 
 if (params.isUnpublishedOnly) {
 	

--- a/snomed/com.b2international.snowowl.validation.snomed/src/main/resources/scripts/rule671.groovy
+++ b/snomed/com.b2international.snowowl.validation.snomed/src/main/resources/scripts/rule671.groovy
@@ -16,7 +16,7 @@ import com.google.common.collect.Sets
 
 def Set<ComponentIdentifier> issues = []
 def RevisionSearcher searcher = ctx.service(RevisionSearcher.class)
-def activeDescriptionIndicatorIds = [Concepts.PENDING_MOVE, Concepts.LIMITED, Concepts.CONCEPT_NON_CURRENT]
+def activeDescriptionIndicatorIds = [Concepts.PENDING_MOVE, Concepts.LIMITED]
 
 if (params.isUnpublishedOnly) {
 	

--- a/snomed/com.b2international.snowowl.validation.snomed/src/main/resources/scripts/rule671.groovy
+++ b/snomed/com.b2international.snowowl.validation.snomed/src/main/resources/scripts/rule671.groovy
@@ -16,7 +16,13 @@ import com.google.common.collect.Sets
 
 def Set<ComponentIdentifier> issues = []
 def RevisionSearcher searcher = ctx.service(RevisionSearcher.class)
-def activeDescriptionIndicatorIds = [Concepts.PENDING_MOVE, Concepts.CONCEPT_NON_CURRENT, Concepts.LIMITED]
+// XXX keeping the CNC indicator here for customers who still rely on it (SI inactivated all indicators in the 2026 Jan release but kept the functionality available for extension maintainers) 
+def activeDescriptionIndicatorIds = [Concepts.PENDING_MOVE, Concepts.LIMITED, Concepts.CONCEPT_NON_CURRENT]
+
+// the main scope of the rule is inactive concepts, anything that is on active concepts could be ignored, BUT
+// in the unpublished case we will report all issues so that users can be notified when they made a mistake during authoring
+// in the published case we will follow what the rule says and report incorrect patterns on inactive concepts only to reduce the scope and increase performance
+// running the entire rule on all descriptions require a lot of computation and it is very likely that it will report issues that customers don't care much about
 
 if (params.isUnpublishedOnly) {
 	
@@ -77,10 +83,10 @@ if (params.isUnpublishedOnly) {
 } else {
 	// report descriptions with incorrect unpublished or published inactivation indicator members
 	def checkDescriptions = { boolean active , List<String> inactiveConceptIds ->
-		final List<String> descriptionIds = []
-		
+
+		// depending on the incoming active parameter, we will collect all inactive or active descriptions from inactive concepts
+		final List<String> activeOrInactiveDescriptionIdsInScope = []
 		//	println "Searching ${active ? 'active' : 'inactive'} descriptions on inactive concepts..."
-			
 		searcher.stream(Query.select(String.class)
 				.from(SnomedDescriptionIndexEntry.class)
 				.fields(SnomedDescriptionIndexEntry.Fields.ID)
@@ -93,20 +99,15 @@ if (params.isUnpublishedOnly) {
 				.limit(100_000)
 				.build())
 				.forEachOrdered({Hits<String> hits ->
-					descriptionIds.addAll(hits.getHits())
+					activeOrInactiveDescriptionIdsInScope.addAll(hits.getHits())
 				})
-					
 		//	println "Found ${descriptionIds.size()} ${active ? 'active' : 'inactive'} descriptions on inactive concepts..."
 		
 		ExpressionBuilder memberQuery = Expressions.bool()
 				.filter(SnomedRefSetMemberIndexEntry.Expressions.active())
 				.filter(SnomedRefSetMemberIndexEntry.Expressions.refsetId(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR))
-				.filter(SnomedRefSetMemberIndexEntry.Expressions.referencedComponentIds(descriptionIds))
+				.filter(SnomedRefSetMemberIndexEntry.Expressions.referencedComponentIds(activeOrInactiveDescriptionIdsInScope))
 				
-		if (params.isUnpublishedOnly) {
-			memberQuery.filter(SnomedRefSetMemberIndexEntry.Expressions.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME))
-		}
-	
 		if (active) {
 			memberQuery
 					.mustNot(SnomedRefSetMemberIndexEntry.Expressions.valueIds(activeDescriptionIndicatorIds))
@@ -134,7 +135,7 @@ if (params.isUnpublishedOnly) {
 	
 	ExpressionBuilder filterInactiveConceptsExpressionBuilder = Expressions.bool()
 			.filter(SnomedConceptDocument.Expressions.inactive())
-	
+
 	List<String> inactiveConceptIds = []
 	
 	//println "Loading inactive concepts"
@@ -148,7 +149,7 @@ if (params.isUnpublishedOnly) {
 				inactiveConceptIds.addAll(hits.getHits())
 			})
 	//println "Loaded ${inactiveConceptIds.size()} inactive concepts"
-			
+	
 	checkDescriptions(true, inactiveConceptIds)
 	checkDescriptions(false, inactiveConceptIds)
 }

--- a/snomed/com.b2international.snowowl.validation.snomed/src/main/resources/validation-rules-common.json
+++ b/snomed/com.b2international.snowowl.validation.snomed/src/main/resources/validation-rules-common.json
@@ -281,7 +281,7 @@
   {
   	"id": "671",
     "toolingId": "snomed",
-    "messageTemplate": "All active descriptions, and only active descriptions, of inactive concepts should have a single Concept non-current or Pending Move inactivation indicator.",
+    "messageTemplate": "Only active descriptions of inactive concepts can have the following inactivity indicators: Pending move, Limited, or Concept non-current.",
     "severity": "WARNING",
     "checkType": "FAST",
     "type": "script-groovy",

--- a/snomed/com.b2international.snowowl.validation.snomed/src/test/java/com/b2international/snowowl/validation/snomed/GenericValidationRuleTest.java
+++ b/snomed/com.b2international.snowowl.validation.snomed/src/test/java/com/b2international/snowowl/validation/snomed/GenericValidationRuleTest.java
@@ -1172,38 +1172,49 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 		final String ruleId = "671";
 		indexRule(ruleId);
 		
+		// prepare the first concept
 		String conceptId1 = generateConceptId();
 		SnomedDescriptionIndexEntry fsn1 = description(generateDescriptionId(), Concepts.FULLY_SPECIFIED_NAME, "Fully specified name 1 (tag)")
 				.conceptId(conceptId1)
 				.acceptability(Concepts.REFSET_LANGUAGE_TYPE_ES, Acceptability.PREFERRED)
 				.build();
+		// no need to generate an indicator here, active FSN without any indicator should be ALLOWED by the rule 
 		
 		SnomedDescriptionIndexEntry pt1 = description(generateDescriptionId(), Concepts.SYNONYM, "Preferred term 1")
 				.acceptability(Concepts.REFSET_LANGUAGE_TYPE_ES, Acceptability.PREFERRED)
 				.conceptId(conceptId1)
 				.build();
+		// mark this active PT with a active concept non-current indicator which should be ALLOWED by the rule
+		SnomedRefSetMemberIndexEntry validCNCForPt1 = member(pt1.getId(), Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR).valueId(Concepts.CONCEPT_NON_CURRENT).build();
 		
 		SnomedDescriptionIndexEntry pt2 = description(generateDescriptionId(), Concepts.SYNONYM, "Preferred term 2")
 				.acceptability(Concepts.REFSET_LANGUAGE_TYPE_ES, Acceptability.PREFERRED)
 				.conceptId(conceptId1)
 				.build();
-		
-		SnomedRefSetMemberIndexEntry ptMember1 = member(pt1.getId(), Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR).valueId(Concepts.CONCEPT_NON_CURRENT).build();
-		SnomedRefSetMemberIndexEntry ptMember2 = member(pt2.getId(), Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR).valueId(Concepts.ERRONEOUS).build();
-		
-		SnomedConceptDocument conceptWithActiveDescription = concept(conceptId1)
+		// mark this active PT with an active erroneous indicator which should NOT be allowed by the rule
+		SnomedRefSetMemberIndexEntry invalidErroneousForPt2 = member(pt2.getId(), Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR).valueId(Concepts.ERRONEOUS).build();
+
+		// register the concept as inactive along with the three active descriptions
+		// simulates normal inactivation plus manual editing scenario resulting in a mixed disallowed state
+		SnomedConceptDocument inactiveConceptWithActiveDescriptions = concept(conceptId1)
 				.preferredDescriptions(List.of(
-						new SnomedDescriptionFragment(fsn1.getId(), fsn1.getTypeId(), fsn1.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES),
-						new SnomedDescriptionFragment(pt1.getId(), pt1.getTypeId(), pt1.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES),
-						new SnomedDescriptionFragment(pt2.getId(), pt2.getTypeId(), pt2.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES)
-						))
+					new SnomedDescriptionFragment(fsn1.getId(), fsn1.getTypeId(), fsn1.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES),
+					new SnomedDescriptionFragment(pt1.getId(), pt1.getTypeId(), pt1.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES),
+					new SnomedDescriptionFragment(pt2.getId(), pt2.getTypeId(), pt2.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES)
+				))
 				.active(false)
 				.build();
 		
+		// prepare the second concept
 		String conceptId2 = generateConceptId();
 		SnomedDescriptionIndexEntry fsn2 = description(generateDescriptionId(), Concepts.FULLY_SPECIFIED_NAME, "Fully specified name 2 (tag)")
 				.conceptId(conceptId2)
 				.acceptability(Concepts.REFSET_LANGUAGE_TYPE_ES, Acceptability.PREFERRED)
+				.build();
+		// generate an inactive CNC indicator to test that it is not reported by the rule at all
+		SnomedRefSetMemberIndexEntry validCNCForFsn2 = member(fsn2.getId(), Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR)
+				.active(false)
+				.valueId(Concepts.CONCEPT_NON_CURRENT)
 				.build();
 		
 		SnomedDescriptionIndexEntry pt3 = description(generateDescriptionId(), Concepts.SYNONYM, "Preferred term 3")
@@ -1211,25 +1222,51 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 				.active(false)
 				.conceptId(conceptId2)
 				.build();
+		// mark this inactive PT with a concept non-current indicator which should NOT be allowed by the rule as the description is inactive
+		SnomedRefSetMemberIndexEntry invalidCNCOnPt3 = member(pt3.getId(), Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR).valueId(Concepts.CONCEPT_NON_CURRENT).build();
+		SnomedDescriptionIndexEntry pt4 = description(generateDescriptionId(), Concepts.SYNONYM, "Preferred term 4")
+				.acceptability(Concepts.REFSET_LANGUAGE_TYPE_ES, Acceptability.PREFERRED)
+				.active(false)
+				.conceptId(conceptId1)
+				.build();
+		// mark this active PT with an active erroneous indicator which should NOT be allowed by the rule
+		SnomedRefSetMemberIndexEntry validErroneousForPt4 = member(pt4.getId(), Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR).valueId(Concepts.ERRONEOUS).build();
 		
-		
-		SnomedRefSetMemberIndexEntry ptMember3 = member(pt3.getId(), Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR).valueId(Concepts.CONCEPT_NON_CURRENT).build();
-		
+		// register the concept as inactive along with the two active/inactive descriptions
+		// simulates concept inactivation along with an incorrect description inactivation
 		SnomedConceptDocument conceptWithInactiveDescription = concept(conceptId2)
 				.preferredDescriptions(List.of(
-						new SnomedDescriptionFragment(fsn2.getId(), fsn2.getTypeId(), fsn2.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES),
-						new SnomedDescriptionFragment(pt3.getId(), pt3.getTypeId(), pt3.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES)
-						))
+					new SnomedDescriptionFragment(fsn2.getId(), fsn2.getTypeId(), fsn2.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES),
+					new SnomedDescriptionFragment(pt3.getId(), pt3.getTypeId(), pt3.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES)
+				))
 				.active(false)
 				.build();
 		
-		indexRevision(MAIN, conceptWithActiveDescription, fsn1, pt1, ptMember1, conceptWithInactiveDescription, fsn2, pt2, pt3, ptMember2, ptMember3);
+		indexRevision(MAIN,
+			// index active concept state
+			inactiveConceptWithActiveDescriptions, 
+			fsn1, 
+			pt1, 
+			validCNCForPt1, 
+			pt2, 
+			invalidErroneousForPt2, 
+			
+			// index inactive concept state
+			conceptWithInactiveDescription, 
+			fsn2,
+			validCNCForFsn2,
+			pt3,
+			invalidCNCOnPt3,
+			pt4,
+			validErroneousForPt4
+		);
 		
 		final ValidationIssues issues = validate(ruleId);
 		
 		assertAffectedComponents(issues, 
-				ComponentIdentifier.of(SnomedDescription.TYPE, pt2.getId()),
-				ComponentIdentifier.of(SnomedDescription.TYPE, pt3.getId()));
+			ComponentIdentifier.of(SnomedDescription.TYPE, pt2.getId()),
+			ComponentIdentifier.of(SnomedDescription.TYPE, pt3.getId())
+		);
 	}
 	
 	@Test

--- a/snomed/com.b2international.snowowl.validation.snomed/src/test/java/com/b2international/snowowl/validation/snomed/GenericValidationRuleTest.java
+++ b/snomed/com.b2international.snowowl.validation.snomed/src/test/java/com/b2international/snowowl/validation/snomed/GenericValidationRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2011-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,8 +47,6 @@ import com.b2international.snowowl.snomed.core.domain.*;
 import com.b2international.snowowl.snomed.core.domain.refset.SnomedRefSetType;
 import com.b2international.snowowl.snomed.core.domain.refset.SnomedReferenceSetMember;
 import com.b2international.snowowl.snomed.datastore.index.entry.*;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 /**
  * @since 6.4
@@ -136,7 +134,7 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 		ValidationIssues issues = validate(ruleId);
 		assertThat(issues.stream().map(ValidationIssue::getAffectedComponent).collect(Collectors.toSet()))
 			.contains(ComponentIdentifier.of(SnomedConcept.TYPE, activeConceptWithoutInferredParent.getId()))
-			.doesNotContainAnyElementsOf(ImmutableList.of(ComponentIdentifier.of(SnomedConcept.TYPE, activeConceptWithInferredParent.getId()),
+			.doesNotContainAnyElementsOf(List.of(ComponentIdentifier.of(SnomedConcept.TYPE, activeConceptWithInferredParent.getId()),
 					ComponentIdentifier.of(SnomedConcept.TYPE, inactiveConceptWithoutInferredParent.getId())));
 	}
 	
@@ -160,7 +158,7 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 		ValidationIssues issues = validate(ruleId);
 		assertThat(issues.stream().map(ValidationIssue::getAffectedComponent).collect(Collectors.toSet()))
 			.contains(ComponentIdentifier.of(SnomedConcept.TYPE, activeConceptWithoutStatedParent.getId()))
-			.doesNotContainAnyElementsOf(ImmutableList.of(ComponentIdentifier.of(SnomedConcept.TYPE, activeConceptWithStatedParent.getId()),
+			.doesNotContainAnyElementsOf(List.of(ComponentIdentifier.of(SnomedConcept.TYPE, activeConceptWithStatedParent.getId()),
 					ComponentIdentifier.of(SnomedConcept.TYPE, inactiveConceptWithoutStatedParent.getId())));
 	}
 	
@@ -223,7 +221,7 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 		
 		assertThat(issues.stream().map(ValidationIssue::getAffectedComponent).collect(Collectors.toSet()))
 			.contains(ComponentIdentifier.of(SnomedRelationship.TYPE, nonDefiningRelationshipInGroup0.getId()))
-			.doesNotContainAnyElementsOf(ImmutableList.of(ComponentIdentifier.of(SnomedRelationship.TYPE, definingRelationshipInGroup0.getId()),
+			.doesNotContainAnyElementsOf(List.of(ComponentIdentifier.of(SnomedRelationship.TYPE, definingRelationshipInGroup0.getId()),
 				ComponentIdentifier.of(SnomedRelationship.TYPE, relationshipInGroup2.getId())));		
 	}
 	
@@ -380,7 +378,7 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 		SnomedRelationshipIndexEntry relationshipOnValidConcept = relationship(validConcept1.getId(), Concepts.IS_A, invalidConcept.getId()).build();
 		
 		SnomedRefSetMemberIndexEntry owlAxiomMemberOnValidConcpet = member(validConcept2.getId(), Concepts.REFSET_OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.IS_A, validConcept1.getId(), 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.IS_A, validConcept1.getId(), 0)))
 				.referenceSetType(SnomedRefSetType.OWL_AXIOM)
 				.build();
 		
@@ -390,7 +388,7 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 		
 		assertThat(issues.stream().map(ValidationIssue::getAffectedComponent).collect(Collectors.toSet()))
 			.contains(ComponentIdentifier.of(SnomedConcept.TYPE, invalidConcept.getId()))
-			.doesNotContainAnyElementsOf(ImmutableList.of(ComponentIdentifier.of(SnomedConcept.TYPE, validConcept1.getId()),
+			.doesNotContainAnyElementsOf(List.of(ComponentIdentifier.of(SnomedConcept.TYPE, validConcept1.getId()),
 					ComponentIdentifier.of(SnomedConcept.TYPE, validConcept2.getId())));
 	}
 	
@@ -467,7 +465,7 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 		
 		SnomedRefSetMemberIndexEntry owlAxiomMember1 = member(validConcept.getId(), Concepts.REFSET_OWL_AXIOM)
 				.referenceSetType(SnomedRefSetType.OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.IS_A, Concepts.PHYSICAL_OBJECT, 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.IS_A, Concepts.PHYSICAL_OBJECT, 0)))
 				.build();
 		
 		SnomedConceptDocument concept = concept(generateConceptId())
@@ -475,13 +473,13 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 		
 		SnomedRefSetMemberIndexEntry owlAxiomMember2 = member(concept.getId(), Concepts.REFSET_OWL_AXIOM)
 				.referenceSetType(SnomedRefSetType.OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.SYNONYM, Concepts.PHYSICAL_OBJECT, 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.SYNONYM, Concepts.PHYSICAL_OBJECT, 0)))
 				.build();
 		
 		SnomedRefSetMemberIndexEntry owlAxiomMemberWithoutClassAxioms = member(concept.getId(), Concepts.REFSET_OWL_AXIOM)
 				.referenceSetType(SnomedRefSetType.OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList())
-				.gciAxiomRelationships(Lists.newArrayList())
+				.classAxiomRelationships(List.of())
+				.gciAxiomRelationships(List.of())
 				.build();
 
 		indexRevision(MAIN, relationship1, relationship2, validConcept, concept, owlAxiomMember1, owlAxiomMember2, owlAxiomMemberWithoutClassAxioms);	
@@ -508,12 +506,12 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 
 		SnomedConceptDocument badConcept = concept(generateConceptId())
 				.active(false)
-				.activeMemberOf(ImmutableList.of(r1.getId()))
+				.activeMemberOf(List.of(r1.getId()))
 				.build();
 
 		SnomedConceptDocument goodConcept = concept(generateConceptId())
 				.active(true)
-				.activeMemberOf(ImmutableList.of(r1.getId()))
+				.activeMemberOf(List.of(r1.getId()))
 				.build();
 		
 		indexRevision(MAIN, r1, badConcept, goodConcept);
@@ -537,12 +535,12 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 
 		SnomedDescriptionIndexEntry badDesc = description(generateDescriptionId(), Concepts.FULLY_SPECIFIED_NAME, "I've been bad, i deserve this")
 				.active(false)
-				.activeMemberOf(ImmutableList.of(r1.getId()))
+				.activeMemberOf(List.of(r1.getId()))
 				.build();
 
 		SnomedDescriptionIndexEntry goodDesc = description(generateDescriptionId(), Concepts.FULLY_SPECIFIED_NAME, "I've been good, i deserve this")
 				.active(true)
-				.activeMemberOf(ImmutableList.of(r1.getId()))
+				.activeMemberOf(List.of(r1.getId()))
 				.build();
 		
 		indexRevision(MAIN, r1, badDesc, goodDesc);
@@ -775,7 +773,7 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 				.build();
 		
 		SnomedDescriptionIndexEntry shouldNotCauseIssueDescription3 = description(generateDescriptionId(), descriptionType, "duplicate description")
-				.activeMemberOf(ImmutableList.of(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR))
+				.activeMemberOf(List.of(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR))
 				.conceptId(generateConceptId())
 				.build();
 		
@@ -949,7 +947,7 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 				.build();
 		SnomedRefSetMemberIndexEntry fsn2Member = createLanguageRefsetMember(fsn2);
 		SnomedConceptDocument c1 = concept(concept1Id)
-				.preferredDescriptions(ImmutableList.of(
+				.preferredDescriptions(List.of(
 						new SnomedDescriptionFragment(fsn1.getId(), fsn1.getTypeId(), fsn1.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES),
 						new SnomedDescriptionFragment(fsn2.getId(), fsn2.getTypeId(), fsn2.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES)))
 				.build();
@@ -968,7 +966,7 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 		SnomedRefSetMemberIndexEntry pt2Member = createLanguageRefsetMember(pt2);
 		SnomedConceptDocument c2 = concept(concept2Id)
 				.preferredDescriptions(
-						ImmutableList.of(
+						List.of(
 								new SnomedDescriptionFragment(pt1.getId(), pt1.getTypeId(), pt1.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES),
 								new SnomedDescriptionFragment(pt2.getId(), pt2.getTypeId(), pt2.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES)))
 				.build();
@@ -986,7 +984,7 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 				.build();
 		SnomedRefSetMemberIndexEntry pt3Member = createLanguageRefsetMember(pt3);
 		SnomedConceptDocument c3 = concept(concept3Id)
-				.preferredDescriptions(ImmutableList.of(
+				.preferredDescriptions(List.of(
 						new SnomedDescriptionFragment(fsn3.getId(), fsn3.getTypeId(), fsn3.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES),
 						new SnomedDescriptionFragment(pt3.getId(), pt3.getTypeId(), pt3.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES)
 						))
@@ -1065,26 +1063,26 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 		SnomedConceptDocument activeDestinationConcept = concept(generateConceptId()).active(true).build();
 
 		SnomedRefSetMemberIndexEntry invalidSourceAxiomMember = member(inactiveSourceConcept.getId(), Concepts.REFSET_OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.IS_A, activeDestinationConcept.getId(), 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.IS_A, activeDestinationConcept.getId(), 0)))
 				.build();
 		
 		SnomedRefSetMemberIndexEntry validSourceAxiomMember = member(activeSourceConcept.getId(), Concepts.REFSET_OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.IS_A, activeDestinationConcept.getId(), 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.IS_A, activeDestinationConcept.getId(), 0)))
 				.build();
 		
 		SnomedRefSetMemberIndexEntry invalidDestinationAxiomMember = member(activeSourceConcept.getId(), Concepts.REFSET_OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.IS_A, inactiveDestinationConcept.getId(), 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.IS_A, inactiveDestinationConcept.getId(), 0)))
 				.build();
 		
 		SnomedRefSetMemberIndexEntry invalidDestinationGciAxiomMember = member(activeSourceConcept.getId(), Concepts.REFSET_OWL_AXIOM)
-				.gciAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(activeTypeConcept.getId(), inactiveDestinationConcept.getId(), 0)))
+				.gciAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(activeTypeConcept.getId(), inactiveDestinationConcept.getId(), 0)))
 				.build();
 		
 		SnomedRefSetMemberIndexEntry invalidTypeAxiomMember = member(activeSourceConcept.getId(), Concepts.REFSET_OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(inactiveTypeConcept.getId(), activeDestinationConcept.getId(), 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(inactiveTypeConcept.getId(), activeDestinationConcept.getId(), 0)))
 				.build();
 		SnomedRefSetMemberIndexEntry validGciAxiomMember = member(activeSourceConcept.getId(), Concepts.REFSET_OWL_AXIOM)
-				.gciAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(activeTypeConcept.getId(), activeDestinationConcept.getId(), 0)))
+				.gciAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(activeTypeConcept.getId(), activeDestinationConcept.getId(), 0)))
 				.build();
 
 		indexRevision(MAIN, 
@@ -1190,7 +1188,7 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 		SnomedRefSetMemberIndexEntry ptMember2 = member(pt2.getId(), Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR).valueId(Concepts.ERRONEOUS).build();
 		
 		SnomedConceptDocument conceptWithActiveDescription = concept(conceptId1)
-				.preferredDescriptions(ImmutableList.of(
+				.preferredDescriptions(List.of(
 						new SnomedDescriptionFragment(fsn1.getId(), fsn1.getTypeId(), fsn1.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES),
 						new SnomedDescriptionFragment(pt1.getId(), pt1.getTypeId(), pt1.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES),
 						new SnomedDescriptionFragment(pt2.getId(), pt2.getTypeId(), pt2.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES)
@@ -1214,7 +1212,7 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 		SnomedRefSetMemberIndexEntry ptMember3 = member(pt3.getId(), Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR).valueId(Concepts.CONCEPT_NON_CURRENT).build();
 		
 		SnomedConceptDocument conceptWithInactiveDescription = concept(conceptId2)
-				.preferredDescriptions(ImmutableList.of(
+				.preferredDescriptions(List.of(
 						new SnomedDescriptionFragment(fsn2.getId(), fsn2.getTypeId(), fsn2.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES),
 						new SnomedDescriptionFragment(pt3.getId(), pt3.getTypeId(), pt3.getTerm(), Concepts.REFSET_LANGUAGE_TYPE_ES)
 						))
@@ -1304,21 +1302,21 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 				.relationshipGroup(2).moduleId(MODULE_SCT_CORE).build(); //Incorrect range for type, out of scope module, shouldn't be reported
 		
 		SnomedRefSetMemberIndexEntry axiomMember1 = member(Concepts.CONCEPT_MODEL_ATTRIBUTE, Concepts.REFSET_OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
 				.owlExpression(String.format("ObjectSomeValuesFrom(:%s :%s)", Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE))
 				.referenceSetType(SnomedRefSetType.OWL_AXIOM)
 				.moduleId(MODULE_B2I_EXTENSION)
 				.build();
 		
 		SnomedRefSetMemberIndexEntry axiomMember2 = member(Concepts.CONCEPT_MODEL_ATTRIBUTE, Concepts.REFSET_OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.PHYSICAL_OBJECT, 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.PHYSICAL_OBJECT, 0)))
 				.owlExpression(String.format("ObjectSomeValuesFrom(:%s :%s)", Concepts.FINDING_SITE, Concepts.PHYSICAL_OBJECT))
 				.referenceSetType(SnomedRefSetType.OWL_AXIOM)
 				.moduleId(MODULE_B2I_EXTENSION)
 				.build();
 		
 		SnomedRefSetMemberIndexEntry axiomMember3 = member(Concepts.ROOT_CONCEPT, Concepts.REFSET_OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
 				.owlExpression(String.format("ObjectSomeValuesFrom(:%s :%s)", Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE))
 				.referenceSetType(SnomedRefSetType.OWL_AXIOM)
 				.moduleId(MODULE_B2I_EXTENSION)
@@ -1326,20 +1324,20 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 		
 		//Incorrect range for type, out of scope module, shouldn't be reported
 		SnomedRefSetMemberIndexEntry axiomMember4 = member(Concepts.ROOT_CONCEPT, Concepts.REFSET_OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
 				.owlExpression(String.format("ObjectSomeValuesFrom(:%s :%s)", Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE))
 				.referenceSetType(SnomedRefSetType.OWL_AXIOM)
 				.moduleId(MODULE_SCT_CORE)
 				.build();
 		
 		SnomedRefSetMemberIndexEntry axiomMember5 = member(Concepts.ROOT_CONCEPT, Concepts.REFSET_OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
 				.owlExpression(String.format("TransitiveObjectProperty(:%s)", Concepts.ROOT_CONCEPT))
 				.referenceSetType(SnomedRefSetType.OWL_AXIOM)
 				.build();
 		
 		SnomedRefSetMemberIndexEntry axiomMember6 = member(Concepts.ROOT_CONCEPT, Concepts.REFSET_OWL_AXIOM)
-				.gciAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
+				.gciAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
 				.owlExpression(String.format("ObjectSomeValuesFrom(:%s :%s)", Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE))
 				.referenceSetType(SnomedRefSetType.OWL_AXIOM)
 				.build();
@@ -1418,21 +1416,21 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 		// OWL axioms
 		SnomedRefSetMemberIndexEntry axiomMember1 = member(Concepts.CONCEPT_MODEL_ATTRIBUTE, Concepts.REFSET_OWL_AXIOM)
 				.referenceSetType(SnomedRefSetType.OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
 				.owlExpression(String.format("ObjectSomeValuesFrom(:%s :%s)", Concepts.FINDING_SITE, Concepts.CONCEPT_MODEL_ATTRIBUTE))
 				.moduleId(MODULE_B2I_EXTENSION)
 				.build();
 		
 		SnomedRefSetMemberIndexEntry axiomMember2 = member(Concepts.PHYSICAL_OBJECT, Concepts.REFSET_OWL_AXIOM)
 				.referenceSetType(SnomedRefSetType.OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.PHYSICAL_OBJECT, 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.PHYSICAL_OBJECT, 0)))
 				.owlExpression(String.format("ObjectSomeValuesFrom(:%s :%s)", Concepts.FINDING_SITE, Concepts.PHYSICAL_OBJECT))
 				.moduleId(MODULE_B2I_EXTENSION)
 				.build();
 		
 		SnomedRefSetMemberIndexEntry axiomMember3 = member(Concepts.CONCEPT_MODEL_ATTRIBUTE, Concepts.REFSET_OWL_AXIOM)
 				.referenceSetType(SnomedRefSetType.OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.PHYSICAL_OBJECT, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.PHYSICAL_OBJECT, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
 				.owlExpression(String.format("ObjectSomeValuesFrom(:%s :%s)", Concepts.PHYSICAL_OBJECT, Concepts.CONCEPT_MODEL_ATTRIBUTE))
 				.moduleId(MODULE_B2I_EXTENSION)
 				.build();
@@ -1440,21 +1438,21 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 		//Incorrect type, out of scope module, shouldn't be reported
 		SnomedRefSetMemberIndexEntry axiomMember4 = member(Concepts.CONCEPT_MODEL_ATTRIBUTE, Concepts.REFSET_OWL_AXIOM)
 				.referenceSetType(SnomedRefSetType.OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.PHYSICAL_OBJECT, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.PHYSICAL_OBJECT, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
 				.owlExpression(String.format("ObjectSomeValuesFrom(:%s :%s)", Concepts.PHYSICAL_OBJECT, Concepts.CONCEPT_MODEL_ATTRIBUTE))
 				.moduleId(MODULE_SCT_CORE)
 				.build();
 		
 		SnomedRefSetMemberIndexEntry axiomMember5 = member(Concepts.CONCEPT_MODEL_ATTRIBUTE, Concepts.REFSET_OWL_AXIOM)
 				.referenceSetType(SnomedRefSetType.OWL_AXIOM)
-				.classAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.PHYSICAL_OBJECT, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
+				.classAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.PHYSICAL_OBJECT, Concepts.CONCEPT_MODEL_ATTRIBUTE, 0)))
 				.owlExpression(String.format("ObjectSomeValuesFrom(:%s :%s)", Concepts.PHYSICAL_OBJECT, Concepts.CONCEPT_MODEL_ATTRIBUTE))
 				.owlExpression(String.format("ReflexiveObjectProperty(:%s)", Concepts.ROOT_CONCEPT))
 				.build();
 		
 		SnomedRefSetMemberIndexEntry axiomMember6 = member(Concepts.PHYSICAL_OBJECT, Concepts.REFSET_OWL_AXIOM)
 				.referenceSetType(SnomedRefSetType.OWL_AXIOM)
-				.gciAxiomRelationships(Lists.newArrayList(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.PHYSICAL_OBJECT, 0)))
+				.gciAxiomRelationships(List.of(SnomedOWLRelationshipDocument.create(Concepts.FINDING_SITE, Concepts.PHYSICAL_OBJECT, 0)))
 				.owlExpression(String.format("ObjectSomeValuesFrom(:%s :%s)", Concepts.FINDING_SITE, Concepts.PHYSICAL_OBJECT))
 				.build();
 		

--- a/snomed/com.b2international.snowowl.validation.snomed/src/test/java/com/b2international/snowowl/validation/snomed/GenericValidationRuleTest.java
+++ b/snomed/com.b2international.snowowl.validation.snomed/src/test/java/com/b2international/snowowl/validation/snomed/GenericValidationRuleTest.java
@@ -706,34 +706,27 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 	}
 	
 	@Test
-	public void rule532a_pharmacy_1() throws Exception {
+	public void rule532a() throws Exception {
 		rule532("532a", Concepts.FULLY_SPECIFIED_NAME, Concepts.MODULE_B2I_EXTENSION);
 	}
 
 	@Test
-	public void rule532a_pharmacy_2() throws Exception {
-		rule532("532a", Concepts.FULLY_SPECIFIED_NAME, Concepts.MODULE_B2I_EXTENSION);
-	}
-	
-	@Test
-	public void rule532b_pharmacy_1() throws Exception {
+	public void rule532b() throws Exception {
 		rule532("532b", Concepts.SYNONYM, Concepts.MODULE_B2I_EXTENSION);
 	}
 
-	@Test
-	public void rule532b_pharmacy_2() throws Exception {
-		rule532("532b", Concepts.SYNONYM, Concepts.MODULE_B2I_EXTENSION);
-	}
-	
 	private void rule532(String ruleId, String descriptionType, String moduleId) throws Exception {
 		indexRule(ruleId);
 		
+		SnomedConceptDocument activeConcept = concept(generateConceptId()).build();
+		SnomedConceptDocument inactiveConcept = concept(generateConceptId()).active(false).build();
+		
 		SnomedDescriptionIndexEntry validDescription = description(generateDescriptionId(), descriptionType, "Not duplicate term")
-				.conceptId(generateConceptId())
+				.conceptId(activeConcept.getId())
 				.build();
 		
 		SnomedDescriptionIndexEntry invalidDescription1 = description(generateDescriptionId(), descriptionType, "Duplicate description")
-				.conceptId(generateConceptId())
+				.conceptId(activeConcept.getId())
 				.moduleId(moduleId)
 				.build();
 		
@@ -743,42 +736,51 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 			.build();
 		
 		SnomedDescriptionIndexEntry invalidDescription2 = description(generateDescriptionId(), descriptionType, "duplicate description")
-				.conceptId(generateConceptId())
+				.conceptId(activeConcept.getId())
 				.moduleId(moduleId)
 				.build();
 		
 		SnomedDescriptionIndexEntry invalidIntDescription1 = description(generateDescriptionId(), descriptionType, "Duplicate description")
-				.conceptId(generateConceptId())
+				.conceptId(activeConcept.getId())
 				.moduleId(Concepts.MODULE_SCT_CORE)
 				.build();
 		
 		SnomedDescriptionIndexEntry invalidIntDescription2 = description(generateDescriptionId(), descriptionType, "Duplicate of International description")
-				.conceptId(generateConceptId())
+				.conceptId(activeConcept.getId())
 				.moduleId(Concepts.MODULE_SCT_CORE)
 				.build();
 		
 		SnomedDescriptionIndexEntry invalidIntDescription3 = description(generateDescriptionId(), descriptionType, "Duplicate of International description")
-				.conceptId(generateConceptId())
+				.conceptId(activeConcept.getId())
 				.moduleId(Concepts.MODULE_SCT_CORE)
 				.build();
 		
 		SnomedDescriptionIndexEntry invalidDescription3 = description(generateDescriptionId(), descriptionType, "This is fine")
-				.conceptId(generateConceptId())
+				.conceptId(activeConcept.getId())
 				.moduleId(moduleId)
 				.build();
 		
 		SnomedDescriptionIndexEntry invalidDescription4 = description(generateDescriptionId(), descriptionType, "this is fine")
-				.conceptId(generateConceptId())
+				.conceptId(activeConcept.getId())
 				.moduleId(moduleId)
 				.build();
 		
-		SnomedDescriptionIndexEntry shouldNotCauseIssueDescription3 = description(generateDescriptionId(), descriptionType, "duplicate description")
+		SnomedDescriptionIndexEntry invalidDescriptionOnActiveConceptWithActiveInactivityIndicator = description(generateDescriptionId(), descriptionType, "duplicate description")
 				.activeMemberOf(List.of(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR))
-				.conceptId(generateConceptId())
+				.conceptId(activeConcept.getId())
+				.build();
+		
+		SnomedDescriptionIndexEntry duplicateDescriptionButOnInactiveConceptWithAnInactiveIndicatorMember = description(generateDescriptionId(), descriptionType, "duplicate description")
+				// simulating an indicator that is inactive in the inactivity refset (possibly a CNC indicator in many cases)
+				.memberOf(List.of(Concepts.REFSET_DESCRIPTION_INACTIVITY_INDICATOR))
+				// in this case the concept itself is inactive therefore the term should not be considered
+				.conceptId(inactiveConcept.getId())
 				.build();
 		
 		index()
 			.prepareCommit(MAIN)
+			.stageNew(activeConcept)
+			.stageNew(inactiveConcept)
 			.stageNew(validDescription)
 			.stageNew(invalidDescription1)
 			.stageNew(inactivationIndicator1)
@@ -788,7 +790,8 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 			.stageNew(invalidIntDescription3)
 			.stageNew(invalidDescription3)
 			.stageNew(invalidDescription4)
-			.stageNew(shouldNotCauseIssueDescription3)
+			.stageNew(invalidDescriptionOnActiveConceptWithActiveInactivityIndicator)
+			.stageNew(duplicateDescriptionButOnInactiveConceptWithAnInactiveIndicatorMember)
 			.commit(currentTime(), UUID.randomUUID().toString(), "Indexing data for rule 532 test");
 		
 		ValidationIssues issues = validate(ruleId);
@@ -798,7 +801,8 @@ public class GenericValidationRuleTest extends BaseGenericValidationRuleTest {
 			ComponentIdentifier.of(SnomedDescription.TYPE, invalidIntDescription1.getId()),
 			ComponentIdentifier.of(SnomedDescription.TYPE, invalidDescription2.getId()),
 			ComponentIdentifier.of(SnomedDescription.TYPE, invalidDescription3.getId()),
-			ComponentIdentifier.of(SnomedDescription.TYPE, invalidDescription4.getId())
+			ComponentIdentifier.of(SnomedDescription.TYPE, invalidDescription4.getId()),
+			ComponentIdentifier.of(SnomedDescription.TYPE, invalidDescriptionOnActiveConceptWithActiveInactivityIndicator.getId())
 		);
 	}
 	


### PR DESCRIPTION
Update all other checks/references and deprecate the ID constant in SnomedConstants to notify developers about the change.

Jira: https://snowowl.atlassian.net/browse/SO-6555