### PR TITLE
Map native Snow Owl resource IDs to FHIR-compatible identifiers

### DIFF
--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/FhirModelHelpers.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/FhirModelHelpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2024-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,9 +35,11 @@ import com.b2international.snowowl.core.TerminologyResource;
 import com.b2international.snowowl.core.request.ResourceRequests;
 import com.b2international.snowowl.core.terminology.TerminologyRegistry;
 import com.b2international.snowowl.core.version.Version;
+import com.google.common.base.CharMatcher;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.hash.Hashing;
 
 /**
  * @since 9.4.0
@@ -47,6 +49,11 @@ public class FhirModelHelpers {
 	public static final String OID_PREFIX = "urn:oid:";
 	
 	public static final String SNOMED_BASE_URI_STRING = "http://snomed.info/sct";
+
+	private static final CharMatcher HEX_MATCHER = CharMatcher.inRange('0', '9')
+			.or(CharMatcher.inRange('a', 'f'))
+			.or(CharMatcher.inRange('A', 'F'))
+			.precomputed();
 
 	public static ResourceURI resourceUriFrom(final Resource resource) {
 		final ResourceURI resourceUri = (ResourceURI) resource.getUserData(TerminologyResource.Fields.RESOURCE_URI);
@@ -207,5 +214,133 @@ public class FhirModelHelpers {
 		final CanonicalType canonicalType = new CanonicalType();
 		setSystemAndVersion(resourceUri, mapperFunction, canonicalType::setValue, canonicalType::addVersion);
 		return canonicalType;
+	}
+
+	/**
+	 * Converts a native resource ID to a FHIR-compatible resource ID.
+	 * <p>
+	 * Rules are evaluated in order in a left-to-right pass and only the first
+	 * matching rule is applied, no stacking of multiple rules occurs:
+	 * <ol>
+	 * <li>Each occurrence of {@code "/"} is replaced with {@code "--"}</li>
+	 * <li>Each occurrence of {@code "--"} is replaced with {@code ".h"}</li>
+	 * <li>Each occurrence of {@code "_"} is replaced with {@code ".u"}</li>
+	 * <li>If the resulting ID would be longer than 64 characters, return the 
+	 * first 46 characters of the result, then {@code ".c"}, then 16 hex digits 
+	 * of a SipHash-2-4 tag of the original input to ensure uniqueness while 
+	 * retaining a recoverable prefix of the original ID
+	 * </ol>
+	 * If none of the rules match, the input is returned unchanged.
+	 *
+	 * @param nativeId the native resource ID to convert
+	 * @return the FHIR-compatible resource ID
+	 */
+	public static String toFhirResourceId(final String nativeId) {
+		if (nativeId == null) {
+			return null;
+		}
+		
+		final StringBuilder sb = new StringBuilder(nativeId.length());
+		int i = 0;
+		
+		while (i < nativeId.length()) {
+			if (nativeId.charAt(i) == '/') {
+				sb.append("--");
+				i++;
+			} else if (nativeId.startsWith("--", i)) {
+				sb.append(".h");
+				i += 2;
+			} else if (nativeId.charAt(i) == '_') {
+				sb.append(".u");
+				i++;
+			} else {
+				sb.append(nativeId.charAt(i));
+				i++;
+			}
+		}
+		
+		if (sb.length() > 64) {
+			final String hash = Hashing.sipHash24()
+				.hashUnencodedChars(nativeId)
+				.toString();
+			
+			// Carve out space for the hash trailer and append it
+			sb.setLength((64 - 2 - 16));
+			sb.append(".c");
+			sb.append(hash);
+		}
+		
+		return sb.toString();
+	}
+
+	/**
+	 * Reverses a FHIR resource ID previously produced by {@link #toFhirResourceId(String)}, 
+	 * recovering the original native resource ID or its prefix.
+	 * <p>
+	 * The following substitutions are applied in a single left-to-right pass:
+	 * <ol>
+	 * <li>Each occurrence of {@code "--"} is replaced with {@code "/"}</li>
+	 * <li>Each occurrence of {@code ".h"} is replaced with {@code "--"}</li>
+	 * <li>Each occurrence of {@code ".u"} is replaced with {@code "_"}</li>
+	 * </ol>
+	 * When rule 4 (length truncation with hash) was applied during encoding, the
+	 * original string cannot be fully recovered. In that case only the prefix that
+	 * was retained during encoding is returned (after reverse-substitution),
+	 * without the hash trailer.
+	 * <p>The caller can detect this situation by checking whether {@code fhirId} 
+	 * matches the pattern {@code <14 chars>.c<12 hex digits>} before calling this method.
+	 *
+	 * @param fhirId the FHIR resource ID to reverse
+	 * @return the original native resource ID, or its recoverable prefix
+	 */
+	public static String fromFhirResourceId(final String fhirId) {
+		if (fhirId == null) {
+			return null;
+		}
+
+		if (isTruncatedFhirResourceId(fhirId)) {
+			// Only the first 46 characters are recoverable
+			return reverseSubstitutes(fhirId.substring(0, 46));
+		} else {
+			return reverseSubstitutes(fhirId);
+		}
+	}
+
+	/**
+	 * Checks whether the given FHIR resource ID matches the pattern of a truncated
+	 * ID produced by {@link #toFhirResourceId(String)} when the input was too long.
+	 * 
+	 * @param fhirId the FHIR resource ID to check
+	 * @return {@code true} if the ID matches the pattern of a truncated ID, 
+	 * {@code false} otherwise
+	 */
+	public static boolean isTruncatedFhirResourceId(final String fhirId) {
+		return fhirId.length() == 64
+			&& fhirId.charAt(46) == '.'
+			&& fhirId.charAt(47) == 'c'
+			&& HEX_MATCHER.matchesAllOf(fhirId.substring(48));
+	}
+
+	private static String reverseSubstitutes(final String fhirId) {
+		final StringBuilder sb = new StringBuilder(fhirId.length());
+		int i = 0;
+		
+		while (i < fhirId.length()) {
+			if (fhirId.startsWith("--", i)) {
+				sb.append('/');
+				i += 2;
+			} else if (fhirId.startsWith(".h", i)) {
+				sb.append("--");
+				i += 2;
+			} else if (fhirId.startsWith(".u", i)) {
+				sb.append('_');
+				i += 2;
+			} else {
+				sb.append(fhirId.charAt(i));
+				i++;
+			}
+		}
+		
+		return sb.toString();
 	}
 }

--- a/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/FhirResourceSearchRequest.java
+++ b/fhir/com.b2international.snowowl.fhir.core/src/com/b2international/snowowl/fhir/core/request/FhirResourceSearchRequest.java
@@ -113,12 +113,51 @@ public abstract class FhirResourceSearchRequest<T extends MetadataResource> exte
 	 */
 	protected abstract String getResourceType();
 
-	private final void addFhirIdFilter(final ExpressionBuilder query) {
-		// Both documents have an "id" and a "url" field; we will use the expression from ResourceDocument purely by choice
-		addIdFilter(query, ids -> Expressions.bool()
-			.should(ResourceDocument.Expressions.ids(ids))
-			.should(ResourceDocument.Expressions.urls(ids))
-			.build());
+	private final void addFhirIdFilter(final RepositoryContext context, final ExpressionBuilder query) {
+		addIdFilter(query, ids -> {
+	
+			// Decide if the incoming FHIR-compatible IDs are complete or truncated
+			final Map<Boolean, Set<String>> fhirIds = ids.stream()
+				.collect(Collectors.partitioningBy(
+					FhirModelHelpers::isTruncatedFhirResourceId, 
+					Collectors.toSet()));
+			
+			// Run a pre-flight search request to find the complete IDs for the truncated ones first
+			final Set<String> truncatedFhirIds = fhirIds.get(Boolean.TRUE);
+			final Set<String> truncatedInternalIdPrefixes = truncatedFhirIds.stream()
+				.map(FhirModelHelpers::fromFhirResourceId)
+				.collect(Collectors.toSet());
+
+			final Set<String> completeInternalIds = fhirIds.get(Boolean.FALSE).stream()
+				.map(FhirModelHelpers::fromFhirResourceId)
+				.collect(Collectors.toSet());
+
+			if (!truncatedFhirIds.isEmpty()) {
+				Hits<String> idHits;
+				
+				try {
+					
+					idHits = context.service(RevisionSearcher.class)
+						.search(Query.select(String.class)
+							.from(ResourceDocument.class, VersionDocument.class)
+							.fields(ResourceDocument.Fields.ID)
+							.where(ResourceDocument.Expressions.idPrefixes(truncatedInternalIdPrefixes))
+							.limit(truncatedInternalIdPrefixes.size())
+							.build());
+					
+				} catch (final IOException e) {
+					throw new RuntimeException(e);
+				}
+				
+				// Apply the transformation from internal to FHIR ID again and see which ones were actually requested in the original filter
+				idHits.stream()
+					.filter(id -> truncatedFhirIds.contains(FhirModelHelpers.toFhirResourceId(id)))
+					.forEach(completeInternalIds::add);
+			}
+			
+			// Both resource and version documents have an "id" field; we will use the expression from ResourceDocument
+			return ResourceDocument.Expressions.ids(completeInternalIds);
+		});
 	}
 
 	/**
@@ -351,7 +390,7 @@ public abstract class FhirResourceSearchRequest<T extends MetadataResource> exte
 	private T toFhirResource(final RepositoryContext context, final ResourceFragment resource) {
 		final T entry = createResource();
 		
-		entry.setId(resource.getId());
+		entry.setId(FhirModelHelpers.toFhirResourceId(resource.getId()));
 		entry.setStatus(toPublicationStatus(resource.getStatus()));
 		entry.setMeta(toMeta(resource.getUpdatedAt(), resource.getCreatedAt()));
 		
@@ -359,8 +398,9 @@ public abstract class FhirResourceSearchRequest<T extends MetadataResource> exte
 		entry.setUserData(TerminologyResource.Fields.TOOLING_ID, resource.getToolingId());
 		entry.setUserData(TerminologyResource.Fields.RESOURCE_URI, resource.getResourceURI());
 		
-		// We are using the raw ID of the resource as machine readable name
+		// Copy Snow Owl's native identifier to "name" when requested to be included
 		includeIfFieldSelected(R5ObjectFields.MetadataResource.NAME, resource::getId, entry::setName);
+		
 		// We have a description field available both for the resource and the version, here the one for the resource is needed
 		includeIfFieldSelected(R5ObjectFields.MetadataResource.DESCRIPTION, resource::getResourceDescription, entry::setDescription);
 		includeIfFieldSelected(R5ObjectFields.MetadataResource.TITLE, resource::getTitle, entry::setTitle);
@@ -399,7 +439,7 @@ public abstract class FhirResourceSearchRequest<T extends MetadataResource> exte
 			.filter(ResourceDocument.Expressions.resourceType(getResourceType())); 
 		
 		// Support filtering by the FHIR resource ID which needs to be transformed to the internal ID first
-		addFhirIdFilter(query);
+		addFhirIdFilter(context, query);
 		
 		/*
 		 * The "name" property can be used to query the native resource ID. Values do

--- a/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/AllFhirRestTests.java
+++ b/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/AllFhirRestTests.java
@@ -42,6 +42,7 @@ import com.b2international.snowowl.test.commons.SnowOwlAppRule;
 @SuiteClasses({
 	// Helpers
 	SnomedUriParsingTest.class,
+	FhirResourceIdMappingTest.class,
 	
 	// Resource types
 	FhirCodeSystemApiTest.class,

--- a/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/FhirResourceIdMappingTest.java
+++ b/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/FhirResourceIdMappingTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 B2i Healthcare, https://b2ihealthcare.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.fhir.rest.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.b2international.snowowl.fhir.core.FhirModelHelpers;
+
+/**
+ * Verifies ID conversion methods {@link FhirModelHelpers#toFhirResourceId(String)} and
+ * {@link FhirModelHelpers#fromFhirResourceId(String)}.
+ *
+ * @since 9.4.0
+ */
+public class FhirResourceIdMappingTest {
+
+	private record ForwardCase(String description, String input, String expected) {
+		// Empty record body
+	}
+
+	private record RoundTripCase(String description, String input) {
+		// Empty record body
+	}
+
+	private static final List<ForwardCase> FORWARD_CASES = List.of(
+
+		// Null / identity
+		new ForwardCase("null input",                   null,                  null),
+		new ForwardCase("empty string unchanged",       "",                    ""),
+		new ForwardCase("plain id unchanged",           "SNOMEDCT",            "SNOMEDCT"),
+		new ForwardCase("exactly 64 chars unchanged",   "a".repeat(64),        "a".repeat(64)),
+
+		// Rule 1: "/" -> "--"
+		new ForwardCase("single slash",                 "SNOMEDCT/20240101",   "SNOMEDCT--20240101"),
+		new ForwardCase("multiple slashes",             "a/b/c",               "a--b--c"),
+
+		// Rule 2: "--" -> ".h"
+		new ForwardCase("single double-dash",           "a--b",                "a.hb"),
+		new ForwardCase("multiple double-dashes",       "a--b--c",             "a.hb.hc"),
+
+		// Rule 3: "_" -> ".u"
+		new ForwardCase("single underscore",            "some_id",             "some.uid"),
+		new ForwardCase("multiple underscores",         "a_b_c",               "a.ub.uc"),
+
+		// Mixed: all three rules applied in a single pass
+		new ForwardCase("slash and double-dash",        "a/b--c",              "a--b.hc"),
+		new ForwardCase("slash and underscore",         "a/b_c",               "a--b.uc"),
+		new ForwardCase("double-dash and underscore",   "a--b_c",              "a.hb.uc"),
+		new ForwardCase("all three patterns",           "a/b--c_d",            "a--b.hc.ud"),
+
+		// No chaining: "/" must not produce ".h" via a second pass
+		new ForwardCase("slash does not chain to .h",   "a/b",                 "a--b")
+	);
+
+	private static final List<RoundTripCase> ROUND_TRIP_CASES = List.of(
+
+		new RoundTripCase(null,                 null),
+		new RoundTripCase("",                   ""),
+		new RoundTripCase("plain id",           "SNOMEDCT"),
+		new RoundTripCase("slash",              "SNOMEDCT/20240101"),
+		new RoundTripCase("multiple slashes",   "a/b/c"),
+		new RoundTripCase("double-dash",        "a--b"),
+		new RoundTripCase("underscore",         "some_id"),
+		new RoundTripCase("mixed patterns",     "a/b--c_d")
+	);
+
+	@Test
+	public void testForwardMapping() {
+		for (ForwardCase c : FORWARD_CASES) {
+			assertEquals(c.description(), c.expected(), 
+				FhirModelHelpers.toFhirResourceId(c.input()));
+		}
+	}
+
+	@Test
+	public void testRoundTrip() {
+		for (RoundTripCase c : ROUND_TRIP_CASES) {
+			assertEquals(c.description(), c.input(),
+				FhirModelHelpers.fromFhirResourceId(FhirModelHelpers.toFhirResourceId(c.input())));
+		}
+	}
+
+	@Test
+	public void testLongIdTruncatedWithHash() {
+		String longId = "a".repeat(65);
+		String fhirId = FhirModelHelpers.toFhirResourceId(longId);
+		
+		assertEquals(64, fhirId.length());
+		assertEquals("a".repeat(46), fhirId.substring(0, 46));
+		assertEquals(".c", fhirId.substring(46, 48));
+		
+		fhirId.substring(48).chars().forEach(ch ->
+			assertTrue("Expected hex digit, got: " + (char) ch,
+				(ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f')));
+	}
+
+	@Test
+	public void testLongIdHashIsDeterministic() {
+		assertEquals(
+			FhirModelHelpers.toFhirResourceId("x".repeat(65)),
+			FhirModelHelpers.toFhirResourceId("x".repeat(65)));
+	}
+
+	@Test
+	public void testLongIdSamePrefixProduceDifferentHashes() {
+		assertNotEquals(
+			FhirModelHelpers.toFhirResourceId("a".repeat(46) + "x".repeat(19)),
+			FhirModelHelpers.toFhirResourceId("a".repeat(46) + "y".repeat(19)));
+	}
+
+	@Test
+	public void testLongIdWithSubstitutionCausingTruncation() {
+		// 31 'a' + '/' + 32 'b' = 64 input chars; after substitution: 65 chars
+		String borderlineId = "a".repeat(31) + "/" + "b".repeat(32);
+		String fhirId = FhirModelHelpers.toFhirResourceId(borderlineId);
+		assertEquals(64, fhirId.length());
+		assertEquals(".c", fhirId.substring(46, 48));
+	}
+
+	@Test
+	public void testHashTruncatedReverseReturnsSuffix() {
+		// Only the 46-char prefix is recoverable
+		String longId = "a".repeat(65);
+		String fhirId = FhirModelHelpers.toFhirResourceId(longId);
+		assertEquals("a".repeat(46), FhirModelHelpers.fromFhirResourceId(fhirId));
+	}
+}

--- a/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/codesystem/FhirCodeSystemApiTest.java
+++ b/fhir/com.b2international.snowowl.fhir.rest.tests/src/com/b2international/snowowl/fhir/rest/tests/codesystem/FhirCodeSystemApiTest.java
@@ -42,6 +42,10 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 	
 	private static final int NUM_CONCEPTS = 1943;
 
+	private String getTestFhirId() {
+		return FhirModelHelpers.toFhirResourceId(getTestCodeSystemId());
+	}
+
 	@Test
 	public void GET_CodeSystem() throws Exception {
 		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
@@ -52,7 +56,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			.body("type", equalTo("searchset"))
 			.body("meta.tag.code", not(hasItem(FhirCodeSystems.CODING_SUBSETTED.getCode())))
 			.body("total", greaterThanOrEqualTo(1)) // actual number depends on test data, just verify existence
-			.body("entry[0].resource.id", equalTo(getTestCodeSystemId()))
+			.body("entry[0].resource.id", equalTo(getTestFhirId()))
 			.body("entry[0].resource.url", equalTo(FhirModelHelpers.SNOMED_BASE_URI_STRING))
 			.body("entry[0].resource.version", equalTo(getTestCodeSystemUrl()))
 			.body("entry[0].resource.valueSet", equalTo(String.join("?", getTestCodeSystemUrl(), SnomedUri.QueryPart.PREFIX_VS)))
@@ -88,7 +92,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 	@Test
 	public void GET_CodeSystem_IdFilter_Match() throws Exception {
 		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
-			.queryParam("_id", getTestCodeSystemId())
+			.queryParam("_id", getTestFhirId())
 			.when().get(CODESYSTEM)
 			.then().assertThat()
 			.statusCode(200)
@@ -105,7 +109,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 		String anotherCodeSystemId = createCodeSystem(UUID.randomUUID().toString());
 		String thirdCodeSystemId = createCodeSystem(UUID.randomUUID().toString());
 		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
-			.queryParam("_id", getTestCodeSystemId(), anotherCodeSystemId)
+			.queryParam("_id", getTestFhirId(), FhirModelHelpers.toFhirResourceId(anotherCodeSystemId))
 			.when().get(CODESYSTEM)
 			.then().assertThat()
 			.statusCode(200)
@@ -114,8 +118,8 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			.body("meta.tag.code", not(hasItem(FhirCodeSystems.CODING_SUBSETTED.getCode())))
 			.body("total", equalTo(2))
 			.body("entry.resource.id", allOf(
-				hasItems(getTestCodeSystemId(), anotherCodeSystemId), 
-				not(hasItem(thirdCodeSystemId))))
+				hasItems(getTestFhirId(), FhirModelHelpers.toFhirResourceId(anotherCodeSystemId)), 
+				not(hasItem(FhirModelHelpers.toFhirResourceId(thirdCodeSystemId)))))
 			.body("entry.resource.url", hasItem(FhirModelHelpers.SNOMED_BASE_URI_STRING))
 			.body("entry.resource.version", hasItem(getTestCodeSystemUrl()));
 	}
@@ -144,7 +148,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			.body("type", equalTo("searchset"))
 			.body("meta.tag.code", not(hasItem(FhirCodeSystems.CODING_SUBSETTED.getCode())))
 			.body("total", equalTo(1))
-			.body("entry[0].resource.id", equalTo(getTestCodeSystemId()))
+			.body("entry[0].resource.id", equalTo(getTestFhirId()))
 			.body("entry[0].resource.url", equalTo(FhirModelHelpers.SNOMED_BASE_URI_STRING))
 			.body("entry[0].resource.version", equalTo(getTestCodeSystemUrl()));
 	}
@@ -163,15 +167,15 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			.body("type", equalTo("searchset"))
 			.body("total", equalTo(2))
 			.body("entry.resource.id", allOf(
-				hasItems(getTestCodeSystemId(), anotherCodeSystemId),
-				not(hasItem(thirdCodeSystemId))))
+				hasItems(getTestFhirId(), FhirModelHelpers.toFhirResourceId(anotherCodeSystemId)),
+				not(hasItem(FhirModelHelpers.toFhirResourceId(thirdCodeSystemId)))))
 			.body("entry.resource.version", hasItem(getTestCodeSystemUrl()));
 	}
 	
 	@Test
 	public void GET_CodeSystem_Summary_True() throws Exception {
 		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
-			.queryParam("_id", getTestCodeSystemId())
+			.queryParam("_id", getTestFhirId())
 			.queryParam("_summary", true)
 			.when().get(CODESYSTEM)
 			.then().assertThat()
@@ -180,7 +184,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			.body("meta.tag.code", hasItem(FhirCodeSystems.CODING_SUBSETTED.getCode()))
 			.body("type", equalTo("searchset"))
 			.body("total", equalTo(1))
-			.body("entry[0].resource.id", equalTo(getTestCodeSystemId()))
+			.body("entry[0].resource.id", equalTo(getTestFhirId()))
 			.body("entry[0].resource.title", equalTo("Title of " + getTestCodeSystemId()))
 			.body("entry[0].resource.property", notNullValue())
 			.body("entry[0].resource.filter", notNullValue())
@@ -192,7 +196,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 	@Test
 	public void GET_CodeSystem_Summary_Text() throws Exception {
 		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
-			.queryParam("_id", getTestCodeSystemId())
+			.queryParam("_id", getTestFhirId())
 			.queryParam("_summary", "text")
 			.when().get(CODESYSTEM)
 			.then().assertThat()
@@ -202,7 +206,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			.body("type", equalTo("searchset"))
 			.body("total", equalTo(1))
 			// only text, id, meta and mandatory
-			.body("entry[0].resource.id", equalTo(getTestCodeSystemId()))
+			.body("entry[0].resource.id", equalTo(getTestFhirId()))
 			.body("entry[0].resource.status", equalTo("draft"))
 			.body("entry[0].resource.content", equalTo("complete"))
 			.body("entry[0].resource.meta", notNullValue())
@@ -217,7 +221,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 	@Test
 	public void GET_CodeSystem_Summary_Data() throws Exception {
 		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
-			.queryParam("_id", getTestCodeSystemId())
+			.queryParam("_id", getTestFhirId())
 			.queryParam("_summary", "data")
 			.when().get(CODESYSTEM)
 			.then().assertThat()
@@ -243,7 +247,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 	@Test
 	public void GET_CodeSystem_Summary_Count() throws Exception {
 		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
-			.queryParam("_id", getTestCodeSystemId())
+			.queryParam("_id", getTestFhirId())
 			.queryParam("_summary", "count")
 			.when().get(CODESYSTEM)
 			.then().assertThat()
@@ -258,7 +262,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 	@Test
 	public void GET_CodeSystem_Summary_False() throws Exception {
 		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
-			.queryParam("_id", getTestCodeSystemId())
+			.queryParam("_id", getTestFhirId())
 			.queryParam("_summary", false)
 			.when().get(CODESYSTEM)
 			.then().assertThat()
@@ -267,7 +271,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			.body("meta.tag.code", not(hasItem(FhirCodeSystems.CODING_SUBSETTED.getCode())))
 			.body("total", equalTo(1))
 			.body("type", equalTo("searchset"))
-			.body("entry[0].resource.id", equalTo(getTestCodeSystemId()))
+			.body("entry[0].resource.id", equalTo(getTestFhirId()))
 			.body("entry[0].resource.url", equalTo(FhirModelHelpers.SNOMED_BASE_URI_STRING))
 			.body("entry[0].resource.version", equalTo(getTestCodeSystemUrl()));
 	}
@@ -275,7 +279,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 	@Test
 	public void GET_CodeSystem_Elements() throws Exception {
 		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
-			.queryParam("_id", getTestCodeSystemId())
+			.queryParam("_id", getTestFhirId())
 			.queryParam("_elements", "name", "url")
 			.when().get(CODESYSTEM)
 			.then().assertThat() 
@@ -287,7 +291,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			// mandatory fields
 			.body("entry[0].resource.status", equalTo("draft"))
 			.body("entry[0].resource.content", equalTo("complete"))
-			.body("entry[0].resource.id", equalTo(getTestCodeSystemId()))
+			.body("entry[0].resource.id", equalTo(getTestFhirId()))
 			// returned because we need to calculate the concept count for the content property
 			.body("entry[0].resource.count", equalTo(NUM_CONCEPTS))
 			// summary and optional fields
@@ -302,7 +306,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 	@Test
 	public void GET_CodeSystem_multiple_Elements_stored_in_settings() throws Exception {
 		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
-			.queryParam("_id", getTestCodeSystemId())
+			.queryParam("_id", getTestFhirId())
 			// Both publisher and caseSensitive are stored settings, this case tests if issues arise when 
 			// the settings field is called multiple times
 			.queryParam("_elements", "publisher", "caseSensitive")
@@ -316,7 +320,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			// mandatory fields
 			.body("entry[0].resource.status", equalTo("draft"))
 			.body("entry[0].resource.content", equalTo("complete"))
-			.body("entry[0].resource.id", equalTo(getTestCodeSystemId()))
+			.body("entry[0].resource.id", equalTo(getTestFhirId()))
 			// returned because we need to calculate the concept count for the content property
 			.body("entry[0].resource.count", equalTo(NUM_CONCEPTS))
 			// summary and optional fields
@@ -331,7 +335,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 	@Test
 	public void GET_CodeSystem_ElementsMixedWithSummaryFields() throws Exception {
 		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
-			.queryParam("_id", getTestCodeSystemId())
+			.queryParam("_id", getTestFhirId())
 			.queryParam("_elements", 
 				R5ObjectFields.CodeSystem.ID, 
 				R5ObjectFields.CodeSystem.META, 
@@ -349,7 +353,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			.body("total", equalTo(1))
 			.body("type", equalTo("searchset"))
 			// mandatory fields
-			.body("entry[0].resource.id", equalTo(getTestCodeSystemId()))
+			.body("entry[0].resource.id", equalTo(getTestFhirId()))
 			.body("entry[0].resource.status", equalTo("draft"))
 			.body("entry[0].resource.content", equalTo("complete"))
 			// requested fields
@@ -423,7 +427,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			.body("meta.tag.code", not(hasItem(FhirCodeSystems.CODING_SUBSETTED.getCode())))
 			.body("total", equalTo(1))
 			.body("type", equalTo("searchset"))
-			.body("entry[0].resource.id", equalTo("SNOMEDCT/2002-01-31"))
+			.body("entry[0].resource.id", equalTo(FhirModelHelpers.toFhirResourceId("SNOMEDCT/2002-01-31")))
 			.body("entry[0].resource.url", equalTo(FhirModelHelpers.SNOMED_BASE_URI_STRING))
 			.body("entry[0].resource.valueSet", equalTo(SNOMEDCT_URL + "/version/20020131?fhir_vs"))
 			.body("entry[0].resource.version", equalTo(SNOMEDCT_URL + "/version/20020131"))
@@ -441,12 +445,12 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			.body("meta.tag.code", not(hasItem(FhirCodeSystems.CODING_SUBSETTED.getCode())))
 			.body("total", equalTo(2))
 			.body("type", equalTo("searchset"))
-			.body("entry[0].resource.id", equalTo("SNOMEDCT/2002-01-31"))
+			.body("entry[0].resource.id", equalTo(FhirModelHelpers.toFhirResourceId("SNOMEDCT/2002-01-31")))
 			.body("entry[0].resource.url", equalTo(FhirModelHelpers.SNOMED_BASE_URI_STRING))
 			.body("entry[0].resource.valueSet", equalTo(SNOMEDCT_URL + "/version/20020131?fhir_vs"))
 			.body("entry[0].resource.version", equalTo(SNOMEDCT_URL + "/version/20020131"))
 			.body("entry[0].resource.date", equalTo("2002-01-31T00:00:00Z"))
-			.body("entry[1].resource.id", equalTo("SNOMEDCT/2020-01-31"))
+			.body("entry[1].resource.id", equalTo(FhirModelHelpers.toFhirResourceId("SNOMEDCT/2020-01-31")))
 			.body("entry[1].resource.url", equalTo(FhirModelHelpers.SNOMED_BASE_URI_STRING))
 			.body("entry[1].resource.valueSet", equalTo(SNOMEDCT_URL + "/version/20200131?fhir_vs"))
 			.body("entry[1].resource.version", equalTo(SNOMEDCT_URL + "/version/20200131"))
@@ -481,7 +485,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			.body("meta.tag.code", not(hasItem(FhirCodeSystems.CODING_SUBSETTED.getCode())))
 			.body("total", equalTo(1))
 			.body("type", equalTo("searchset"))
-			.body("entry[0].resource.id", equalTo("GET_CodeSystem_Status_Match_Single"))
+			.body("entry[0].resource.id", equalTo(FhirModelHelpers.toFhirResourceId("GET_CodeSystem_Status_Match_Single")))
 			.body("entry[0].resource.url", equalTo(FhirModelHelpers.SNOMED_BASE_URI_STRING))
 			.body("entry[0].resource.version", equalTo(getTestCodeSystemUrl()))
 			// This is the PublicationStatus code "mysterious" maps to
@@ -503,7 +507,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 			.body("meta.tag.code", not(hasItem(FhirCodeSystems.CODING_SUBSETTED.getCode())))
 			.body("total", equalTo(39))
 			.body("type", equalTo("searchset"))
-			.body("entry[0].resource.id", equalTo("GET_CodeSystem_Status_Match_Multiple"))
+			.body("entry[0].resource.id", equalTo(FhirModelHelpers.toFhirResourceId("GET_CodeSystem_Status_Match_Multiple")))
 			.body("entry[0].resource.url", equalTo(FhirModelHelpers.SNOMED_BASE_URI_STRING))
 			.body("entry[0].resource.version", equalTo(getTestCodeSystemUrl()))
 			// This is the PublicationStatus code "mysterious" maps to
@@ -517,11 +521,11 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 	@Test
 	public void GET_CodeSystemId() throws Exception {
 		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
-			.when().get(CODESYSTEM_ID, getTestCodeSystemId())
+			.when().get(CODESYSTEM_ID, getTestFhirId())
 			.then().assertThat()
 			.statusCode(200)
 			.body("resourceType", equalTo("CodeSystem"))
-			.body("id", equalTo(getTestCodeSystemId()))
+			.body("id", equalTo(getTestFhirId()))
 			.body("url", equalTo(FhirModelHelpers.SNOMED_BASE_URI_STRING))
 			.body("version", equalTo(getTestCodeSystemUrl()))
 			.body("status", equalTo("draft"));
@@ -530,11 +534,11 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 	@Test
 	public void GET_CodeSystemId_Versioned() throws Exception {
 		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
-			.when().get(CODESYSTEM_ID, "SNOMEDCT/2002-01-31")
+			.when().get(CODESYSTEM_ID, FhirModelHelpers.toFhirResourceId("SNOMEDCT/2002-01-31"))
 			.then().assertThat()
 			.statusCode(200)
 			.body("resourceType", equalTo("CodeSystem"))
-			.body("id", equalTo("SNOMEDCT/2002-01-31"))
+			.body("id", equalTo(FhirModelHelpers.toFhirResourceId("SNOMEDCT/2002-01-31")))
 			.body("url", equalTo(FhirModelHelpers.SNOMED_BASE_URI_STRING))
 			.body("status", equalTo("active"))
 			.body("version", equalTo(SNOMEDCT_URL + "/version/20020131"))
@@ -550,7 +554,7 @@ public class FhirCodeSystemApiTest extends FhirRestTest {
 	public void GET_CodeSystemId_Summary_Count_BadRequest() {
 		givenAuthenticatedRequest(FHIR_ROOT_CONTEXT)
 			.queryParam("_summary", "count")
-			.when().get(CODESYSTEM_ID, getTestCodeSystemId())
+			.when().get(CODESYSTEM_ID, getTestFhirId())
 			.then().assertThat()
 			.statusCode(400)
 			.body("resourceType", equalTo("OperationOutcome"))


### PR DESCRIPTION
## Constraints on allowed values
(note that `\` only appears to escape the dash in regexp character class expressions)

- **Branch names**: allowed characters are `[a-zA-Z0-9._~\-]` with 100 characters limit
- **Native resource IDs**: allowed characters are `[A-Za-z0-9\-_]` with no length limit
  - in practice rules on branch names also apply
- Special resource IDs for **versioned resources**: contain single `/` character separating resource and version identifiers
  - first part should adhere to native resource ID rules
  - second part should adhere to branch name rules
  - maximum combined length is 100 + 1 + 100 characters
- **FHIR identifiers**: allowed characters are `[A-Za-z0-9\-.]` with 64 characters limit

## Proposed mapping rules
Evaluated in order in a left-to-right pass (no stacking of multiple rules:

1. Each occurrence of `"/"` is replaced with `"--"`
2. Each occurrence of `"--"` is replaced with `".h"`
3. Each occurrence of `"_"` is replaced with `".u"`

If the resulting ID would be longer than 64 characters, return the first 46 characters of the result, then `".c"`, then 16 hex digits of a [SipHash-2-4](https://en.wikipedia.org/wiki/SipHash) tag of the original input to ensure uniqueness while retaining a recoverable prefix of the original ID. 

If none of the rules match, the input is returned unmodified.

Jira: 
- https://snowowl.atlassian.net/browse/SO-6576