### PR TITLE
SNRAY-2075: JWT/JWKS identity configuration changes

### DIFF
--- a/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/identity/JWTConfigurationTest.java
+++ b/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/identity/JWTConfigurationTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.InstantSource;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.After;
@@ -29,6 +30,8 @@ import org.junit.Test;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.b2international.commons.exceptions.BadRequestException;
 import com.b2international.snowowl.core.SnowOwl;
+import com.b2international.snowowl.core.identity.jwks.JwksIdentityProviderConfig;
+import com.b2international.snowowl.core.plugin.ClassPathScanner;
 
 /**
  * @since 8.1
@@ -122,6 +125,71 @@ public class JWTConfigurationTest extends BaseIdentityPluginTest {
 		assertThat(token.getAlgorithm()).isEqualTo("RS256");
 	}
 	
+	@Test
+	public void rs256_customUserIdClaim() throws Exception {
+		IdentityConfiguration conf = readConfig("rs256.yml");
+		JWTSupport jwtSupport = new IdentityPlugin().initJWT(env, conf);
+		String jwt = jwtSupport.generate("test@example.com", Map.of("http://example.com/userId", "user-id-value"));
+		
+		JWTConfiguration jwtConfigWithCustomClaim = new JWTConfiguration();
+		
+		jwtConfigWithCustomClaim.setIssuer(conf.getIssuer());
+		jwtConfigWithCustomClaim.setJws(conf.getJws());
+		jwtConfigWithCustomClaim.setSecret(conf.getSecret());
+		jwtConfigWithCustomClaim.setSigningKey(conf.getSigningKey());
+		jwtConfigWithCustomClaim.setVerificationKey(conf.getVerificationKey());
+		jwtConfigWithCustomClaim.setPermissionsClaimProperty(conf.getPermissionsClaimProperty());
+		
+		// Override the default userId claim property
+		jwtConfigWithCustomClaim.setUserIdClaimProperty("http://example.com/userId");
+		
+		// For verification we will use the same JWTSupport instance but this shouldn't cause any issues
+		DecodedJWT token = jwtSupport.verify(jwt);
+		User user = JWTSupport.toUser(token, jwtConfigWithCustomClaim);
+		assertThat(user.getUserId()).isEqualTo("user-id-value");
+	}
+	
+	@Test
+	public void rs256_customPermissionsClaim() throws Exception {
+		IdentityConfiguration conf = readConfig("rs256.yml");
+		JWTSupport jwtSupport = new IdentityPlugin().initJWT(env, conf);
+		String jwt = jwtSupport.generate("test@example.com", Map.of("http://example.com/permissions", List.of("read:snomedct")));
+		
+		JWTConfiguration jwtConfigWithCustomClaim = new JWTConfiguration();
+		
+		jwtConfigWithCustomClaim.setIssuer(conf.getIssuer());
+		jwtConfigWithCustomClaim.setJws(conf.getJws());
+		jwtConfigWithCustomClaim.setSecret(conf.getSecret());
+		jwtConfigWithCustomClaim.setSigningKey(conf.getSigningKey());
+		jwtConfigWithCustomClaim.setVerificationKey(conf.getVerificationKey());
+		jwtConfigWithCustomClaim.setUserIdClaimProperty(conf.getUserIdClaimProperty());
+		
+		// Override the default permissions claim property
+		jwtConfigWithCustomClaim.setPermissionsClaimProperty("http://example.com/permissions");
+		
+		DecodedJWT token = jwtSupport.verify(jwt);
+		User user = JWTSupport.toUser(token, jwtConfigWithCustomClaim);
+		assertThat(user.getPermissions()).extracting(Permission::getPermission).containsOnly("read:snomedct");
+	}
+	
+	@Test
+	public void rs256_emailClaimProperty_identityConfiguration() throws Exception {
+		IdentityConfiguration conf = readConfig("rs256_emailClaimProperty.yml");
+		assertThat(conf.getUserIdClaimProperty()).isEqualTo("http://example.com/userId");
+	}
+
+	@Test
+	public void rs256_emailClaimProperty_jwksIdentityProviderConfig() throws Exception {
+		// Deserialization of JwksIdentityProviderConfig needs the ClassPathScanner to be registered
+		ClassPathScanner scanner = new ClassPathScanner(JwksIdentityProviderConfig.class.getPackage().getName());
+		env.services().registerService(ClassPathScanner.class, scanner);
+
+		IdentityConfiguration conf = readConfig("rs256_emailClaimProperty_jwks.yml");
+
+		JwksIdentityProviderConfig jwksConf = (JwksIdentityProviderConfig) conf.getProviderConfigurations().get(0);
+		assertThat(jwksConf.getUserIdClaimProperty()).isEqualTo("http://example.com/userId");
+	}
+
 	@Test
 	public void rs256_VerifyOnly_X509() throws Exception {
 		// configure support for both signing and verifying first

--- a/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/identity/rs256_emailClaimProperty.yml
+++ b/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/identity/rs256_emailClaimProperty.yml
@@ -1,0 +1,2 @@
+jws: RS256
+emailClaimProperty: http://example.com/userId

--- a/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/identity/rs256_emailClaimProperty_jwks.yml
+++ b/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/identity/rs256_emailClaimProperty_jwks.yml
@@ -1,0 +1,4 @@
+providers:
+  - jwks:
+      jws: RS256
+      emailClaimProperty: http://example.com/userId

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/DefaultJWTGenerator.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/DefaultJWTGenerator.java
@@ -39,26 +39,37 @@ final class DefaultJWTGenerator implements JWTGenerator {
 
 	private final Algorithm algorithm;
 	private final String issuer;
-	private final String emailClaimProperty;
+	private final String userIdClaimProperty;
 	private final String permissionsClaimProperty;
 	private final InstantSource instantSource;
 
-	public DefaultJWTGenerator(final Algorithm algorithm, final String issuer, final String emailClaimProperty, final String permissionsClaimProperty, InstantSource instantSource) {
+	public DefaultJWTGenerator(
+		final Algorithm algorithm, 
+		final String issuer, 
+		final String userIdClaimProperty, 
+		final String permissionsClaimProperty, 
+		final InstantSource instantSource
+	) {
 		this.algorithm = checkNotNull(algorithm);
 		this.issuer = issuer;
-		this.emailClaimProperty = emailClaimProperty;
+		this.userIdClaimProperty = userIdClaimProperty;
 		this.permissionsClaimProperty = permissionsClaimProperty;
 		this.instantSource = checkNotNull(instantSource);
 	}
 	
 	@Override
-	public String generate(String email, Map<String, Object> claims, String expiration) {
+	public String generate(String userId, Map<String, Object> claims, String expiration) {
 		
+		/*
+		 * XXX: If userIdClaimProperty is different from "sub", we add it as a separate
+		 * claim; otherwise we will do a bit of extra work but no duplicate claims will
+		 * end up in the token.
+		 */
 		Builder builder = JWT.create()
-				.withIssuer(issuer)
-				.withSubject(email)
-				.withIssuedAt(new Date())
-				.withClaim(emailClaimProperty, email);
+			.withIssuer(issuer)
+			.withSubject(userId)
+			.withIssuedAt(new Date())
+			.withClaim(userIdClaimProperty, userId);
 		
 		if (!Strings.isNullOrEmpty(expiration)) {
 			try {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/IdentityPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/IdentityPlugin.java
@@ -100,7 +100,7 @@ public final class IdentityPlugin extends Plugin {
 			jwksConfig.setJwksUrl(conf.getJwksUrl());
 			jwksConfig.setJws(conf.getJws());
 			jwksConfig.setIssuer(conf.getIssuer());
-			jwksConfig.setEmailClaimProperty(conf.getEmailClaimProperty());
+			jwksConfig.setUserIdClaimProperty(conf.getUserIdClaimProperty());
 			jwksConfig.setPermissionsClaimProperty(conf.getPermissionsClaimProperty());
 			
 			// add a JWKS URL identity provider

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/JWTConfiguration.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/JWTConfiguration.java
@@ -28,15 +28,15 @@ public class JWTConfiguration {
 	private String secret;
 	private String signingKey;
 	private String verificationKey;
-	private String emailClaimProperty = "sub";
+	private String userIdClaimProperty = "sub";
 	private String permissionsClaimProperty = "permissions";
 	
 	public String getIssuer() {
 		return issuer;
 	}
 	
-	public String getEmailClaimProperty() {
-		return emailClaimProperty;
+	public String getUserIdClaimProperty() {
+		return userIdClaimProperty;
 	}
 
 	public String getJws() {
@@ -59,9 +59,20 @@ public class JWTConfiguration {
 		return verificationKey;
 	}
 	
-	public void setEmailClaimProperty(String emailClaimProperty) {
-		this.emailClaimProperty = emailClaimProperty;
+	public void setUserIdClaimProperty(String userIdClaimProperty) {
+		this.userIdClaimProperty = userIdClaimProperty;
 	}
+	
+	/*
+	 * XXX: Setter retained for backwards compatibility (IdentityConfiguration is a
+	 * subclass of JWTConfiguration and we supported JWT-related properties on the
+	 * top level of the identity section in earlier versions of Snow Owl)
+	 */
+	@Deprecated
+	public void setEmailClaimProperty(String emailClaimProperty) {
+		this.userIdClaimProperty = emailClaimProperty;
+	}
+
 	
 	public void setIssuer(String issuer) {
 		this.issuer = issuer;

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/JWTSupport.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/JWTSupport.java
@@ -23,7 +23,10 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.time.InstantSource;
-import java.util.*;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -131,7 +134,7 @@ public class JWTSupport implements JWTGenerator {
 			generator = JWT_GENERATOR_DISABLED;
 			verifier = createJWTVerifier(algorithm, config);
 		} else {
-			generator = new DefaultJWTGenerator(algorithm, config.getIssuer(), config.getEmailClaimProperty(), config.getPermissionsClaimProperty(), instantSource);
+			generator = new DefaultJWTGenerator(algorithm, config.getIssuer(), config.getUserIdClaimProperty(), config.getPermissionsClaimProperty(), instantSource);
 			verifier = createJWTVerifier(algorithm, config);
 		}
 	}
@@ -257,37 +260,47 @@ public class JWTSupport implements JWTGenerator {
 	/**
 	 * Converts the given JWT access token to a {@link User} representation using the configured email and permission claims.
 	 * 
-	 * @param jwt
-	 *            - the JWT to convert to a {@link User} object
-	 * @return
-	 * @throws BadRequestException
-	 *             - if either the configured email or permissions property is missing from the given JWT
+	 * @param jwt - the JWT to convert to a {@link User} object
+	 * @return the converted {@link User} instance with user ID and permissions extracted from the input
+	 * @throws BadRequestException - if either the configured email or permissions property is missing from the given JWT
 	 */
 	public static User toUser(DecodedJWT jwt, JWTConfiguration config) {
-		final String userId;
+		final String userIdProperty = config.getUserIdClaimProperty();
+		final String permissionsProperty = config.getPermissionsClaimProperty();
+		
+		final String userId = getUserId(jwt, userIdProperty);
+		final List<String> permissions = getPermissions(jwt, permissionsProperty);
+		final List<Permission> permissionObjects = permissions.stream()
+			.map(Permission::valueOf)
+			.collect(Collectors.toList());
 
-		// XXX emailClaimProperty should be renamed to userIdProperty
-		String userIdProperty = config.getEmailClaimProperty();
-		if (Strings.isNullOrEmpty(userIdProperty)) {
-			userId = jwt.getSubject();
-		} else {
-			final Claim emailClaim = jwt.getClaim(userIdProperty);
-			if (emailClaim == null || emailClaim.isNull()) {
-				throw new BadRequestException("'%s' JWT access token field is required for userId access, but it was missing.", userIdProperty);
-			}
-			userId = emailClaim.asString();
-		}
-
-		List<String> permissions = Collections.emptyList();
-		final String permissionsClaimProperty = config.getPermissionsClaimProperty();
-		if (!Strings.isNullOrEmpty(permissionsClaimProperty)) {
-			Claim permissionsClaim = jwt.getClaim(permissionsClaimProperty);
-			if (permissionsClaim != null && !permissionsClaim.isNull() && !permissionsClaim.isMissing()) {
-				permissions = permissionsClaim.asList(String.class);
-			}
-		}
-
-		return new User(userId, permissions.stream().map(Permission::valueOf).collect(Collectors.toList()), jwt.getToken());
+		return new User(userId, permissionObjects, jwt.getToken());
 	}
 
+	private static String getUserId(final DecodedJWT jwt, final String userIdProperty) {
+		if (Strings.isNullOrEmpty(userIdProperty)) {
+			return jwt.getSubject();
+		}
+			
+		final Claim userIdClaim = jwt.getClaim(userIdProperty);
+		if (userIdClaim == null || userIdClaim.isNull()) {
+			throw new BadRequestException("'%s' JWT access token field is required for userId access, but it was missing.", userIdProperty);
+		}
+			
+		return userIdClaim.asString();
+	}
+	
+	private static List<String> getPermissions(final DecodedJWT jwt, final String permissionsProperty) {
+		if (Strings.isNullOrEmpty(permissionsProperty)) {
+			return List.of();
+		}
+		
+		final Claim permissionsClaim = jwt.getClaim(permissionsProperty);
+		if (permissionsClaim == null || permissionsClaim.isNull() || permissionsClaim.isMissing()) {
+			// If permissions claim is missing, return an empty list as this is entirely optional 
+			return List.of();
+		}
+		
+		return permissionsClaim.asList(String.class);
+	}
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/jwks/JwksIdentityProviderConfig.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/jwks/JwksIdentityProviderConfig.java
@@ -15,11 +15,11 @@
  */
 package com.b2international.snowowl.core.identity.jwks;
 
-import jakarta.validation.constraints.NotEmpty;
-
 import com.b2international.snowowl.core.identity.IdentityProviderConfig;
 import com.b2international.snowowl.core.identity.JWTConfiguration;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import jakarta.validation.constraints.NotEmpty;
 
 /**
  * @since 8.8.0
@@ -36,7 +36,7 @@ public class JwksIdentityProviderConfig implements IdentityProviderConfig {
 	@NotEmpty
 	private String jwksUrl;
 	
-	private String emailClaimProperty = "sub";
+	private String userIdClaimProperty = "sub";
 	private String permissionsClaimProperty = "permissions";
 	
 	public String getIssuer() {
@@ -55,8 +55,8 @@ public class JwksIdentityProviderConfig implements IdentityProviderConfig {
 		return permissionsClaimProperty;
 	}
 	
-	public String getEmailClaimProperty() {
-		return emailClaimProperty;
+	public String getUserIdClaimProperty() {
+		return userIdClaimProperty;
 	}
 	
 	public void setIssuer(String issuer) {
@@ -75,15 +75,21 @@ public class JwksIdentityProviderConfig implements IdentityProviderConfig {
 		this.permissionsClaimProperty = permissionsClaimProperty;
 	}
 	
+	public void setUserIdClaimProperty(String userIdClaimProperty) {
+		this.userIdClaimProperty = userIdClaimProperty;
+	}
+
+	// Setter retained for backwards compatibility
+	@Deprecated
 	public void setEmailClaimProperty(String emailClaimProperty) {
-		this.emailClaimProperty = emailClaimProperty;
+		this.userIdClaimProperty = emailClaimProperty;
 	}
 
 	public JWTConfiguration toJWTConfiguration() {
 		final JWTConfiguration jwtConfiguration = new JWTConfiguration();
 		jwtConfiguration.setJws(jws);
 		jwtConfiguration.setIssuer(issuer);
-		jwtConfiguration.setEmailClaimProperty(emailClaimProperty);
+		jwtConfiguration.setUserIdClaimProperty(userIdClaimProperty);
 		jwtConfiguration.setPermissionsClaimProperty(permissionsClaimProperty);
 		return jwtConfiguration;
 	}


### PR DESCRIPTION
- Rename `emailClaimProperty` to `userIdClaimProperty`, retaining property setters for backwards compatibility purposes
- Add test cases to verify claim extraction from decoded JWT
- Add test cases to verify whether using the previous property name in configuration files still registers the value correctly