### PR TITLE
Release scanned classpath entries after boot phase

### DIFF
--- a/cis/com.b2international.snowowl.snomed.cis/src/com/b2international/snowowl/snomed/cis/SnomedIdentifierPlugin.java
+++ b/cis/com.b2international.snowowl.snomed.cis/src/com/b2international/snowowl/snomed/cis/SnomedIdentifierPlugin.java
@@ -30,6 +30,7 @@ import com.b2international.index.mapping.Mappings;
 import com.b2international.snowowl.core.config.IndexSettings;
 import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.config.SnowOwlConfiguration;
+import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.b2international.snowowl.core.plugin.Component;
 import com.b2international.snowowl.core.setup.ConfigurationRegistry;
 import com.b2international.snowowl.core.setup.Environment;
@@ -61,7 +62,7 @@ public final class SnomedIdentifierPlugin extends Plugin {
 	}
 	
 	@Override
-	public void init(final SnowOwlConfiguration configuration, final Environment env) throws Exception {
+	public void init(final SnowOwlConfiguration configuration, final Environment env, ClassPathScanner scanner) throws Exception {
 		checkIdGenerationSource(configuration);
 
 		final ISnomedIdentifierReservationService reservationService = new SnomedIdentifierReservationServiceImpl();
@@ -71,7 +72,7 @@ public final class SnomedIdentifierPlugin extends Plugin {
 	}
 
 	@Override
-	public void run(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public void run(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 		if (env.isServer()) {
 			final ISnomedIdentifierReservationService reservationService = env.service(ISnomedIdentifierReservationService.class);
 			final SnomedIdentifierConfiguration conf = configuration.getModuleConfig(SnomedIdentifierConfiguration.class);

--- a/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/validation/issue/ValidationIssueApiTest.java
+++ b/core/com.b2international.snowowl.core.tests/src/com/b2international/snowowl/core/validation/issue/ValidationIssueApiTest.java
@@ -64,7 +64,6 @@ public class ValidationIssueApiTest extends BaseElasticsearchAwareTest {
 		final ValidationRepository repository = new ValidationRepository(index);
 		final ClassPathScanner scanner = new ClassPathScanner("com.b2international");
 		context = ServiceProvider.EMPTY.inject()
-				.bind(ClassPathScanner.class, scanner)
 				.bind(ValidationRepository.class, repository)
 				.bind(ValidationIssueDetailExtensionProvider.class, new ValidationIssueDetailExtensionProvider(scanner))
 				.bind(ResourceURIPathResolver.class, ResourceURIPathResolver.fromMap(Map.of("SNOMEDCT", Branch.MAIN_PATH)))

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/SnowOwl.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/SnowOwl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2011-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,9 +28,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.URIUtil;
+import org.eclipse.core.runtime.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,6 +84,8 @@ public final class SnowOwl {
 	private SnowOwlConfiguration configuration;
 	private Logger log;
 
+	private ClassPathScanner scanner;
+
 	private SnowOwl(Plugin...additionalPlugins) throws Exception {
 		final Path homePath = getHomePath();
 		// make sure homePath sysprop is set to the computed path
@@ -119,11 +119,11 @@ public final class SnowOwl {
 		}
 		
 		// register classpath scanner as the first item in the context so other services will be discovered properly
-		final ClassPathScanner scanner = new ClassPathScanner(packagesToScan.toArray(String[]::new));
-		ApplicationContext.getInstance().registerService(ClassPathScanner.class, scanner);
+		// do NOT register the scanner into the injection context, we will destroy the scan result to gain back memory
+		this.scanner = new ClassPathScanner(packagesToScan.toArray(String[]::new));
 		
 		List<Plugin> plugins = ImmutableList.<Plugin>builder()
-			.addAll(scanner.getComponentsBySuperclass(Plugin.class))
+			.addAll(this.scanner.getComponentsBySuperclass(Plugin.class))
 			.add(additionalPlugins != null ? additionalPlugins : new Plugin[]{})
 			.build();
 		this.plugins = new Plugins(plugins);
@@ -235,7 +235,7 @@ public final class SnowOwl {
 	public SnowOwl bootstrap() throws Exception {
 		if (!isRunning()) {
 			log.info("Initializing...");
-			this.plugins.init(this.configuration, this.environment);
+			this.plugins.init(this.configuration, this.environment, this.scanner);
 			// after init set the mode to SERVER if not already set by something else
 			if (this.environment.services().getService(Mode.class) == null) {
 				this.environment.services().registerService(Mode.class, Mode.SERVER); // by default assume Snow Owl is in server mode
@@ -301,16 +301,18 @@ public final class SnowOwl {
 		if (!isRunning()) {
 			checkState(plugins != null, "Bootstrap the application first");
 			if (preRunCompleted.compareAndSet(false, true)) {
-				this.plugins.preRun(configuration, environment);
+				this.plugins.preRun(configuration, environment, scanner);
 			}
 			if (preRunRunnable != null) {
 				preRunRunnable.run();
 			}
 			log.info("Preparing to run Snow Owl...");
-			this.plugins.run(configuration, environment);
+			this.plugins.run(configuration, environment, scanner);
 			checkApplicationState();
 			running.set(true);
-			this.plugins.postRun(configuration, environment);
+			this.plugins.postRun(configuration, environment, scanner);
+			// destroy the scanner and its result to gain back memory
+			this.scanner = null;
 			log.info("Snow Owl successfully started.");
 		} else {
 			log.info("Snow Owl is already running.");

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/SnowOwl.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/SnowOwl.java
@@ -122,6 +122,9 @@ public final class SnowOwl {
 		// do NOT register the scanner into the injection context, we will destroy the scan result to gain back memory
 		this.scanner = new ClassPathScanner(packagesToScan.toArray(String[]::new));
 		
+		// temporarily register the scanner into the app context, so that various config deserialization classes work as expected
+		ApplicationContext.getInstance().registerService(ClassPathScanner.class, this.scanner);
+		
 		List<Plugin> plugins = ImmutableList.<Plugin>builder()
 			.addAll(this.scanner.getComponentsBySuperclass(Plugin.class))
 			.add(additionalPlugins != null ? additionalPlugins : new Plugin[]{})
@@ -137,6 +140,9 @@ public final class SnowOwl {
 		// log environment and setting info
 		logEnvironment();
 		this.plugins.getPlugins().forEach(plugin -> log.info("loaded plugin [{}]", plugin));
+		
+		// once all plugins are parsed, remove the scanner from the global context
+		ApplicationContext.getInstance().unregisterService(ClassPathScanner.class);
 	}
 	
 	private Path getHomePath() {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/attachments/AttachmentPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/attachments/AttachmentPlugin.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 
 import com.b2international.snowowl.core.client.TransportConfiguration;
 import com.b2international.snowowl.core.config.SnowOwlConfiguration;
+import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.b2international.snowowl.core.plugin.Component;
 import com.b2international.snowowl.core.setup.Environment;
 import com.b2international.snowowl.core.setup.Plugin;
@@ -33,7 +34,7 @@ public final class AttachmentPlugin extends Plugin {
 	private static final String ATTACHMENTS_FOLDER = "attachments";
 
 	@Override
-	public void preRun(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public void preRun(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 		final IEventBus bus = env.service(IEventBus.class);
 		
 		if (env.isServer()) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/console/CommandRegistry.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/console/CommandRegistry.java
@@ -15,30 +15,16 @@
  */
 package com.b2international.snowowl.core.console;
 
-import java.util.Collection;
-
-import com.b2international.snowowl.core.api.SnowowlRuntimeException;
 import com.b2international.snowowl.core.plugin.ClassPathScanner;
+import com.b2international.snowowl.core.plugin.PluggableServiceRegistry;
 
 /**
  * @since 10.2.0
  */
-public final class PluginCommandProvider {
+public final class CommandRegistry extends PluggableServiceRegistry<Command> {
 
-	private final Collection<Class<?>> commandClasses;
-
-	public PluginCommandProvider(ClassPathScanner scanner) {
-		this.commandClasses = scanner.getComponentsClassesBySuperclass(Command.class);
-	}
-	
-	public Collection<Command> getCommands() {
-		return commandClasses.stream().map(commandClass -> {
-			try {
-				return (Command) commandClass.getConstructor().newInstance();
-			} catch (Throwable e) {
-				throw new SnowowlRuntimeException("Unable to instantiate command class: " + commandClass, e);
-			}
-		}).toList();
+	public CommandRegistry(ClassPathScanner scanner) {
+		super(scanner);
 	}
 	
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/console/PluginCommandProvider.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/console/PluginCommandProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 B2i Healthcare, https://b2ihealthcare.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.console;
+
+import java.util.Collection;
+
+import com.b2international.snowowl.core.api.SnowowlRuntimeException;
+import com.b2international.snowowl.core.plugin.ClassPathScanner;
+
+/**
+ * @since 10.2.0
+ */
+public final class PluginCommandProvider {
+
+	private final Collection<Class<?>> commandClasses;
+
+	public PluginCommandProvider(ClassPathScanner scanner) {
+		this.commandClasses = scanner.getComponentsClassesBySuperclass(Command.class);
+	}
+	
+	public Collection<Command> getCommands() {
+		return commandClasses.stream().map(commandClass -> {
+			try {
+				return (Command) commandClass.getConstructor().newInstance();
+			} catch (Throwable e) {
+				throw new SnowowlRuntimeException("Unable to instantiate command class: " + commandClass, e);
+			}
+		}).toList();
+	}
+	
+}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/console/SnowOwlCommandProvider.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/console/SnowOwlCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2018-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import org.eclipse.osgi.framework.console.CommandProvider;
 import com.b2international.snowowl.core.ApplicationContext;
 import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.identity.User;
-import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.b2international.snowowl.core.repository.RepositoryRequests;
 import com.b2international.snowowl.core.setup.Environment;
 import com.b2international.snowowl.eventbus.IEventBus;
@@ -109,7 +108,7 @@ public final class SnowOwlCommandProvider implements CommandProvider {
 		final CommandLine cli = new CommandLine(new SnowOwlCommand());
 		cli.setUsageHelpWidth(USAGE_WIDTH);
 		cli.addSubcommand("help", new CommandLine.HelpCommand());
-		context.service(ClassPathScanner.class).getComponentsBySuperclass(Command.class)
+		context.service(PluginCommandProvider.class).getCommands()
 			.stream()
 			.sorted(Ordering.natural().onResultOf(Command::getCommand))
 			.forEach(cmd -> {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/console/SnowOwlCommandProvider.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/console/SnowOwlCommandProvider.java
@@ -108,7 +108,7 @@ public final class SnowOwlCommandProvider implements CommandProvider {
 		final CommandLine cli = new CommandLine(new SnowOwlCommand());
 		cli.setUsageHelpWidth(USAGE_WIDTH);
 		cli.addSubcommand("help", new CommandLine.HelpCommand());
-		context.service(PluginCommandProvider.class).getCommands()
+		context.service(CommandRegistry.class).get()
 			.stream()
 			.sorted(Ordering.natural().onResultOf(Command::getCommand))
 			.forEach(cmd -> {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ecl/EclPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/ecl/EclPlugin.java
@@ -21,6 +21,7 @@ import org.eclipse.xtext.validation.IResourceValidator;
 
 import com.b2international.snomed.ecl.EclStandaloneSetup;
 import com.b2international.snowowl.core.config.SnowOwlConfiguration;
+import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.b2international.snowowl.core.plugin.Component;
 import com.b2international.snowowl.core.setup.Environment;
 import com.b2international.snowowl.core.setup.Plugin;
@@ -33,7 +34,7 @@ import com.google.inject.Injector;
 public class EclPlugin extends Plugin {
 
 	@Override
-	public void init(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public void init(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 		final Injector injector = new EclStandaloneSetup().createInjectorAndDoEMFRegistration();
 		env.services().registerService(EclParser.class, new DefaultEclParser(injector.getInstance(IParser.class), injector.getInstance(IResourceValidator.class)));
 		env.services().registerService(EclSerializer.class, new DefaultEclSerializer(injector.getInstance(ISerializer.class)));

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/IdentityPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/IdentityPlugin.java
@@ -51,7 +51,7 @@ public final class IdentityPlugin extends Plugin {
 	}
 	
 	@Override
-	public void init(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public void init(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 		final IdentityConfiguration conf = configuration.getModuleConfig(IdentityConfiguration.class);
 		IdentityProvider identityProvider = initIdentityProvider(env, conf);
 		

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/IdentityProviderConfig.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/identity/IdentityProviderConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2017-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ public interface IdentityProviderConfig {
 
 		public IdentityProviderTypeIdResolver() throws IOException {
 			this.subTypeCache = Suppliers.memoize(() -> {
+				// XXX this is used very early in the app before any plugin gets recognized even, classpath scanner should be available globally at this time
 				return IdentityPlugin.getAvailableConfigClasses(ApplicationContext.getInstance().getServiceChecked(ClassPathScanner.class)).stream() 
 					.filter(this::isValid)
 					.collect(Collectors.toMap(this::getType, Function.identity()));	

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/SnowOwlPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/SnowOwlPlugin.java
@@ -17,9 +17,7 @@ package com.b2international.snowowl.core.internal;
 
 import static com.google.common.collect.Maps.newHashMapWithExpectedSize;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.b2international.collections.PrimitiveCollectionModule;
@@ -27,47 +25,29 @@ import com.b2international.commons.metric.Metrics;
 import com.b2international.index.Index;
 import com.b2international.index.Indexes;
 import com.b2international.index.mapping.Mappings;
-import com.b2international.index.revision.DefaultRevisionIndex;
-import com.b2international.index.revision.RevisionBranch;
+import com.b2international.index.revision.*;
 import com.b2international.index.revision.RevisionBranch.BranchNameValidator;
-import com.b2international.index.revision.RevisionIndex;
-import com.b2international.index.revision.TimestampProvider;
-import com.b2international.snowowl.core.DeprecationLogger;
-import com.b2international.snowowl.core.ResourceTypeConverter;
-import com.b2international.snowowl.core.ResourceURI;
+import com.b2international.snowowl.core.*;
 import com.b2international.snowowl.core.collection.TerminologyResourceCollectionToolingSupport;
-import com.b2international.snowowl.core.config.IndexSettings;
-import com.b2international.snowowl.core.config.RepositoryConfiguration;
-import com.b2international.snowowl.core.config.SnowOwlConfiguration;
+import com.b2international.snowowl.core.config.*;
 import com.b2international.snowowl.core.console.PluginCommandProvider;
 import com.b2international.snowowl.core.monitoring.MonitoringConfiguration;
 import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.b2international.snowowl.core.plugin.Component;
-import com.b2international.snowowl.core.repository.JsonSupport;
-import com.b2international.snowowl.core.repository.ObjectMapperCustomizer;
-import com.b2international.snowowl.core.repository.PathTerminologyResourceResolver;
+import com.b2international.snowowl.core.repository.*;
 import com.b2international.snowowl.core.request.suggest.ConceptSuggester;
-import com.b2international.snowowl.core.setup.ConfigurationRegistry;
-import com.b2international.snowowl.core.setup.Environment;
-import com.b2international.snowowl.core.setup.Plugin;
+import com.b2international.snowowl.core.setup.*;
 import com.b2international.snowowl.core.terminology.TerminologyRegistry;
-import com.b2international.snowowl.core.uri.DefaultResourceURIPathResolver;
-import com.b2international.snowowl.core.uri.ResourceURIPathResolver;
-import com.b2international.snowowl.core.uri.TerminologyResourceURIPathResolver;
+import com.b2international.snowowl.core.uri.*;
 import com.b2international.snowowl.core.version.VersionDocument;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.jvm.*;
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
-import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
-import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
-import io.micrometer.core.instrument.binder.system.UptimeMetrics;
+import io.micrometer.core.instrument.binder.system.*;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
@@ -81,10 +61,8 @@ public final class SnowOwlPlugin extends Plugin {
 	private static final String RESOURCES_INDEX = "resources";
 
 	@Override
-	public void init(SnowOwlConfiguration configuration, Environment env) {
+	public void init(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) {
 		env.services().registerService(DeprecationLogger.class, new DeprecationLogger());
-		
-		final ClassPathScanner scanner = env.service(ClassPathScanner.class);
 		
 		final ObjectMapper mapper = JsonSupport.getDefaultObjectMapper();
 		mapper.registerModule(new PrimitiveCollectionModule());
@@ -130,7 +108,7 @@ public final class SnowOwlPlugin extends Plugin {
 	}
 	
 	@Override
-	public void preRun(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public void preRun(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 		if (env.isServer()) {
 			
 			final ObjectMapper mapper = env.service(ObjectMapper.class);

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/SnowOwlPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/SnowOwlPlugin.java
@@ -39,6 +39,7 @@ import com.b2international.snowowl.core.collection.TerminologyResourceCollection
 import com.b2international.snowowl.core.config.IndexSettings;
 import com.b2international.snowowl.core.config.RepositoryConfiguration;
 import com.b2international.snowowl.core.config.SnowOwlConfiguration;
+import com.b2international.snowowl.core.console.PluginCommandProvider;
 import com.b2international.snowowl.core.monitoring.MonitoringConfiguration;
 import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.b2international.snowowl.core.plugin.Component;
@@ -100,6 +101,7 @@ public final class SnowOwlPlugin extends Plugin {
 		env.services().registerService(ResourceTypeConverter.Registry.class, new ResourceTypeConverter.Registry(scanner));
 		env.services().registerService(ConceptSuggester.Registry.class, new ConceptSuggester.Registry(scanner, mapper));
 		env.services().registerService(TerminologyResourceCollectionToolingSupport.Registry.class, new TerminologyResourceCollectionToolingSupport.Registry(scanner));
+		env.services().registerService(PluginCommandProvider.class, new PluginCommandProvider(scanner));
 		
 		// configure global branch name validator
 		env.services().registerService(BranchNameValidator.class, new BranchNameValidator.Default(

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/SnowOwlPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/SnowOwlPlugin.java
@@ -17,7 +17,9 @@ package com.b2international.snowowl.core.internal;
 
 import static com.google.common.collect.Maps.newHashMapWithExpectedSize;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.b2international.collections.PrimitiveCollectionModule;
@@ -25,29 +27,48 @@ import com.b2international.commons.metric.Metrics;
 import com.b2international.index.Index;
 import com.b2international.index.Indexes;
 import com.b2international.index.mapping.Mappings;
-import com.b2international.index.revision.*;
+import com.b2international.index.revision.DefaultRevisionIndex;
+import com.b2international.index.revision.RevisionBranch;
 import com.b2international.index.revision.RevisionBranch.BranchNameValidator;
-import com.b2international.snowowl.core.*;
+import com.b2international.index.revision.RevisionIndex;
+import com.b2international.index.revision.TimestampProvider;
+import com.b2international.snowowl.core.DeprecationLogger;
+import com.b2international.snowowl.core.ResourceTypeConverter;
+import com.b2international.snowowl.core.ResourceURI;
 import com.b2international.snowowl.core.collection.TerminologyResourceCollectionToolingSupport;
-import com.b2international.snowowl.core.config.*;
-import com.b2international.snowowl.core.console.PluginCommandProvider;
+import com.b2international.snowowl.core.config.IndexSettings;
+import com.b2international.snowowl.core.config.RepositoryConfiguration;
+import com.b2international.snowowl.core.config.SnowOwlConfiguration;
+import com.b2international.snowowl.core.console.CommandRegistry;
 import com.b2international.snowowl.core.monitoring.MonitoringConfiguration;
 import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.b2international.snowowl.core.plugin.Component;
-import com.b2international.snowowl.core.repository.*;
+import com.b2international.snowowl.core.repository.JsonSupport;
+import com.b2international.snowowl.core.repository.ObjectMapperCustomizer;
+import com.b2international.snowowl.core.repository.PathTerminologyResourceResolver;
+import com.b2international.snowowl.core.request.expand.ResourceExpanderExtension;
 import com.b2international.snowowl.core.request.suggest.ConceptSuggester;
-import com.b2international.snowowl.core.setup.*;
+import com.b2international.snowowl.core.setup.ConfigurationRegistry;
+import com.b2international.snowowl.core.setup.Environment;
+import com.b2international.snowowl.core.setup.Plugin;
 import com.b2international.snowowl.core.terminology.TerminologyRegistry;
-import com.b2international.snowowl.core.uri.*;
+import com.b2international.snowowl.core.uri.DefaultResourceURIPathResolver;
+import com.b2international.snowowl.core.uri.ResourceURIPathResolver;
+import com.b2international.snowowl.core.uri.TerminologyResourceURIPathResolver;
 import com.b2international.snowowl.core.version.VersionDocument;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.binder.jvm.*;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
-import io.micrometer.core.instrument.binder.system.*;
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
@@ -79,7 +100,8 @@ public final class SnowOwlPlugin extends Plugin {
 		env.services().registerService(ResourceTypeConverter.Registry.class, new ResourceTypeConverter.Registry(scanner));
 		env.services().registerService(ConceptSuggester.Registry.class, new ConceptSuggester.Registry(scanner, mapper));
 		env.services().registerService(TerminologyResourceCollectionToolingSupport.Registry.class, new TerminologyResourceCollectionToolingSupport.Registry(scanner));
-		env.services().registerService(PluginCommandProvider.class, new PluginCommandProvider(scanner));
+		env.services().registerService(CommandRegistry.class, new CommandRegistry(scanner));
+		env.services().registerService(ResourceExpanderExtension.Registry.class, new ResourceExpanderExtension.Registry(scanner));
 		
 		// configure global branch name validator
 		env.services().registerService(BranchNameValidator.class, new BranchNameValidator.Default(

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/locks/LockPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/locks/LockPlugin.java
@@ -24,6 +24,7 @@ import com.b2international.snowowl.core.config.SnowOwlConfiguration;
 import com.b2international.snowowl.core.locks.DatastoreLockIndexEntry;
 import com.b2international.snowowl.core.locks.DefaultOperationLockManager;
 import com.b2international.snowowl.core.locks.IOperationLockManager;
+import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.b2international.snowowl.core.plugin.Component;
 import com.b2international.snowowl.core.setup.Environment;
 import com.b2international.snowowl.core.setup.Plugin;
@@ -39,7 +40,7 @@ public final class LockPlugin extends Plugin {
 	private static final String LOCKS_INDEX = "locks";
 
 	@Override
-	public void preRun(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public void preRun(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 		if (env.isServer()) {
 			final Index locksIndex = Indexes.createIndex(
 				LOCKS_INDEX, 

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/validation/ValidationPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/internal/validation/ValidationPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2017-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public final class ValidationPlugin extends Plugin {
 	}
 	
 	@Override
-	public void preRun(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public void preRun(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 		if (env.isServer()) {
 			final List<Path> validationDirectories = new ArrayList<>();
 			// default directory is the server configuration dir
@@ -111,7 +111,7 @@ public final class ValidationPlugin extends Plugin {
 			
 			env.services().registerService(ValidationConfiguration.class, validationConfig);
 			env.services().registerService(ValidationThreadPool.class, new ValidationThreadPool(workerPoolSize, maxConcurrentExpensiveJobs, maxConcurrentNormalJobs));
-			env.services().registerService(ValidationIssueDetailExtensionProvider.class, new ValidationIssueDetailExtensionProvider(env.service(ClassPathScanner.class)));
+			env.services().registerService(ValidationIssueDetailExtensionProvider.class, new ValidationIssueDetailExtensionProvider(scanner));
 			
 			final List<File> listOfFiles = validationDirectories.stream().flatMap(path -> Arrays.asList(path.toFile().listFiles()).stream()).toList();
 			final Set<File> validationRuleFiles = Sets.newHashSet();

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/plugin/PluggableServiceRegistry.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/plugin/PluggableServiceRegistry.java
@@ -33,8 +33,8 @@ public abstract class PluggableServiceRegistry<T> {
 	
 	public PluggableServiceRegistry(ClassPathScanner scanner) {
 		final Class<?>[] types = TypeResolver.resolveRawArguments(PluggableServiceRegistry.class, getClass());
-		checkState(TypeResolver.Unknown.class != types[1], "Couldn't resolve type for class %s", getClass().getSimpleName());
-		var pluggableClass = (Class<T>) types[1];
+		checkState(TypeResolver.Unknown.class != types[0], "Couldn't resolve type for class %s", getClass().getSimpleName());
+		var pluggableClass = (Class<T>) types[0];
 		if (pluggableClass.isInterface()) {
 			this.classes = scanner.getComponentsClassesByInterface(pluggableClass);
 		} else {
@@ -43,14 +43,13 @@ public abstract class PluggableServiceRegistry<T> {
 	}
 	
 	public Collection<T> get() {
-		return classes.stream().map(commandClass -> {
+		return classes.stream().map(klass -> {
 			try {
-				return (T) commandClass.getConstructor().newInstance();
+				return (T) klass.getConstructor().newInstance();
 			} catch (Throwable e) {
-				throw new SnowowlRuntimeException("Unable to instantiate command class: " + commandClass, e);
+				throw new SnowowlRuntimeException("Unable to instantiate registry class: " + klass, e);
 			}
 		}).toList();
 	}
 	
 }
-

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/plugin/PluggableServiceRegistry.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/plugin/PluggableServiceRegistry.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 B2i Healthcare, https://b2ihealthcare.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.core.plugin;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.Collection;
+
+import com.b2international.snowowl.core.api.SnowowlRuntimeException;
+
+import net.jodah.typetools.TypeResolver;
+
+/**
+ * @since 10.2.0
+ * @param <T>
+ */
+public abstract class PluggableServiceRegistry<T> {
+	
+	private final Collection<Class<?>> classes;
+	
+	public PluggableServiceRegistry(ClassPathScanner scanner) {
+		final Class<?>[] types = TypeResolver.resolveRawArguments(PluggableServiceRegistry.class, getClass());
+		checkState(TypeResolver.Unknown.class != types[1], "Couldn't resolve type for class %s", getClass().getSimpleName());
+		var pluggableClass = (Class<T>) types[1];
+		if (pluggableClass.isInterface()) {
+			this.classes = scanner.getComponentsClassesByInterface(pluggableClass);
+		} else {
+			this.classes = scanner.getComponentsClassesBySuperclass(pluggableClass);
+		}
+	}
+	
+	public Collection<T> get() {
+		return classes.stream().map(commandClass -> {
+			try {
+				return (T) commandClass.getConstructor().newInstance();
+			} catch (Throwable e) {
+				throw new SnowowlRuntimeException("Unable to instantiate command class: " + commandClass, e);
+			}
+		}).toList();
+	}
+	
+}
+

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/ApiPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/rate/ApiPlugin.java
@@ -16,6 +16,7 @@
 package com.b2international.snowowl.core.rate;
 
 import com.b2international.snowowl.core.config.SnowOwlConfiguration;
+import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.b2international.snowowl.core.plugin.Component;
 import com.b2international.snowowl.core.setup.ConfigurationRegistry;
 import com.b2international.snowowl.core.setup.Environment;
@@ -34,7 +35,7 @@ public class ApiPlugin extends Plugin {
 	}
 	
 	@Override
-	public void init(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public void init(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 		ApiConfiguration apiConfig = configuration.getModuleConfig(ApiConfiguration.class);
 		env.services().registerService(ApiConfiguration.class, apiConfig);
 		initRateLimiter(env, apiConfig.getRateLimit());

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryBuilder.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2011-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,9 +96,9 @@ public final class RepositoryBuilder {
 		return this;
 	}
 	
-	public Repository build(Environment env) {
+	public Repository build(Environment env, ClassPathScanner scanner) {
 		// get all repository configuration plugins and apply them to customize the repository
-		List<TerminologyRepositoryConfigurer> repositoryConfigurers = env.service(ClassPathScanner.class).getComponentsByInterface(TerminologyRepositoryConfigurer.class)
+		List<TerminologyRepositoryConfigurer> repositoryConfigurers = scanner.getComponentsByInterface(TerminologyRepositoryConfigurer.class)
 			.stream()
 			.filter(configurer -> repositoryId.equals(configurer.getToolingId()))
 			.collect(Collectors.toList());

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/RepositoryPlugin.java
@@ -41,6 +41,7 @@ import com.b2international.snowowl.core.events.Notifications;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.jobs.RemoteJobEntry;
 import com.b2international.snowowl.core.jobs.RemoteJobTracker;
+import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.b2international.snowowl.core.plugin.Component;
 import com.b2international.snowowl.core.setup.ConfigurationRegistry;
 import com.b2international.snowowl.core.setup.Environment;
@@ -82,7 +83,7 @@ public final class RepositoryPlugin extends Plugin {
 	}
 	
 	@Override
-	public void init(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public void init(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 		RepositoryConfiguration repositoryConfiguration = configuration.getModuleConfig(RepositoryConfiguration.class);
 		env.services().registerService(RepositoryConfiguration.class, repositoryConfiguration);
 		int maxThreads = repositoryConfiguration.getMaxThreads();
@@ -135,7 +136,7 @@ public final class RepositoryPlugin extends Plugin {
 	}
 	
 	@Override
-	public void preRun(SnowOwlConfiguration configuration, Environment env) {
+	public void preRun(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) {
 		if (env.isServer()) {
 			LOG.debug("Initializing repository plugin.");
 			final MeterRegistry registry = env.service(MeterRegistry.class);
@@ -244,7 +245,7 @@ public final class RepositoryPlugin extends Plugin {
 	}
 	
 	@Override
-	public void run(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public void run(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 		if (env.isServer()) {
 			initializeJobSupport(env, configuration);
 		}

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/TerminologyRepositoryPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/repository/TerminologyRepositoryPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2018-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,7 @@
  */
 package com.b2international.snowowl.core.repository;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,25 +24,21 @@ import com.b2international.index.IndexClient;
 import com.b2international.index.es.client.EsClient;
 import com.b2international.index.mapping.DocumentMapping;
 import com.b2international.index.revision.Hooks;
-import com.b2international.snowowl.core.Repository;
-import com.b2international.snowowl.core.RepositoryInfo;
+import com.b2international.snowowl.core.*;
 import com.b2international.snowowl.core.RepositoryInfo.Health;
-import com.b2international.snowowl.core.RepositoryManager;
 import com.b2international.snowowl.core.compare.DependencyComparer;
 import com.b2international.snowowl.core.compare.ResourceContentComparer;
 import com.b2international.snowowl.core.config.SnowOwlConfiguration;
 import com.b2international.snowowl.core.domain.ContextConfigurer;
 import com.b2international.snowowl.core.merge.ComponentRevisionConflictProcessor;
 import com.b2international.snowowl.core.merge.IMergeConflictRule;
+import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.b2international.snowowl.core.request.*;
 import com.b2international.snowowl.core.request.ecl.EclRewriter;
 import com.b2international.snowowl.core.request.version.VersioningRequestBuilder;
 import com.b2international.snowowl.core.setup.Environment;
 import com.b2international.snowowl.core.setup.Plugin;
-import com.b2international.snowowl.core.terminology.ComponentCategory;
-import com.b2international.snowowl.core.terminology.Terminology;
-import com.b2international.snowowl.core.terminology.TerminologyComponent;
-import com.b2international.snowowl.core.terminology.TerminologyRegistry;
+import com.b2international.snowowl.core.terminology.*;
 import com.b2international.snowowl.core.uri.ResourceURLSchemaSupport;
 
 /**
@@ -56,7 +49,7 @@ public abstract class TerminologyRepositoryPlugin extends Plugin implements Term
 	private static final Logger LOG = LoggerFactory.getLogger("repository");
 	
 	@Override
-	public final void run(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public final void run(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 		// register terminology and component definitions
 		TerminologyRegistry registry = env.service(TerminologyRegistry.class);
 		registry.register(this);
@@ -84,7 +77,7 @@ public abstract class TerminologyRepositoryPlugin extends Plugin implements Term
 					.bind(EclRewriter.class, getEclRewriter())
 					.bind(DependencyComparer.class, getDependencyComparer())
 					.bind(ResourceContentComparer.class, getContentComparer())
-					.build(env);
+					.build(env, scanner);
 			
 			RepositoryInfo status = repo.status();
 			if (status.health() == Health.GREEN) {

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/BaseResourceConverter.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/BaseResourceConverter.java
@@ -104,11 +104,14 @@ public abstract class BaseResourceConverter<T, R, CR extends CollectionResource<
 	}
 
 	private final void expandViaPlugins(List<R> results) {
-		context().service(ResourceExpanderExtension.Registry.class)
-				.get()
-				.stream()
-				.filter(expanderExtension -> expanderExtension.canExpand(getType()))
-				.forEach(expanderExtension -> expanderExtension.create(context(), expand(), locales(), getType()).expand(results));
+		context().optionalService(ResourceExpanderExtension.Registry.class)
+				.ifPresent(expanderRegistry -> {
+					expanderRegistry
+						.get()
+						.stream()
+						.filter(expanderExtension -> expanderExtension.canExpand(getType()))
+						.forEach(expanderExtension -> expanderExtension.create(context(), expand(), locales(), getType()).expand(results));
+				});
 	}
 
 	protected abstract CR createCollectionResource(List<R> results, String searchAfter, int limit, int total);

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/BaseResourceConverter.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/BaseResourceConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2023 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2011-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,10 +27,8 @@ import com.b2international.index.Hits;
 import com.b2international.snowowl.core.ServiceProvider;
 import com.b2international.snowowl.core.date.EffectiveTimes;
 import com.b2international.snowowl.core.domain.CollectionResource;
-import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.b2international.snowowl.core.request.expand.BaseResourceExpander;
 import com.b2international.snowowl.core.request.expand.ResourceExpanderExtension;
-import com.google.common.collect.Iterables;
 
 /**
  * @since 4.0
@@ -55,7 +53,7 @@ public abstract class BaseResourceConverter<T, R, CR extends CollectionResource<
 	 * @return
 	 */
 	public final R convert(T component) {
-		return Iterables.getOnlyElement(convert(Collections.singleton(component), null, 1, 1));
+		return convert(Collections.singleton(component), null, 1, 1).first().get();
 	}
 
 	/**
@@ -106,12 +104,11 @@ public abstract class BaseResourceConverter<T, R, CR extends CollectionResource<
 	}
 
 	private final void expandViaPlugins(List<R> results) {
-		context().optionalService(ClassPathScanner.class).ifPresent(scanner -> {
-			scanner.getComponentsByInterface(ResourceExpanderExtension.class)
+		context().service(ResourceExpanderExtension.Registry.class)
+				.get()
 				.stream()
 				.filter(expanderExtension -> expanderExtension.canExpand(getType()))
 				.forEach(expanderExtension -> expanderExtension.create(context(), expand(), locales(), getType()).expand(results));
-		});
 	}
 
 	protected abstract CR createCollectionResource(List<R> results, String searchAfter, int limit, int total);

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/expand/ResourceExpanderExtension.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/request/expand/ResourceExpanderExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2022-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,24 @@ import java.util.List;
 import com.b2international.commons.http.ExtendedLocale;
 import com.b2international.commons.options.Options;
 import com.b2international.snowowl.core.ServiceProvider;
+import com.b2international.snowowl.core.plugin.ClassPathScanner;
+import com.b2international.snowowl.core.plugin.PluggableServiceRegistry;
 
 /**
  * @since 8.1
  */
 public interface ResourceExpanderExtension {
 
+	/**
+	 * @since 10.2.0
+	 */
+	class Registry extends PluggableServiceRegistry<ResourceExpanderExtension> {
+
+		public Registry(ClassPathScanner scanner) {
+			super(scanner);
+		}
+	}
+	
 	<T> boolean canExpand(Class<T> type);
 	
 	<T> ResourceExpander<T> create(ServiceProvider context, Options expand, List<ExtendedLocale> locales, Class<T> type);

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/scripts/ScriptPlugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/scripts/ScriptPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2020-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ import com.b2international.snowowl.core.setup.Plugin;
 public final class ScriptPlugin extends Plugin {
 
 	@Override
-	public void init(SnowOwlConfiguration configuration, Environment env) throws Exception {
-		env.services().registerService(ScriptEngine.Registry.class, new ScriptEngine.Registry(env.service(ClassPathScanner.class)));
+	public void init(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
+		env.services().registerService(ScriptEngine.Registry.class, new ScriptEngine.Registry(scanner));
 	}
 	
 }

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/setup/Plugin.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/setup/Plugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2018-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.b2international.snowowl.core.setup;
 
 import com.b2international.snowowl.core.SnowOwl;
 import com.b2international.snowowl.core.config.SnowOwlConfiguration;
+import com.b2international.snowowl.core.plugin.ClassPathScanner;
 
 /**
  * @since 7.0
@@ -39,9 +40,11 @@ public abstract class Plugin {
 	 *            - Snow Owl Application configuration
 	 * @param env
 	 *            - the environment within this plug-in will be initialized
+	 * @param scanner
+	 *            - the scanner that can be used to dependency inject various implementations into services through class path scanning
 	 * @throws Exception
 	 */
-	public void init(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public void init(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 	}
 
 	/**
@@ -50,9 +53,11 @@ public abstract class Plugin {
 	 * 
 	 * @param configuration
 	 * @param env
+	 * @param scanner
+	 *            - the scanner that can be used to dependency inject various implementations into services through class path scanning
 	 * @throws Exception
 	 */
-	public void preRun(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public void preRun(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 	}
 
 	/**
@@ -63,9 +68,11 @@ public abstract class Plugin {
 	 *            - Snow Owl Application configuration
 	 * @param env
 	 *            - the environment
+	 * @param scanner
+	 *            - the scanner that can be used to dependency inject various implementations into services through class path scanning
 	 * @throws Exception
 	 */
-	public void run(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public void run(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 	}
 
 	/**
@@ -74,9 +81,11 @@ public abstract class Plugin {
 	 * 
 	 * @param configuration
 	 * @param env
+	 * @param scanner
+	 *            - the scanner that can be used to dependency inject various implementations into services through class path scanning
 	 * @throws Exception
 	 */
-	public void postRun(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public void postRun(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 	}
 	
 	@Override

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/setup/Plugins.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/setup/Plugins.java
@@ -15,23 +15,17 @@
  */
 package com.b2international.snowowl.core.setup;
 
-import static com.google.common.collect.Maps.newHashMap;
-
-import java.util.Collection;
-import java.util.Map;
-
-import org.eclipse.core.runtime.IProgressMonitor;
+import java.util.*;
 
 import com.b2international.commons.CompositeClassLoader;
 import com.b2international.snowowl.core.SnowOwl;
 import com.b2international.snowowl.core.config.SnowOwlConfiguration;
 import com.b2international.snowowl.core.plugin.ClassPathScanner;
-import com.google.common.collect.ImmutableList;
 
 /**
  * @since 7.0
  */
-public final class Plugins {
+public final class Plugins implements Iterable<Plugin> {
 
 	private final Collection<Plugin> plugins;
 	private final CompositeClassLoader compositeClassLoader;
@@ -42,7 +36,7 @@ public final class Plugins {
 	 * @param plugins
 	 */
 	public Plugins(Collection<Plugin> plugins) {
-		this.plugins = ImmutableList.copyOf(plugins);
+		this.plugins = List.copyOf(plugins);
 		final CompositeClassLoader classLoader = new CompositeClassLoader();
 		plugins.stream().map(Plugin::getClass).map(Class::getClassLoader).forEach(classLoader::add);
 		this.compositeClassLoader = classLoader;
@@ -65,7 +59,7 @@ public final class Plugins {
 	}
 
 	/**
-	 * Executes {@link Plugin#run(SnowOwlConfiguration, Environment, IProgressMonitor)} methods.
+	 * Executes {@link Plugin#run(SnowOwlConfiguration, Environment, ClassPathScanner)} methods.
 	 * 
 	 * @param configuration
 	 * @param environment
@@ -119,6 +113,11 @@ public final class Plugins {
 		return plugins;
 	}
 
+	@Override
+	public Iterator<Plugin> iterator() {
+		return plugins.iterator();
+	}
+
 	/**
 	 * Collects all plugin configuration contributions and returns them in a {@link Map} where the key is the desired property name of the
 	 * configuration node and the value is the {@link Class} of the actual configuration node.
@@ -127,7 +126,7 @@ public final class Plugins {
 	 * @since 3.4
 	 */
 	public Map<String, Class<?>> getPluginConfigurations() {
-		final Map<String, Class<?>> moduleConfigMap = newHashMap();
+		final Map<String, Class<?>> moduleConfigMap = new HashMap<>();
 		for (Plugin plugin : getPlugins()) {
 			plugin.addConfigurations(new ConfigurationRegistry() {
 				@Override

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/setup/Plugins.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/setup/Plugins.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2018-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import com.b2international.commons.CompositeClassLoader;
 import com.b2international.snowowl.core.SnowOwl;
 import com.b2international.snowowl.core.config.SnowOwlConfiguration;
+import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -52,12 +53,14 @@ public final class Plugins {
 	 * 
 	 * @param configuration
 	 * @param environment
+	 * @param scanner
+	 *            - the scanner that can be used to dependency inject various implementations into services through class path scanning
 	 * @throws Exception
 	 * @see Plugin#init(Environment)
 	 */
-	public void init(SnowOwlConfiguration configuration, Environment environment) throws Exception {
+	public void init(SnowOwlConfiguration configuration, Environment environment, ClassPathScanner scanner) throws Exception {
 		for (Plugin plugin : plugins) {
-			plugin.init(configuration, environment);
+			plugin.init(configuration, environment, scanner);
 		}
 	}
 
@@ -66,12 +69,14 @@ public final class Plugins {
 	 * 
 	 * @param configuration
 	 * @param environment
+	 * @param scanner
+	 *            - the scanner that can be used to dependency inject various implementations into services through class path scanning
 	 * @throws Exception
 	 * @see Plugin#run(Environment)
 	 */
-	public void run(SnowOwlConfiguration configuration, Environment environment) throws Exception {
+	public void run(SnowOwlConfiguration configuration, Environment environment, ClassPathScanner scanner) throws Exception {
 		for (Plugin plugin : plugins) {
-			plugin.run(configuration, environment);
+			plugin.run(configuration, environment, scanner);
 		}
 	}
 
@@ -81,11 +86,13 @@ public final class Plugins {
 	 * 
 	 * @param configuration
 	 * @param environment
+	 * @param scanner
+	 *            - the scanner that can be used to dependency inject various implementations into services through class path scanning
 	 * @throws Exception 
 	 */
-	public void preRun(SnowOwlConfiguration configuration, Environment environment) throws Exception {
+	public void preRun(SnowOwlConfiguration configuration, Environment environment, ClassPathScanner scanner) throws Exception {
 		for (Plugin plugin : plugins) {
-			plugin.preRun(configuration, environment);
+			plugin.preRun(configuration, environment, scanner);
 		}
 	}
 	
@@ -95,11 +102,13 @@ public final class Plugins {
 	 * 
 	 * @param configuration
 	 * @param environment
+	 * @param scanner
+	 *            - the scanner that can be used to dependency inject various implementations into services through class path scanning
 	 * @throws Exception 
 	 */
-	public void postRun(SnowOwlConfiguration configuration, Environment environment) throws Exception {
+	public void postRun(SnowOwlConfiguration configuration, Environment environment, ClassPathScanner scanner) throws Exception {
 		for (Plugin fragment : plugins) {
-			fragment.postRun(configuration, environment);
+			fragment.postRun(configuration, environment, scanner);
 		}
 	}
 

--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/validation/SnomedValidationIssueDetailTest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/validation/SnomedValidationIssueDetailTest.java
@@ -117,7 +117,6 @@ public class SnomedValidationIssueDetailTest extends BaseRevisionIndexTest {
 				.with(RevisionIndex.class, index())
 				.with(ValidationThreadPool.class, new ValidationThreadPool(1, 1, 1))
 				.with(ValidationRepository.class, repository)
-				.with(ClassPathScanner.class, scanner)
 				.with(ValidationIssueDetailExtensionProvider.class, new ValidationIssueDetailExtensionProvider(scanner))
 				.with(ResourceURIPathResolver.class, ResourceURIPathResolver.fromMap(Map.of("SNOMEDCT", Branch.MAIN_PATH)))
 				.build();

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/SnomedPlugin.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/SnomedPlugin.java
@@ -28,6 +28,7 @@ import com.b2international.snowowl.core.domain.ContextConfigurer;
 import com.b2international.snowowl.core.domain.IComponent;
 import com.b2international.snowowl.core.internal.locks.DatastoreLockContextDescriptions;
 import com.b2international.snowowl.core.merge.ComponentRevisionConflictProcessor;
+import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.b2international.snowowl.core.plugin.Component;
 import com.b2international.snowowl.core.repository.ComponentDeletionPolicy;
 import com.b2international.snowowl.core.repository.CompositeComponentDeletionPolicy;
@@ -76,7 +77,7 @@ public final class SnomedPlugin extends TerminologyRepositoryPlugin {
 	}
 	
 	@Override
-	public void init(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public void init(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 		final SnomedCoreConfiguration coreConfig = configuration.getModuleConfig(SnomedCoreConfiguration.class);
 		env.services().registerService(SnomedCoreConfiguration.class, coreConfig);
 		

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/AssignerType.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/AssignerType.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 B2i Healthcare, https://b2ihealthcare.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.snomed.datastore.id.assigner;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.*;
+
+/**
+ * @since 10.2.0
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+@Documented
+public @interface AssignerType {
+
+	String name();
+	
+}

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/DefaultNamespaceAndModuleAssigner.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/DefaultNamespaceAndModuleAssigner.java
@@ -61,7 +61,7 @@ public final class DefaultNamespaceAndModuleAssigner implements SnomedNamespaceA
 
 	@Override
 	public String toString() {
-		return String.format("[defaultNamespace: '%s', defaultModule: '%s']", getClass().getSimpleName(), defaultNamespace, defaultModule);
+		return String.format("default[defaultNamespace: '%s', defaultModule: '%s']", defaultNamespace, defaultModule);
 	}
 	
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/DefaultNamespaceAndModuleAssigner.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/DefaultNamespaceAndModuleAssigner.java
@@ -26,6 +26,7 @@ import com.b2international.snowowl.core.plugin.Component;
  * @since 5.11.5
  */
 @Component
+@AssignerType(name = "default")
 public final class DefaultNamespaceAndModuleAssigner implements SnomedNamespaceAndModuleAssigner {
 
 	private String defaultNamespace;
@@ -59,13 +60,8 @@ public final class DefaultNamespaceAndModuleAssigner implements SnomedNamespaceA
 	}
 
 	@Override
-	public String getName() {
-		return "default";
-	}
-	
-	@Override
 	public String toString() {
-		return String.format("%s[defaultNamespace: '%s', defaultModule: '%s']", getName(), defaultNamespace, defaultModule);
+		return String.format("[defaultNamespace: '%s', defaultModule: '%s']", getClass().getSimpleName(), defaultNamespace, defaultModule);
 	}
 	
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/ExtensionNamespaceAndModuleAssigner.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/ExtensionNamespaceAndModuleAssigner.java
@@ -17,9 +17,7 @@ package com.b2international.snowowl.snomed.datastore.id.assigner;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Consumer;
 
 import com.b2international.collections.PrimitiveMaps;
@@ -48,6 +46,7 @@ import com.google.common.collect.Sets;
  * @since 5.11.5
  */
 @Component
+@AssignerType(name = "extension")
 public final class ExtensionNamespaceAndModuleAssigner implements SnomedNamespaceAndModuleAssigner {
 	
 	private final LongKeyLongMap relationshipModuleMap = PrimitiveMaps.newLongKeyLongOpenHashMap();
@@ -135,12 +134,7 @@ public final class ExtensionNamespaceAndModuleAssigner implements SnomedNamespac
 	}
 
 	@Override
-	public String getName() {
-		return "extension";
-	}
-	
-	@Override
 	public String toString() {
-		return String.format("%s[defaultNamespace: '%s', defaultModule: '%s']", getName(), defaultNamespace, defaultModule);
+		return String.format("%s[defaultNamespace: '%s', defaultModule: '%s']", getClass().getSimpleName(), defaultNamespace, defaultModule);
 	}
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/ExtensionNamespaceAndModuleAssigner.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/ExtensionNamespaceAndModuleAssigner.java
@@ -135,6 +135,6 @@ public final class ExtensionNamespaceAndModuleAssigner implements SnomedNamespac
 
 	@Override
 	public String toString() {
-		return String.format("%s[defaultNamespace: '%s', defaultModule: '%s']", getClass().getSimpleName(), defaultNamespace, defaultModule);
+		return String.format("extension[defaultNamespace: '%s', defaultModule: '%s']", defaultNamespace, defaultModule);
 	}
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/SnomedNamespaceAndModuleAssigner.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/id/assigner/SnomedNamespaceAndModuleAssigner.java
@@ -15,9 +15,12 @@
  */
 package com.b2international.snowowl.snomed.datastore.id.assigner;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.b2international.commons.exceptions.FormattedRuntimeException;
+import com.b2international.snowowl.core.api.SnowowlRuntimeException;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.plugin.ClassPathScanner;
 
@@ -26,15 +29,11 @@ import com.b2international.snowowl.core.plugin.ClassPathScanner;
  * <ul>
  * <li>For each inferred relationship, returns the expected namespace and module ID, given the source concept ID;
  * </ul>
+ * Subclasses must be annotated with {@link AssignerType} annotation to get an identifiable name for the registry.
  * 
  * @since 5.11.5
  */
 public interface SnomedNamespaceAndModuleAssigner {
-
-	/**
-	 * Returns the configuration key of the assigner
-	 */
-	String getName();
 
 	/**
 	 * Initialize the assigner with default module and namespace values.
@@ -73,25 +72,46 @@ public interface SnomedNamespaceAndModuleAssigner {
 	 */
 	void clear();
 
-	/**
-	 * Instantiate a namespace and module assigner instance based on the given type.
-	 * 
-	 * @param context
-	 * @param assignerType
-	 * @param moduleId
-	 * @param namespace
-	 * @return
-	 */
-	static SnomedNamespaceAndModuleAssigner create(BranchContext context, String assignerType, String moduleId, String namespace) {
-		final SnomedNamespaceAndModuleAssigner assigner = context.service(ClassPathScanner.class)
-			.getComponentsByInterface(SnomedNamespaceAndModuleAssigner.class)
-			.stream()
-			.filter(a -> assignerType.equals(a.getName()))
-			.findFirst()
-			.orElseThrow(() -> new FormattedRuntimeException("Couldn't find namespace and module assigner '%s'.", assignerType));
+	class Registry {
 		
-		assigner.init(namespace, moduleId, context);
-		return assigner;
+		private final Map<String, Class<?>> registry;
+
+		public Registry(ClassPathScanner scanner) {
+			this.registry = scanner.getComponentsClassesByInterface(SnomedNamespaceAndModuleAssigner.class)
+				.stream()
+				.collect(Collectors.toMap(this::getAssignerType, a -> a));
+		}
+		
+		private String getAssignerType(Class<?> assignerClass) {
+			return assignerClass.getAnnotation(AssignerType.class).name();
+		}
+		
+		/**
+		 * Instantiate a namespace and module assigner instance based on the given type.
+		 * 
+		 * @param context
+		 * @param assignerType
+		 * @param moduleId
+		 * @param namespace
+		 * @return
+		 */
+		public SnomedNamespaceAndModuleAssigner getAssigner(BranchContext context, String assignerType, String moduleId, String namespace) {
+			final Class<?> assignerClass = this.registry.get(assignerType);
+			
+			if (assignerClass == null) {
+				throw new FormattedRuntimeException("Couldn't find namespace and module assigner '%s'.", assignerType);
+			}
+			
+			try {
+				// the default constructor should exist and should be public, otherwise fail
+				SnomedNamespaceAndModuleAssigner assigner = (SnomedNamespaceAndModuleAssigner) assignerClass.getConstructor().newInstance();
+				assigner.init(namespace, moduleId, context);
+				return assigner;
+			} catch (Exception e) {
+				throw new SnowowlRuntimeException("Unable to instantiate module and namespace assigner of type: " + assignerType, e);
+			}
+		}
 	}
+	
 
 }

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/SnomedReasonerPlugin.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/SnomedReasonerPlugin.java
@@ -29,6 +29,7 @@ import com.b2international.snowowl.core.setup.Environment;
 import com.b2international.snowowl.core.setup.Plugin;
 import com.b2international.snowowl.snomed.common.SnomedTerminologyComponentConstants;
 import com.b2international.snowowl.snomed.datastore.config.SnomedCoreConfiguration;
+import com.b2international.snowowl.snomed.datastore.id.assigner.SnomedNamespaceAndModuleAssigner;
 import com.b2international.snowowl.snomed.reasoner.classification.ClassificationTracker;
 import com.b2international.snowowl.snomed.reasoner.equivalence.IEquivalentConceptMerger;
 import com.b2international.snowowl.snomed.reasoner.index.*;
@@ -51,6 +52,7 @@ public final class SnomedReasonerPlugin extends Plugin implements TerminologyRep
 			
 			final ClassPathScanner scanner = env.service(ClassPathScanner.class);
 			env.services().registerService(IEquivalentConceptMerger.Registry.class, new IEquivalentConceptMerger.Registry(scanner));
+			env.services().registerService(SnomedNamespaceAndModuleAssigner.Registry.class, new SnomedNamespaceAndModuleAssigner.Registry(scanner));
 		}
 	}
 	

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/SnomedReasonerPlugin.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/SnomedReasonerPlugin.java
@@ -41,7 +41,7 @@ import com.b2international.snowowl.snomed.reasoner.index.*;
 public final class SnomedReasonerPlugin extends Plugin implements TerminologyRepositoryConfigurer {
 
 	@Override
-	public void run(final SnowOwlConfiguration configuration, final Environment env) throws Exception {
+	public void run(final SnowOwlConfiguration configuration, final Environment env, ClassPathScanner scanner) throws Exception {
 		if (env.isServer()) {
 			final Index repositoryIndex = env.service(RepositoryManager.class).get(getToolingId()).service(Index.class);
 			final SnomedCoreConfiguration snomedConfig = configuration.getModuleConfig(SnomedCoreConfiguration.class);
@@ -50,7 +50,6 @@ public final class SnomedReasonerPlugin extends Plugin implements TerminologyRep
 			final ClassificationTracker classificationTracker = new ClassificationTracker(repositoryIndex, maximumReasonerRuns, TimeUnit.MINUTES.toMillis(classificationCleanUpInterval));
 			env.services().registerService(ClassificationTracker.class, classificationTracker);
 			
-			final ClassPathScanner scanner = env.service(ClassPathScanner.class);
 			env.services().registerService(IEquivalentConceptMerger.Registry.class, new IEquivalentConceptMerger.Registry(scanner));
 			env.services().registerService(SnomedNamespaceAndModuleAssigner.Registry.class, new SnomedNamespaceAndModuleAssigner.Registry(scanner));
 		}

--- a/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/SaveJobRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner/src/com/b2international/snowowl/snomed/reasoner/request/SaveJobRequest.java
@@ -19,10 +19,7 @@ import static com.b2international.snowowl.snomed.common.SnomedTerminologyCompone
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -57,10 +54,7 @@ import com.b2international.snowowl.snomed.reasoner.domain.*;
 import com.b2international.snowowl.snomed.reasoner.equivalence.IEquivalentConceptMerger;
 import com.b2international.snowowl.snomed.reasoner.exceptions.ReasonerApiException;
 import com.google.common.base.Strings;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Multimap;
+import com.google.common.collect.*;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -444,7 +438,7 @@ final class SaveJobRequest implements Request<BranchContext, Boolean>, AccessCon
 				.getOrDefault(Settings.NAMESPACE_MODULE_ASSIGNER, DEFAULT_NAMESPACE_AND_MODULE_ASSIGNER);
 		}
 		
-		final SnomedNamespaceAndModuleAssigner assigner = SnomedNamespaceAndModuleAssigner.create(context, selectedType, moduleId, namespace);
+		final SnomedNamespaceAndModuleAssigner assigner = context.service(SnomedNamespaceAndModuleAssigner.Registry.class).getAssigner(context, selectedType, moduleId, namespace);
 		
 		LOG.info("Reasoner service will use {} for relationship namespace and module assignment.", assigner);
 		return assigner;

--- a/tests/com.b2international.snowowl.test.commons/src/com/b2international/snowowl/test/commons/DatasetBootstrap.java
+++ b/tests/com.b2international.snowowl.test.commons/src/com/b2international/snowowl/test/commons/DatasetBootstrap.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import com.b2international.commons.FileUtils;
 import com.b2international.snowowl.core.api.SnowowlRuntimeException;
 import com.b2international.snowowl.core.config.SnowOwlConfiguration;
+import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.b2international.snowowl.core.setup.Environment;
 import com.b2international.snowowl.core.setup.Plugin;
 import com.google.common.base.Strings;
@@ -62,7 +63,7 @@ public class DatasetBootstrap extends Plugin {
 	public static final String LOC_PARAM_NAME = "so.dataset.location";
 
 	@Override
-	public void init(SnowOwlConfiguration configuration, Environment env) throws Exception {
+	public void init(SnowOwlConfiguration configuration, Environment env, ClassPathScanner scanner) throws Exception {
 		final String datasetLocation = System.getProperty(LOC_PARAM_NAME);
 		if (Strings.isNullOrEmpty(datasetLocation)) {
 			throw new SnowowlRuntimeException(String.format("%s JVM argument is missing", LOC_PARAM_NAME));

--- a/tests/com.b2international.snowowl.test.commons/src/com/b2international/snowowl/test/commons/validation/BaseValidationTest.java
+++ b/tests/com.b2international.snowowl.test.commons/src/com/b2international/snowowl/test/commons/validation/BaseValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2020-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,6 @@ import com.b2international.snowowl.core.config.IndexConfiguration;
 import com.b2international.snowowl.core.domain.BranchContext;
 import com.b2international.snowowl.core.internal.validation.ValidationRepository;
 import com.b2international.snowowl.core.internal.validation.ValidationThreadPool;
-import com.b2international.snowowl.core.plugin.ClassPathScanner;
 import com.b2international.snowowl.core.request.BranchSnapshotContentRequest;
 import com.b2international.snowowl.core.scripts.ScriptEngine;
 import com.b2international.snowowl.core.terminology.TerminologyRegistry;
@@ -93,7 +92,6 @@ public abstract class BaseValidationTest extends BaseRevisionIndexTest {
 		
 		Builder context = TestBranchContext.on(MAIN)
 				.with(ClassLoader.class, getClass().getClassLoader())
-				.with(ClassPathScanner.class, scanner)
 				.with(Index.class, rawIndex())
 				.with(RevisionIndex.class, index()).with(ObjectMapper.class, getMapper())
 				.with(ValidationRepository.class, new ValidationRepository(rawIndex()))


### PR DESCRIPTION
This PR aims to reduce the base minimum memory requirement of the server by releasing the ClassPathScanner object used to scan the classpath for plugins and their configuration classes. After the boot phase and once everything is set up, only a handful of services used it during runtime, but that can be simply changed to cache the necessary classes and instantiate manually rather than relying on the cached scan results.