### PR TITLE
Incorrect revision merge logic

### DIFF
--- a/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchMergeConflictTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchMergeConflictTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2020-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,6 +144,27 @@ public class RevisionBranchMergeConflictTest extends BaseRevisionIndexTest {
 		deleteRevision(branchA, ContainerRevisionData.class, STORAGE_KEY1);
 		
 		branching().prepareMerge(MAIN, branchA).merge();
+	}
+	
+	@Test
+	public void rebaseComponentOfContainer_ChangedOnSourceAndTarget() throws Exception {
+		ContainerRevisionData container = new ContainerRevisionData(STORAGE_KEY1);
+		indexRevision(MAIN, container);
+		final String branchA = createBranch(MAIN, "a");
+		
+		// apply the same change to both sides
+		ComponentRevisionData component = new ComponentRevisionData(STORAGE_KEY2, STORAGE_KEY1, "field2");
+		indexRevision(MAIN, component);
+		indexRevision(branchA, component);
+		
+		final Commit commit = branching().prepareMerge(MAIN, branchA).merge();
+		
+		assertThat(commit.getDetails()).containsOnly(
+			// indicate that the container has changed
+			CommitDetail.changed(container.getObjectId().type(), container.getObjectId().type()).objects(ObjectId.ROOT).components(Set.of(container.getId())).build(),
+			// assert that the injected poison pill is available on the resulting merge commit properly
+			CommitDetail.removed(container.getObjectId().type(), component.getObjectId().type()).objects(container.getId()).components(Set.of(component.getId())).build()
+		);
 	}
 	
 	@Test
@@ -569,7 +590,9 @@ public class RevisionBranchMergeConflictTest extends BaseRevisionIndexTest {
 		indexChange(MAIN, data, update);
 		indexChange(branchA, data, update);
 		
-		branching().prepareMerge(MAIN, branchA).merge(); // should not throw BranchMergeConflictException
+		final Commit commit = branching().prepareMerge(MAIN, branchA).merge(); // should not throw BranchMergeConflictException
+		// assert that the injected conflict change pill is present properly
+		assertThat(commit.getDetails()).containsOnly(CommitDetail.changed(data.getObjectId().type(), data.getObjectId().type()).objects(ObjectId.ROOT).components(Set.of(data.getId())).build());
 		
 		ObjectPropertyData actual = getRevision(branchA, ObjectPropertyData.class, STORAGE_KEY1);
 		assertDocEquals(

--- a/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchMergeConflictTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchMergeConflictTest.java
@@ -149,21 +149,21 @@ public class RevisionBranchMergeConflictTest extends BaseRevisionIndexTest {
 	@Test
 	public void rebaseComponentOfContainer_ChangedOnSourceAndTarget() throws Exception {
 		ContainerRevisionData container = new ContainerRevisionData(STORAGE_KEY1);
-		indexRevision(MAIN, container);
+		ComponentRevisionData component = new ComponentRevisionData(STORAGE_KEY2, STORAGE_KEY1, "field");
+		indexRevision(MAIN, container, component);
 		final String branchA = createBranch(MAIN, "a");
 		
 		// apply the same change to both sides
-		ComponentRevisionData component = new ComponentRevisionData(STORAGE_KEY2, STORAGE_KEY1, "field2");
-		indexRevision(MAIN, component);
-		indexRevision(branchA, component);
+		indexChange(MAIN, component, new ComponentRevisionData(STORAGE_KEY2, STORAGE_KEY1, "fieldChanged"));
+		indexChange(branchA, component, new ComponentRevisionData(STORAGE_KEY2, STORAGE_KEY1, "fieldChanged"));
 		
 		final Commit commit = branching().prepareMerge(MAIN, branchA).merge();
 		
 		assertThat(commit.getDetails()).containsOnly(
 			// indicate that the container has changed
 			CommitDetail.changed(container.getObjectId().type(), container.getObjectId().type()).objects(ObjectId.ROOT).components(Set.of(container.getId())).build(),
-			// assert that the injected poison pill is available on the resulting merge commit properly
-			CommitDetail.removed(container.getObjectId().type(), component.getObjectId().type()).objects(container.getId()).components(Set.of(component.getId())).build()
+			// assert that the injected change pill is available on the resulting merge commit properly
+			CommitDetail.changed(container.getObjectId().type(), component.getObjectId().type()).objects(container.getId()).components(Set.of(component.getId())).build()
 		);
 	}
 	

--- a/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchMergeTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchMergeTest.java
@@ -15,10 +15,12 @@
  */
 package com.b2international.index.revision;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -148,23 +150,24 @@ public class RevisionBranchMergeTest extends BaseRevisionIndexTest {
 		indexRemove(child, NEW_DATA, NEW_DATA2);
 		// after commit child branch becomes FORWARD
 		assertState(child, MAIN, BranchState.FORWARD);
-		// do the merge with an exclusion
+
+		// do the merge with an exclusion to the deleted element
 		branching()
 			.prepareMerge(child, MAIN)
 			.exclude(STORAGE_KEY1)
 			.squash(true)
 			.merge();
 		
-		// after fast-forward merge
+		// after squash merge
 		// 1. MAIN falls behind compared to the child
 		assertState(MAIN, child, BranchState.FORWARD);
 		
 		// 2. Child should be UP_TO_DATE state compared to the MAIN
 		assertState(child, MAIN, BranchState.BEHIND);
 		
-		// 3. one revision should be visible from MAIN branch, excluded one should not
+		// 3. since nothing got removed, both revisions should be visible after merge
 		assertNotNull(getRevision(MAIN, RevisionData.class, STORAGE_KEY1));
-		assertNull(getRevision(MAIN, RevisionData.class, STORAGE_KEY2));
+		assertNotNull(getRevision(MAIN, RevisionData.class, STORAGE_KEY2));
 	}
 	
 	@Test
@@ -552,8 +555,10 @@ public class RevisionBranchMergeTest extends BaseRevisionIndexTest {
 		final String newParent = createBranch(MAIN, "newParent");
 		final String newBranch = createBranch(newParent, "move");
 		
-		// initial sync produces empty commit but an actual change in the doc
-		branching().prepareMerge(oldBranch, newBranch).squash(false).merge();
+		// initial sync produces a non-empty commit indicating that there was a "conflict" detected during the merge 
+		Commit commit = branching().prepareMerge(oldBranch, newBranch).squash(false).merge();
+		// assert  that the injected conflict change pill is present
+		assertThat(commit.getDetails()).containsOnly(CommitDetail.changed(NEW_DATA.getObjectId().type(), NEW_DATA.getObjectId().type()).objects(ObjectId.ROOT).components(Set.of(NEW_DATA.getId())).build());
 		
 		RevisionData afterFirstSync = getRevision(newBranch, RevisionData.class, STORAGE_KEY1);
 		assertEquals("change", afterFirstSync.getDerivedField());

--- a/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchMergeTest.java
+++ b/commons/com.b2international.index.tests/src/com/b2international/index/revision/RevisionBranchMergeTest.java
@@ -146,12 +146,12 @@ public class RevisionBranchMergeTest extends BaseRevisionIndexTest {
 		indexRevision(MAIN, NEW_DATA);
 		indexRevision(MAIN, NEW_DATA2);
 		String child = createBranch(MAIN, "a");
-		// change a revision on the child branch
+		// delete BOTH revisions on the child branch
 		indexRemove(child, NEW_DATA, NEW_DATA2);
 		// after commit child branch becomes FORWARD
 		assertState(child, MAIN, BranchState.FORWARD);
 
-		// do the merge with an exclusion to the deleted element
+		// but when merging exclude the first one, so that should not be deleted
 		branching()
 			.prepareMerge(child, MAIN)
 			.exclude(STORAGE_KEY1)
@@ -165,9 +165,9 @@ public class RevisionBranchMergeTest extends BaseRevisionIndexTest {
 		// 2. Child should be UP_TO_DATE state compared to the MAIN
 		assertState(child, MAIN, BranchState.BEHIND);
 		
-		// 3. since nothing got removed, both revisions should be visible after merge
+		// 3. one revision should be visible from MAIN branch, excluded one should not
 		assertNotNull(getRevision(MAIN, RevisionData.class, STORAGE_KEY1));
-		assertNotNull(getRevision(MAIN, RevisionData.class, STORAGE_KEY2));
+		assertNull(getRevision(MAIN, RevisionData.class, STORAGE_KEY2));
 	}
 	
 	@Test

--- a/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranchChangeSet.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/RevisionBranchChangeSet.java
@@ -72,6 +72,15 @@ public final class RevisionBranchChangeSet {
 					Class<?> revType = mappings.getClass(detail.getComponent().type());
 					if (Revision.class.isAssignableFrom(revType)) {
 						changedRevisionIdsByType.put((Class<? extends Revision>) revType, detail.getComponent().id());
+						
+						if (!detail.getObject().isRoot()) {
+							Class<?> objectType = mappings.getClass(detail.getObject().type());
+							containersRequiredForNewAndChangedRevisions.put(detail.getComponent(), detail.getObject());
+							// only register as changed container, if the container is not registered as a new revision
+							if (!newRevisionIdsByType.containsEntry((Class<? extends Revision>) objectType, detail.getObject().id())) {
+								changedRevisionIdsByType.put((Class<? extends Revision>) objectType, detail.getObject().id());
+							}
+						}
 					}
 				}
 			} else if (detail.isRemove()) {
@@ -134,7 +143,7 @@ public final class RevisionBranchChangeSet {
 	public ObjectId getContainerId(ObjectId revisionId) {
 		return containersRequiredForNewAndChangedRevisions.get(revisionId);
 	}
-
+	
 	public boolean isRemoved(ObjectId revisionId) {
 		return removedRevisionIdsByType.containsEntry(mappings.getClass(revisionId.type()), revisionId.id());
 	}

--- a/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
@@ -1003,14 +1003,17 @@ public final class StagingArea {
 		
 		applyPropertyUpdates(toRef, propertyUpdatesToApply);
 		
+		// XXX make sure we use only the diff toRef to detect revisions added to the target branch directly
+		var toOnlyRef = toRef.difference(fromRef);
+		
 		// apply new objects
-		applyNewObjects(added, mergeFromBranchRef, toRef, squash);
+		applyNewObjects(added, mergeFromBranchRef, toOnlyRef, squash);
 		
 		// apply changed objects
-		applyChangedObjects(changed, mergeFromBranchRef, toRef, squash);
+		applyChangedObjects(changed, mergeFromBranchRef, toOnlyRef, squash);
 		
 		// always apply deleted objects, they set the revised timestamp properly without introducing any new document
-		applyRemovedObjects(removed, mergeFromBranchRef, toRef, squash);
+		applyRemovedObjects(removed, mergeFromBranchRef, toOnlyRef, squash);
 		
 		// any externally marked revised revisions should be applied here
 		revisionsToReviseOnMergeSource.putAll(externalRevisionsToReviseOnMergeSource);
@@ -1202,24 +1205,24 @@ public final class StagingArea {
 		conflictsToReport.addAll(conflictProcessor.filterConflicts(this, conflicts));		
 	}
 
-	private void applyRemovedObjects(SetMultimap<Class<? extends Revision>, String> removed, RevisionBranchRef fromRef, RevisionBranchRef toRef,
+	private void applyRemovedObjects(SetMultimap<Class<? extends Revision>, String> removed, RevisionBranchRef fromRef, RevisionBranchRef toOnlyRef,
 			boolean squash) {
 		for (Class<? extends Revision> type : ImmutableSet.copyOf(removed.keySet())) {
 			final Collection<String> removedRevisionIds = removed.removeAll(type);
 			for (List<String> currentRemovedRevisionIds : Iterables.partition(removedRevisionIds, maxTermsCount)) {
-				index.read(toRef, searcher -> searcher.get(type, currentRemovedRevisionIds)).forEach(this::stageRemove);
+				index.read(toOnlyRef, searcher -> searcher.get(type, currentRemovedRevisionIds)).forEach(this::stageRemove);
 			}
 		}
 	}
 
-	private void applyChangedObjects(SetMultimap<Class<? extends Revision>, String> changed, RevisionBranchRef fromRef, RevisionBranchRef toRef,
+	private void applyChangedObjects(SetMultimap<Class<? extends Revision>, String> changed, RevisionBranchRef fromRef, RevisionBranchRef toOnlyRef,
 			boolean squash) {
 		for (Class<? extends Revision> type : ImmutableSet.copyOf(changed.keySet())) {
 			final Collection<String> changedRevisionIds = changed.removeAll(type);
 			
 			for (List<String> currentChangedRevisionIds : Iterables.partition(changedRevisionIds, maxTermsCount)) {
 				
-				final Iterable<? extends Revision> oldRevisions = index.read(toRef, searcher -> searcher.get(type, currentChangedRevisionIds));
+				final Iterable<? extends Revision> oldRevisions = index.read(toOnlyRef, searcher -> searcher.get(type, currentChangedRevisionIds));
 				final Map<String, ? extends Revision> oldRevisionsById = FluentIterable.from(oldRevisions).uniqueIndex(Revision::getId);
 				final Iterable<? extends Revision> updatedRevisions = index.read(fromRef, searcher -> searcher.get(type, currentChangedRevisionIds));
 				final Map<String, ? extends Revision> updatedRevisionsById = FluentIterable.from(updatedRevisions).uniqueIndex(Revision::getId);
@@ -1237,14 +1240,14 @@ public final class StagingArea {
 		}
 	}
 
-	private void applyNewObjects(final SetMultimap<Class<? extends Revision>, String> added, RevisionBranchRef fromRef, RevisionBranchRef toRef, boolean squash) {
+	private void applyNewObjects(final SetMultimap<Class<? extends Revision>, String> added, RevisionBranchRef fromRef, RevisionBranchRef toOnlyRef, boolean squash) {
 		for (Class<? extends Revision> type : ImmutableSet.copyOf(added.keySet())) {
 			final Set<String> addedIds = added.removeAll(type);
 			// skip new objects that are already marked as revised on merge source, content that is present on target should take place instead
 			final Set<String> newRevisionIds = Sets.difference(addedIds, externalRevisionsToReviseOnMergeSource.get(type));
 			
 			for (List<String> currentNewRevisionIds : Iterables.partition(newRevisionIds, maxTermsCount)) {
-				final Iterable<? extends Revision> oldRevisions = index.read(toRef, searcher -> searcher.get(type, currentNewRevisionIds));
+				final Iterable<? extends Revision> oldRevisions = index.read(toOnlyRef, searcher -> searcher.get(type, currentNewRevisionIds));
 				final Iterable<? extends Revision> newRevisions = index.read(fromRef, searcher -> searcher.get(type, currentNewRevisionIds));
 				final Map<String, ? extends Revision> oldRevisionsById = FluentIterable.from(oldRevisions).uniqueIndex(Revision::getId);
 				

--- a/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
@@ -71,7 +71,7 @@ public final class StagingArea {
 	private Map<ObjectId, StagedObject> stagedObjects;
 
 	private SortedSet<RevisionBranchPoint> mergeSources;
-	private RevisionBranchRef mergeFromBranchRef;
+	private RevisionBranchRef mergeSourceRef;
 	private boolean squashMerge;
 	private SetMultimap<Class<?>, String> revisionsToReviseOnMergeSource;
 	private SetMultimap<Class<?>, String> externalRevisionsToReviseOnMergeSource;
@@ -157,7 +157,7 @@ public final class StagingArea {
 	 */
 	public <T> T readFromMergeSource(RevisionIndexRead<T> read) {
 		Preconditions.checkState(isMerge(), "Cannot read revisions from mergeSource branch in non-merge scenarios. Perform a merge() before calling this method.");
-		return index.read(mergeFromBranchRef, read);
+		return index.read(mergeSourceRef, read);
 	}
 	
 	/**
@@ -489,7 +489,7 @@ public final class StagingArea {
 		// apply revised flag on merge source branch
 		if (isMerge()) {
 			for (Class<?> type : revisionsToReviseOnMergeSource.keySet()) {
-				writer.setRevised(type, ImmutableSet.copyOf(revisionsToReviseOnMergeSource.get(type)), mergeFromBranchRef);
+				writer.setRevised(type, ImmutableSet.copyOf(revisionsToReviseOnMergeSource.get(type)), mergeSourceRef);
 			}
 		}
 		
@@ -723,7 +723,7 @@ public final class StagingArea {
 	 * @return <code>true</code> if the staging area is merging content from another branch into the current branch
 	 */
 	public boolean isMerge() {
-		return mergeFromBranchRef != null;
+		return mergeSourceRef != null;
 	}
 	
 	/**
@@ -732,7 +732,7 @@ public final class StagingArea {
 	 */
 	public String getMergeFromBranchPath() {
 		Preconditions.checkState(isMerge(), "Cannot get merge from branch path in non-merge scenarios. Start a merge() before calling this method.");
-		return mergeFromBranchRef.path();
+		return mergeSourceRef.path();
 	}
 	
 	/**
@@ -740,7 +740,7 @@ public final class StagingArea {
 	 */
 	public void rollback() {
 		clear();
-		this.mergeFromBranchRef = null;
+		this.mergeSourceRef = null;
 		this.mergeSources = null;
 	}
 	
@@ -939,8 +939,8 @@ public final class StagingArea {
 	
 	/*package*/ void merge(RevisionBranchRef fromRef, RevisionBranchRef toRef, boolean squash, RevisionConflictProcessor conflictProcessor, Set<String> exclusions) throws BranchMergeConflictException {
 		checkArgument(this.mergeSources == null, "Already merged another ref to this StagingArea. Commit staged changes to apply them.");
-		this.mergeFromBranchRef = fromRef.difference(toRef);
-		this.mergeSources = this.mergeFromBranchRef
+		this.mergeSourceRef = fromRef.difference(toRef);
+		this.mergeSources = this.mergeSourceRef
 				.segments()
 				.stream()
 				.filter(segment -> segment.branchId() != toRef.branchId())
@@ -1004,17 +1004,17 @@ public final class StagingArea {
 		applyPropertyUpdates(toRef, propertyUpdatesToApply);
 		
 		// XXX make sure we use only the diff toRef to detect revisions added/changed to the target branch directly (deletions will still use the full history of the to branch)
-		var toOnlyRef = toRef.difference(fromRef);
+		var mergeTargetRef = toRef.difference(fromRef);
 		
 		// apply new objects
-		applyNewObjects(added, mergeFromBranchRef, toOnlyRef, squash);
+		applyNewObjects(added, mergeSourceRef, mergeTargetRef, squash);
 		
 		// apply changed objects
-		applyChangedObjects(changed, mergeFromBranchRef, toOnlyRef, squash);
+		applyChangedObjects(changed, mergeSourceRef, mergeTargetRef, squash);
 		
 		// always apply deleted objects, they set the revised timestamp properly without introducing any new document
 		// XXX here when removing object use the entire history of the toRef to find the latest state available for the document
-		applyRemovedObjects(removed, mergeFromBranchRef, toRef, squash);
+		applyRemovedObjects(removed, mergeSourceRef, toRef, squash);
 		
 		// any externally marked revised revisions should be applied here
 		revisionsToReviseOnMergeSource.putAll(externalRevisionsToReviseOnMergeSource);
@@ -1240,15 +1240,15 @@ public final class StagingArea {
 		}
 	}
 
-	private void applyNewObjects(final SetMultimap<Class<? extends Revision>, String> added, RevisionBranchRef fromRef, RevisionBranchRef toOnlyRef, boolean squash) {
+	private void applyNewObjects(final SetMultimap<Class<? extends Revision>, String> added, RevisionBranchRef mergeSourceRef, RevisionBranchRef mergeTargetRef, boolean squash) {
 		for (Class<? extends Revision> type : ImmutableSet.copyOf(added.keySet())) {
 			final Set<String> addedIds = added.removeAll(type);
 			// skip new objects that are already marked as revised on merge source, content that is present on target should take place instead
 			final Set<String> newRevisionIds = Sets.difference(addedIds, externalRevisionsToReviseOnMergeSource.get(type));
 			
 			for (List<String> currentNewRevisionIds : Iterables.partition(newRevisionIds, maxTermsCount)) {
-				final Iterable<? extends Revision> oldRevisions = index.read(toOnlyRef, searcher -> searcher.get(type, currentNewRevisionIds));
-				final Iterable<? extends Revision> newRevisions = index.read(fromRef, searcher -> searcher.get(type, currentNewRevisionIds));
+				final Iterable<? extends Revision> oldRevisions = index.read(mergeTargetRef, searcher -> searcher.get(type, currentNewRevisionIds));
+				final Iterable<? extends Revision> newRevisions = index.read(mergeSourceRef, searcher -> searcher.get(type, currentNewRevisionIds));
 				final Map<String, ? extends Revision> oldRevisionsById = FluentIterable.from(oldRevisions).uniqueIndex(Revision::getId);
 				
 				newRevisions.forEach(rev -> {

--- a/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
@@ -457,7 +457,6 @@ public final class StagingArea {
 
 					if (isMerge()) {
 						revisionsToReviseOnMergeSource.put(rev.getClass(), rev.getId());
-						injectChangedEntryToMergeCommit(containerId, objectId);
 					}
 					
 					if (rev instanceof CommitSubject subject) {
@@ -1043,6 +1042,7 @@ public final class StagingArea {
 					// FIXME for the future, figure out how to reduce the number of ser/deser during merge
 					stageChange(oldRevision, mapper.convertValue(objectToUpdate, type));
 					revisionsToReviseOnMergeSource.put(type, oldRevision.getId());
+					injectChangedEntryToMergeCommit(oldRevision.getContainerId(), oldRevision.getObjectId());
 				}
 			}
 		}
@@ -1139,6 +1139,12 @@ public final class StagingArea {
 					final Map<String, RevisionCompareDetail> sourcePropertyChanges = sourcePropertyChangesByObject.remove(changedInSourceAndTargetId);
 					final Map<String, RevisionCompareDetail> targetPropertyChanges = targetPropertyChangesByObject.remove(changedInSourceAndTargetId);
 					
+					final ObjectId changeInSourceAndTargetObject = ObjectId.of(type, changedInSourceAndTargetId);
+					ObjectId containerOfChangedInSourceAndTargetObject = fromChangeSet.getContainerId(changeInSourceAndTargetObject);
+					if (containerOfChangedInSourceAndTargetObject == null) {
+						containerOfChangedInSourceAndTargetObject = ObjectId.rootOf(docType);
+					}
+					
 					if (sourcePropertyChanges != null) {
 						for (Entry<String, RevisionCompareDetail> sourceChange : sourcePropertyChanges.entrySet()) {
 							final String changedProperty = sourceChange.getKey();
@@ -1180,6 +1186,8 @@ public final class StagingArea {
 					}
 					
 					// this object has changed on both sides either by tracked field changes or due to some cascading derived field change
+					// apply change pill to the merge commit, so that we know in the future that there was a conflict here which got resolved
+					injectChangedEntryToMergeCommit(containerOfChangedInSourceAndTargetObject, changeInSourceAndTargetObject);
 					// revise the revision on source, since we already have one on this branch already
 					revisionsToReviseOnMergeSource.put(type, changedInSourceAndTargetId);
 				}

--- a/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
@@ -1230,8 +1230,7 @@ public final class StagingArea {
 			
 				for (String updatedId : updatedRevisionsById.keySet()) {
 					if (oldRevisionsById.containsKey(updatedId)) {
-						// actual changed revisions should always register themselves for commit if there is a revision on the target
-						stageChange(oldRevisionsById.get(updatedId), updatedRevisionsById.get(updatedId), true);
+						stageChange(oldRevisionsById.get(updatedId), updatedRevisionsById.get(updatedId), squash);
 					} else {
 						stageNew(updatedRevisionsById.get(updatedId), squash);
 					}
@@ -1254,8 +1253,7 @@ public final class StagingArea {
 				
 				newRevisions.forEach(rev -> {
 					if (oldRevisionsById.containsKey(rev.getId())) {
-						// actual changed revisions should always register themselves for commit if there is a revision on the target 
-						stageChange(oldRevisionsById.get(rev.getId()), rev, true); 
+						stageChange(oldRevisionsById.get(rev.getId()), rev, squash); 
 					} else {
 						stageNew(rev, squash);
 					}

--- a/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
@@ -1206,12 +1206,12 @@ public final class StagingArea {
 		conflictsToReport.addAll(conflictProcessor.filterConflicts(this, conflicts));		
 	}
 
-	private void applyRemovedObjects(SetMultimap<Class<? extends Revision>, String> removed, RevisionBranchRef fromRef, RevisionBranchRef toOnlyRef,
+	private void applyRemovedObjects(SetMultimap<Class<? extends Revision>, String> removed, RevisionBranchRef fromRef, RevisionBranchRef toRef,
 			boolean squash) {
 		for (Class<? extends Revision> type : ImmutableSet.copyOf(removed.keySet())) {
 			final Collection<String> removedRevisionIds = removed.removeAll(type);
 			for (List<String> currentRemovedRevisionIds : Iterables.partition(removedRevisionIds, maxTermsCount)) {
-				index.read(toOnlyRef, searcher -> searcher.get(type, currentRemovedRevisionIds)).forEach(this::stageRemove);
+				index.read(toRef, searcher -> searcher.get(type, currentRemovedRevisionIds)).forEach(this::stageRemove);
 			}
 		}
 	}

--- a/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
+++ b/commons/com.b2international.index/src/com/b2international/index/revision/StagingArea.java
@@ -1003,7 +1003,7 @@ public final class StagingArea {
 		
 		applyPropertyUpdates(toRef, propertyUpdatesToApply);
 		
-		// XXX make sure we use only the diff toRef to detect revisions added to the target branch directly
+		// XXX make sure we use only the diff toRef to detect revisions added/changed to the target branch directly (deletions will still use the full history of the to branch)
 		var toOnlyRef = toRef.difference(fromRef);
 		
 		// apply new objects
@@ -1013,7 +1013,8 @@ public final class StagingArea {
 		applyChangedObjects(changed, mergeFromBranchRef, toOnlyRef, squash);
 		
 		// always apply deleted objects, they set the revised timestamp properly without introducing any new document
-		applyRemovedObjects(removed, mergeFromBranchRef, toOnlyRef, squash);
+		// XXX here when removing object use the entire history of the toRef to find the latest state available for the document
+		applyRemovedObjects(removed, mergeFromBranchRef, toRef, squash);
 		
 		// any externally marked revised revisions should be applied here
 		revisionsToReviseOnMergeSource.putAll(externalRevisionsToReviseOnMergeSource);

--- a/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/branches/SnomedMergeApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.core.rest.tests/src/com/b2international/snowowl/snomed/core/rest/branches/SnomedMergeApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 B2i Healthcare, https://b2ihealthcare.com
+ * Copyright 2011-2026 B2i Healthcare, https://b2ihealthcare.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,9 @@ public class SnomedMergeApiTest extends AbstractSnomedApiTest {
 		deleteComponent(childPath, SnomedComponentType.CONCEPT, conceptId, false).statusCode(204);
 
 		merge(parentPath, childPath, "Rebased concept deletion over concept change").body("status", equalTo(Merge.Status.COMPLETED.name()));
+		
+		// after rebase, the concept should be deleted still
+		getComponent(childPath, SnomedComponentType.CONCEPT, conceptId).statusCode(404);
 	}
 
 	@Test
@@ -450,8 +453,10 @@ public class SnomedMergeApiTest extends AbstractSnomedApiTest {
 		final IBranchPath a = BranchPathUtils.createPath(branchPath, "a");
 		branching.createBranch(a).statusCode(201);
 
+		// apply change on branchPath, deletion on branchA, then rebase the deletion over the change
 		rebaseConceptDeletionOverChange(branchPath, a, conceptId);
 
+		// after successful rebase merge the deletion to branchPath
 		merge(a, branchPath, "Merged concept deletion").body("status", equalTo(Merge.Status.COMPLETED.name()));
 
 		// Concept should now be deleted everywhere


### PR DESCRIPTION
This PR resolves a critical revision merging issue after the introduction of the change poison pills in #1450.
See commit messages for more detail.